### PR TITLE
feat(soundness): complete step-to-trace soundness lifting (#9)

### DIFF
--- a/AbsInterpLTS/Framework/Semantics/Abstract.lean
+++ b/AbsInterpLTS/Framework/Semantics/Abstract.lean
@@ -1,1 +1,2 @@
 import AbsInterpLTS.Framework.Semantics.Abstract.Defs
+import AbsInterpLTS.Framework.Semantics.Abstract.Lemmas

--- a/AbsInterpLTS/Framework/Semantics/Abstract/Defs.lean
+++ b/AbsInterpLTS/Framework/Semantics/Abstract/Defs.lean
@@ -12,8 +12,8 @@ universe u v
 
 This file mirrors concrete trace lifting at the abstract level.
 
-For `postAbs : Label -> (Abstract -> Abstract)`,
-`liftTracePostSharp postAbs` composes abstract step transformers left-to-right
+For `stepPostSharp : Label -> (Abstract -> Abstract)`,
+`liftTracePostSharp stepPostSharp` composes abstract step transformers left-to-right
 along a label list.
 -/
 
@@ -29,9 +29,9 @@ abbrev TracePostSharp (Abstract : Type u) (Label : Type v) := List Label -> Post
 /-- Sequential composition of abstract transformers. -/
 def composePostSharp
     {Abstract : Type u}
-    (postAbs1 postAbs2 : PostSharp Abstract) :
+    (postSharp1 postSharp2 : PostSharp Abstract) :
     PostSharp Abstract :=
-  fun a => postAbs2 (postAbs1 a)
+  fun a => postSharp2 (postSharp1 a)
 
 /--
 Lift one-step abstract transfers to trace transfers by left-to-right composition.
@@ -39,9 +39,9 @@ Lift one-step abstract transfers to trace transfers by left-to-right composition
 def liftTracePostSharp
     {Abstract : Type u}
     {Label : Type v}
-    (postAbs : StepPostSharp Abstract Label) :
+    (stepPostSharp : StepPostSharp Abstract Label) :
     TracePostSharp Abstract Label :=
-  liftTrace composePostSharp (fun a => a) postAbs
+  liftTrace composePostSharp (fun a => a) stepPostSharp
 
 end Framework
 end AbsInterpLTS

--- a/AbsInterpLTS/Framework/Semantics/Abstract/Lemmas.lean
+++ b/AbsInterpLTS/Framework/Semantics/Abstract/Lemmas.lean
@@ -1,0 +1,77 @@
+import Cslib.Init
+
+import AbsInterpLTS.Framework.Semantics.Abstract.Defs
+
+namespace AbsInterpLTS
+namespace Framework
+
+universe u v
+
+section Trace
+
+private theorem composePostSharp_assoc
+    {Abstract : Type u}
+    (postSharp1 postSharp2 postSharp3 : PostSharp Abstract) :
+    composePostSharp (composePostSharp postSharp1 postSharp2) postSharp3 =
+      composePostSharp postSharp1 (composePostSharp postSharp2 postSharp3) := by
+  funext a
+  rfl
+
+private theorem foldl_composePostSharp_acc
+    {Abstract : Type u}
+    {Label : Type v}
+    (stepPostSharp : StepPostSharp Abstract Label) :
+    ∀ (labels : List Label) (acc post0 : PostSharp Abstract),
+      List.foldl
+        (fun current label => composePostSharp current (stepPostSharp label))
+        (composePostSharp acc post0)
+        labels =
+          composePostSharp
+            acc
+            (List.foldl
+              (fun current label => composePostSharp current (stepPostSharp label))
+              post0
+              labels)
+  | [], acc, post0 => by
+      simp
+  | label :: labels, acc, post0 => by
+      simp [List.foldl, foldl_composePostSharp_acc, composePostSharp_assoc]
+
+/--
+Base case of abstract trace lifting:
+`liftTracePostSharp stepPostSharp []` is the identity abstract transformer.
+-/
+@[simp] theorem liftTracePostSharp_nil
+    {Abstract : Type u}
+    {Label : Type v}
+    (stepPostSharp : StepPostSharp Abstract Label) :
+    liftTracePostSharp stepPostSharp [] = (fun a : Abstract => a) :=
+  rfl
+
+/--
+Unfold abstract trace lifting on a non-empty label list.
+
+`liftTracePostSharp stepPostSharp (label :: labels)`
+is one abstract step followed by the lifted remainder:
+`composePostSharp (stepPostSharp label) (liftTracePostSharp stepPostSharp labels)`.
+-/
+@[simp] theorem liftTracePostSharp_cons
+    {Abstract : Type u}
+    {Label : Type v}
+    (stepPostSharp : StepPostSharp Abstract Label)
+    (label : Label)
+    (labels : List Label) :
+    liftTracePostSharp stepPostSharp (label :: labels) =
+      composePostSharp (stepPostSharp label) (liftTracePostSharp stepPostSharp labels) := by
+  have hacc :=
+    foldl_composePostSharp_acc
+      (stepPostSharp := stepPostSharp)
+      labels
+      (stepPostSharp label)
+      (fun a : Abstract => a)
+  simpa [liftTracePostSharp, liftTrace, List.foldl] using hacc
+
+end Trace
+
+end Framework
+end AbsInterpLTS

--- a/AbsInterpLTS/Framework/Semantics/Concrete/Lemmas.lean
+++ b/AbsInterpLTS/Framework/Semantics/Concrete/Lemmas.lean
@@ -48,6 +48,68 @@ end Hom
 
 section Trace
 
+private theorem composePost_assoc
+    {State : Type u}
+    (post1 post2 post3 : Post State) :
+    composePost (composePost post1 post2) post3 =
+      composePost post1 (composePost post2 post3) := by
+  funext states
+  rfl
+
+private theorem foldl_composePost_acc
+    {State : Type u}
+    {Label : Type v}
+    (stepPost : Label -> Post State) :
+    ∀ (labels : List Label) (acc post0 : Post State),
+      List.foldl
+        (fun current label => composePost current (stepPost label))
+        (composePost acc post0)
+        labels =
+          composePost
+            acc
+            (List.foldl
+              (fun current label => composePost current (stepPost label))
+              post0
+              labels)
+  | [], acc, post0 => by
+      simp
+  | label :: labels, acc, post0 => by
+      simp [List.foldl, foldl_composePost_acc, composePost_assoc]
+
+/--
+Base case of concrete trace lifting:
+`liftTracePost stepPost []` is the identity transformer.
+-/
+@[simp] theorem liftTracePost_nil
+    {State : Type u}
+    {Label : Type v}
+    (stepPost : Label -> Post State) :
+    liftTracePost stepPost [] = (fun states : Set State => states) :=
+  rfl
+
+/--
+Unfold trace lifting on a non-empty label list.
+
+`liftTracePost stepPost (label :: labels)`
+is one concrete step followed by the lifted remainder:
+`composePost (stepPost label) (liftTracePost stepPost labels)`.
+-/
+@[simp] theorem liftTracePost_cons
+    {State : Type u}
+    {Label : Type v}
+    (stepPost : Label -> Post State)
+    (label : Label)
+    (labels : List Label) :
+    liftTracePost stepPost (label :: labels) =
+      composePost (stepPost label) (liftTracePost stepPost labels) := by
+  have hacc :=
+    foldl_composePost_acc
+      (stepPost := stepPost)
+      labels
+      (stepPost label)
+      (fun states : Set State => states)
+  simpa [liftTracePost, liftTrace, List.foldl] using hacc
+
 private theorem foldl_post_eq_foldl_postHom_of_monotone
     {State : Type u}
     {Label : Type v}

--- a/AbsInterpLTS/Framework/Soundness.lean
+++ b/AbsInterpLTS/Framework/Soundness.lean
@@ -1,2 +1,3 @@
 import AbsInterpLTS.Framework.Soundness.Defs
+import AbsInterpLTS.Framework.Soundness.Lemmas
 import AbsInterpLTS.Framework.Soundness.StepToTraceSoundness

--- a/AbsInterpLTS/Framework/Soundness/Defs.lean
+++ b/AbsInterpLTS/Framework/Soundness/Defs.lean
@@ -19,19 +19,19 @@ abbrev Gamma (Abstract : Type u) (State : Type v) := Abstract -> Set State
 
 /--
 Core soundness direction:
-`post (gamma a) ⊆ gamma (postAbs a)`.
+`post (gamma a) ⊆ gamma (postSharp a)`.
 -/
 def Sound
     {State : Type u}
     {Abstract : Type v}
     (post : Post State)
     (gamma : Gamma Abstract State)
-    (postAbs : PostSharp Abstract) : Prop :=
-  forall a : Abstract, post (gamma a) ⊆ gamma (postAbs a)
+    (postSharp : PostSharp Abstract) : Prop :=
+  forall a : Abstract, post (gamma a) ⊆ gamma (postSharp a)
 
 /--
 One-step soundness for label-indexed transformers:
-`stepPost label (gamma a) ⊆ gamma (postAbs label a)`.
+`stepPost label (gamma a) ⊆ gamma (stepPostSharp label a)`.
 -/
 def SoundStep
     {State : Type u}
@@ -39,13 +39,13 @@ def SoundStep
     {Abstract : Type w}
     (stepPost : Label -> Post State)
     (gamma : Gamma Abstract State)
-    (postAbs : StepPostSharp Abstract Label) : Prop :=
+    (stepPostSharp : StepPostSharp Abstract Label) : Prop :=
   forall label : Label, forall a : Abstract,
-    stepPost label (gamma a) ⊆ gamma (postAbs label a)
+    stepPost label (gamma a) ⊆ gamma (stepPostSharp label a)
 
 /--
 Trace-level soundness for trace-indexed transformers:
-`tracePost labels (gamma a) ⊆ gamma (postAbs labels a)`.
+`tracePost labels (gamma a) ⊆ gamma (tracePostSharp labels a)`.
 -/
 def SoundTrace
     {State : Type u}
@@ -53,9 +53,9 @@ def SoundTrace
     {Abstract : Type w}
     (tracePost : List Label -> Post State)
     (gamma : Gamma Abstract State)
-    (postAbs : TracePostSharp Abstract Label) : Prop :=
+    (tracePostSharp : TracePostSharp Abstract Label) : Prop :=
   forall labels : List Label, forall a : Abstract,
-    tracePost labels (gamma a) ⊆ gamma (postAbs labels a)
+    tracePost labels (gamma a) ⊆ gamma (tracePostSharp labels a)
 
 end Framework
 end AbsInterpLTS

--- a/AbsInterpLTS/Framework/Soundness/Lemmas.lean
+++ b/AbsInterpLTS/Framework/Soundness/Lemmas.lean
@@ -1,0 +1,42 @@
+import Cslib.Init
+
+import AbsInterpLTS.Framework.Soundness.Defs
+
+namespace AbsInterpLTS
+namespace Framework
+
+universe u v
+
+/--
+Composition closure for soundness.
+
+If
+- `post1` is sound w.r.t. `postSharp1`,
+- `post2` is sound w.r.t. `postSharp2`, and
+- `post2` is monotone,
+
+then their sequential composition is sound:
+`Sound (composePost post1 post2) gamma (composePostSharp postSharp1 postSharp2)`.
+-/
+theorem Sound.compose
+    {State : Type u}
+    {Abstract : Type v}
+    {post1 post2 : Post State}
+    {gamma : Gamma Abstract State}
+    {postSharp1 postSharp2 : PostSharp Abstract}
+    (h1 : Sound post1 gamma postSharp1)
+    (h2 : Sound post2 gamma postSharp2)
+    (hMono2 : MonotonePost post2) :
+    Sound
+      (composePost post1 post2)
+      gamma
+      (composePostSharp postSharp1 postSharp2) := by
+  intro a s hs
+  have hMono :
+      post2 (post1 (gamma a)) ⊆ post2 (gamma (postSharp1 a)) :=
+    hMono2 (h1 a)
+  have hs' : s ∈ post2 (gamma (postSharp1 a)) := hMono hs
+  exact h2 (postSharp1 a) hs'
+
+end Framework
+end AbsInterpLTS

--- a/AbsInterpLTS/Framework/Soundness/StepToTraceSoundness.lean
+++ b/AbsInterpLTS/Framework/Soundness/StepToTraceSoundness.lean
@@ -1,6 +1,8 @@
 import Cslib.Init
 
-import AbsInterpLTS.Framework.Soundness.Defs
+import AbsInterpLTS.Framework.Soundness.Lemmas
+import AbsInterpLTS.Framework.Semantics.Concrete
+import AbsInterpLTS.Framework.Semantics.Abstract
 
 namespace AbsInterpLTS
 namespace Framework
@@ -8,11 +10,18 @@ namespace Framework
 universe u v w
 
 /--
-Step soundness implies trace soundness:
-`(∀ label a, stepPost label (gamma a) ⊆ gamma (postAbs label a)) ->
- (∀ labels a, liftTracePost stepPost labels (gamma a) ⊆ gamma (liftTracePostSharp postAbs labels a))`.
+Step soundness lifts to trace soundness.
 
-This theorem is currently a staged proof obligation.
+Assumptions:
+- `hStep : ∀ label a, stepPost label (gamma a) ⊆ gamma (stepPostSharp label a)`
+- `hStepMono : ∀ label, MonotonePost (stepPost label)`
+
+Conclusion:
+- `∀ labels a,
+    liftTracePost stepPost labels (gamma a) ⊆
+      gamma (liftTracePostSharp stepPostSharp labels a)`.
+
+Monotonicity is required to transport soundness through sequential composition.
 -/
 theorem soundTrace_of_soundStep
     {State : Type u}
@@ -20,10 +29,39 @@ theorem soundTrace_of_soundStep
     {Abstract : Type w}
     {stepPost : Label -> Post State}
     {gamma : Gamma Abstract State}
-    {postAbs : StepPostSharp Abstract Label}
-    (hStep : SoundStep stepPost gamma postAbs) :
-    SoundTrace (liftTracePost stepPost) gamma (liftTracePostSharp postAbs) := by
-  sorry
+    {stepPostSharp : StepPostSharp Abstract Label}
+    (hStep : SoundStep stepPost gamma stepPostSharp)
+    (hStepMono : ∀ label : Label, MonotonePost (stepPost label)) :
+    SoundTrace (liftTracePost stepPost) gamma (liftTracePostSharp stepPostSharp) := by
+  intro labels
+  induction labels with
+  | nil =>
+      intro a s hs
+      simpa using hs
+  | cons label labels ih =>
+      have hStepSound : Sound (stepPost label) gamma (stepPostSharp label) :=
+        hStep label
+      have hTraceMono : MonotonePost (liftTracePost stepPost labels) :=
+        liftTracePost_monotone_of_pointwise
+          (stepPost := stepPost)
+          (hStepMono := hStepMono)
+          labels
+      have hConsSound :
+          Sound
+            (composePost (stepPost label) (liftTracePost stepPost labels))
+            gamma
+            (composePostSharp (stepPostSharp label) (liftTracePostSharp stepPostSharp labels)) :=
+        Sound.compose
+          (post1 := stepPost label)
+          (post2 := liftTracePost stepPost labels)
+          (gamma := gamma)
+          (postSharp1 := stepPostSharp label)
+          (postSharp2 := liftTracePostSharp stepPostSharp labels)
+          hStepSound
+          ih
+          hTraceMono
+      intro a
+      simpa using hConsSound a
 
 end Framework
 end AbsInterpLTS

--- a/AbsInterpLTS/Framework/Soundness/StepToTraceSoundness.lean
+++ b/AbsInterpLTS/Framework/Soundness/StepToTraceSoundness.lean
@@ -39,29 +39,21 @@ theorem soundTrace_of_soundStep
       intro a s hs
       simpa using hs
   | cons label labels ih =>
-      have hStepSound : Sound (stepPost label) gamma (stepPostSharp label) :=
-        hStep label
-      have hTraceMono : MonotonePost (liftTracePost stepPost labels) :=
-        liftTracePost_monotone_of_pointwise
-          (stepPost := stepPost)
-          (hStepMono := hStepMono)
-          labels
-      have hConsSound :
-          Sound
-            (composePost (stepPost label) (liftTracePost stepPost labels))
-            gamma
-            (composePostSharp (stepPostSharp label) (liftTracePostSharp stepPostSharp labels)) :=
+      intro a
+      rw [liftTracePost_cons, liftTracePostSharp_cons]
+      exact
         Sound.compose
           (post1 := stepPost label)
           (post2 := liftTracePost stepPost labels)
           (gamma := gamma)
           (postSharp1 := stepPostSharp label)
           (postSharp2 := liftTracePostSharp stepPostSharp labels)
-          hStepSound
+          (hStep label)
           ih
-          hTraceMono
-      intro a
-      simpa using hConsSound a
+          (liftTracePost_monotone_of_pointwise
+            (stepPost := stepPost)
+            (hStepMono := hStepMono)
+            labels) a
 
 end Framework
 end AbsInterpLTS

--- a/AbsInterpLTS/Instances/LTS/Instantiation/Soundness.lean
+++ b/AbsInterpLTS/Instances/LTS/Instantiation/Soundness.lean
@@ -26,8 +26,9 @@ theorem LTSAbstraction.soundTraceLifted
     (soundTrace_of_soundStep
       (stepPost := postStep cfg.lts)
       (gamma := cfg.gamma)
-      (postAbs := cfg.transfer)
-      cfg.soundStep)
+      (stepPostSharp := cfg.transfer)
+      cfg.soundStep
+      (hStepMono := fun label => postStep_monotone cfg.lts label))
 
 /-- Explicit-data corollary of trace soundness lifting, routed through `LTSAbstraction`. -/
 theorem LTSAbstraction.soundTraceLiftedOfExplicit


### PR DESCRIPTION
## Summary
This PR resolves #9 by completing the framework theorem that lifts step-level soundness to trace-level soundness, and refactors surrounding semantics/soundness APIs to make the proof structure reusable and concise.

## What changed
1. Added reusable trace decomposition lemmas
- `liftTracePost_nil`, `liftTracePost_cons` in concrete semantics lemmas
- `liftTracePostSharp_nil`, `liftTracePostSharp_cons` in abstract semantics lemmas
- kept fold-specific helper lemmas private and exported only semantic-facing lemmas

2. Added soundness composition closure and completed proof
- introduced `Sound.compose`
- rewrote `soundTrace_of_soundStep` as short list induction using:
  - decomposition lemmas
  - existing `liftTracePost_monotone_of_pointwise`
  - `Sound.compose`
- removed staged placeholder from `StepToTraceSoundness`

3. Normalized abstract-side naming for symmetry
- interface placeholders now consistently follow:
  - `post` ↔ `postSharp`
  - `stepPost` ↔ `stepPostSharp`
  - `tracePost` ↔ `tracePostSharp`
- updated formulas/comments and named-argument call sites accordingly

4. LTS instantiation wiring
- updated LTS soundness lift call to pass pointwise monotonicity explicitly

## Validation
- `lake build`
- `lake test`

## Commit structure
- `refactor(semantics): add trace decomposition lemmas`
- `feat(soundness): prove step-to-trace lifting theorem`
- `refactor(framework): normalize sharp naming in interfaces`

Closes #9