### PR TITLE
feat(iteration): expand nat iteration scaffold and soundness bridge (#2)

### DIFF
--- a/AbsInterpLTS/Framework/Iteration/NatIter.lean
+++ b/AbsInterpLTS/Framework/Iteration/NatIter.lean
@@ -144,9 +144,7 @@ theorem iterateNat_chain_of_le
     | zero =>
         simp
     | succ k ih =>
-        exact Set.Subset.trans ih (by
-          simpa [Nat.add_assoc] using
-            iterateNat_chain_step (post := post) hMono hInfl (m + k) init)
+        exact Set.Subset.trans ih (iterateNat_chain_step (post := post) hMono hInfl (m + k) init)
   rcases Nat.exists_eq_add_of_le hLe with ⟨k, hk⟩
   simpa [hk] using hAdd k
 

--- a/AbsInterpLTS/Framework/Iteration/NatIter.lean
+++ b/AbsInterpLTS/Framework/Iteration/NatIter.lean
@@ -9,7 +9,7 @@ namespace Iteration
 
 open AbsInterpLTS.Framework
 
-universe u v
+universe u
 
 /-- Widening interface for abstract iterative solvers. -/
 abbrev Widen (Abstract : Type u) := Abstract -> Abstract -> Abstract
@@ -144,16 +144,9 @@ theorem iterateNat_chain_of_le
     | zero =>
         simp
     | succ k ih =>
-        have hStep :
-            iterateNat post init (m + k) ⊆
-              iterateNat post init (m + k + 1) :=
-          iterateNat_chain_step
-            (post := post)
-            hMono
-            hInfl
-            (m + k)
-            init
-        exact Set.Subset.trans ih (by simpa [Nat.add_assoc] using hStep)
+        exact Set.Subset.trans ih (by
+          simpa [Nat.add_assoc] using
+            iterateNat_chain_step (post := post) hMono hInfl (m + k) init)
   rcases Nat.exists_eq_add_of_le hLe with ⟨k, hk⟩
   simpa [hk] using hAdd k
 
@@ -169,7 +162,7 @@ Conclusion:
 -/
 theorem sound_iterateNat_of_sound
     {State : Type u}
-    {Abstract : Type v}
+    {Abstract : Type _}
     {post : Post State}
     {gamma : Gamma Abstract State}
     {postSharp : PostSharp Abstract}
@@ -181,19 +174,13 @@ theorem sound_iterateNat_of_sound
   | 0, a => by
       simp
   | n + 1, a => by
-      have hIH :
-          iterateNat post (gamma a) n ⊆
-            gamma (iterateNatSharp postSharp a n) :=
-        sound_iterateNat_of_sound
-          (hSound := hSound)
-          (hMono := hMono)
-          n
-          a
-      have hToGamma :
-          post (iterateNat post (gamma a) n) ⊆
-            post (gamma (iterateNatSharp postSharp a n)) :=
-        hMono hIH
-      exact Set.Subset.trans hToGamma (hSound (iterateNatSharp postSharp a n))
+      simp only [iterateNat_succ, iterateNatSharp_succ]
+      calc
+        post (iterateNat post (gamma a) n)
+            ⊆ post (gamma (iterateNatSharp postSharp a n)) := by
+              exact hMono (sound_iterateNat_of_sound (hSound := hSound) (hMono := hMono) n a)
+        _ ⊆ gamma (postSharp (iterateNatSharp postSharp a n)) := by
+              exact hSound (iterateNatSharp postSharp a n)
 
 end Iteration
 end Framework

--- a/AbsInterpLTS/Framework/Iteration/NatIter.lean
+++ b/AbsInterpLTS/Framework/Iteration/NatIter.lean
@@ -1,6 +1,7 @@
 import Cslib.Init
 
 import AbsInterpLTS.Framework.Semantics
+import AbsInterpLTS.Framework.Soundness.Defs
 
 namespace AbsInterpLTS
 namespace Framework
@@ -8,7 +9,7 @@ namespace Iteration
 
 open AbsInterpLTS.Framework
 
-universe u
+universe u v
 
 /-- Widening interface for abstract iterative solvers. -/
 abbrev Widen (Abstract : Type u) := Abstract -> Abstract -> Abstract
@@ -155,6 +156,44 @@ theorem iterateNat_chain_of_le
         exact Set.Subset.trans ih (by simpa [Nat.add_assoc] using hStep)
   rcases Nat.exists_eq_add_of_le hLe with ⟨k, hk⟩
   simpa [hk] using hAdd k
+
+/--
+Lift one-step soundness to natural-number iteration soundness.
+
+Assumptions:
+- `hSound : Sound post gamma postSharp`
+- `hMono : MonotonePost post`
+
+Conclusion:
+- `iterateNat post (gamma a) n ⊆ gamma (iterateNatSharp postSharp a n)`.
+-/
+theorem sound_iterateNat_of_sound
+    {State : Type u}
+    {Abstract : Type v}
+    {post : Post State}
+    {gamma : Gamma Abstract State}
+    {postSharp : PostSharp Abstract}
+    (hSound : Sound post gamma postSharp)
+    (hMono : MonotonePost post) :
+    ∀ (n : Nat) (a : Abstract),
+      iterateNat post (gamma a) n ⊆
+        gamma (iterateNatSharp postSharp a n)
+  | 0, a => by
+      simp
+  | n + 1, a => by
+      have hIH :
+          iterateNat post (gamma a) n ⊆
+            gamma (iterateNatSharp postSharp a n) :=
+        sound_iterateNat_of_sound
+          (hSound := hSound)
+          (hMono := hMono)
+          n
+          a
+      have hToGamma :
+          post (iterateNat post (gamma a) n) ⊆
+            post (gamma (iterateNatSharp postSharp a n)) :=
+        hMono hIH
+      exact Set.Subset.trans hToGamma (hSound (iterateNatSharp postSharp a n))
 
 end Iteration
 end Framework

--- a/AbsInterpLTS/Framework/Iteration/NatIter.lean
+++ b/AbsInterpLTS/Framework/Iteration/NatIter.lean
@@ -13,6 +13,15 @@ universe u
 /-- Widening interface for abstract iterative solvers. -/
 abbrev Widen (Abstract : Type u) := Abstract -> Abstract -> Abstract
 
+/--
+Inflationary concrete transformer predicate:
+`states ⊆ post states`.
+-/
+def InflationaryPost
+    {State : Type u}
+    (post : Post State) : Prop :=
+  ∀ states : Set State, states ⊆ post states
+
 /-- Natural-number iterate scaffold for concrete post operators. -/
 def iterateNat
     {State : Type u}
@@ -21,6 +30,131 @@ def iterateNat
     Nat -> Set State
   | 0 => init
   | n + 1 => post (iterateNat post init n)
+
+/-- Natural-number iterate scaffold for abstract transformers. -/
+def iterateNatSharp
+    {Abstract : Type u}
+    (postSharp : PostSharp Abstract)
+    (init : Abstract) :
+    Nat -> Abstract
+  | 0 => init
+  | n + 1 => postSharp (iterateNatSharp postSharp init n)
+
+@[simp] theorem iterateNat_zero
+    {State : Type u}
+    (post : Post State)
+    (init : Set State) :
+    iterateNat post init 0 = init :=
+  rfl
+
+@[simp] theorem iterateNat_succ
+    {State : Type u}
+    (post : Post State)
+    (init : Set State)
+    (n : Nat) :
+    iterateNat post init (n + 1) = post (iterateNat post init n) :=
+  rfl
+
+@[simp] theorem iterateNatSharp_zero
+    {Abstract : Type u}
+    (postSharp : PostSharp Abstract)
+    (init : Abstract) :
+    iterateNatSharp postSharp init 0 = init :=
+  rfl
+
+@[simp] theorem iterateNatSharp_succ
+    {Abstract : Type u}
+    (postSharp : PostSharp Abstract)
+    (init : Abstract)
+    (n : Nat) :
+    iterateNatSharp postSharp init (n + 1) =
+      postSharp (iterateNatSharp postSharp init n) :=
+  rfl
+
+/--
+Monotonicity of natural-number iteration in the initial set.
+
+Assumptions:
+- `hMono : MonotonePost post`
+- `hInit : init1 ⊆ init2`
+
+Conclusion:
+- `iterateNat post init1 n ⊆ iterateNat post init2 n`.
+-/
+theorem iterateNat_monotone_init
+    {State : Type u}
+    {post : Post State}
+    (hMono : MonotonePost post) :
+    ∀ n : Nat, ∀ {init1 init2 : Set State},
+      init1 ⊆ init2 ->
+      iterateNat post init1 n ⊆ iterateNat post init2 n
+  | 0, init1, init2, hInit => hInit
+  | n + 1, init1, init2, hInit => by
+      simpa using
+        hMono (iterateNat_monotone_init (hMono := hMono) n hInit)
+
+/--
+Successor-chain step for natural-number iteration.
+
+Assumptions:
+- `hMono : MonotonePost post`
+- `hInfl : InflationaryPost post`
+
+Conclusion:
+- `iterateNat post init n ⊆ iterateNat post init (n + 1)`.
+-/
+theorem iterateNat_chain_step
+    {State : Type u}
+    {post : Post State}
+    (hMono : MonotonePost post)
+    (hInfl : InflationaryPost post) :
+    ∀ (n : Nat) (init : Set State),
+      iterateNat post init n ⊆ iterateNat post init (n + 1)
+  | 0, init => by
+      simpa using hInfl init
+  | n + 1, init => by
+      simpa using
+        hMono (iterateNat_chain_step (hMono := hMono) (hInfl := hInfl) n init)
+
+/--
+Iteration chain monotonicity along natural-number indices.
+
+Assumptions:
+- `hMono : MonotonePost post`
+- `hInfl : InflationaryPost post`
+- `hLe : m ≤ n`
+
+Conclusion:
+- `iterateNat post init m ⊆ iterateNat post init n`.
+-/
+theorem iterateNat_chain_of_le
+    {State : Type u}
+    {post : Post State}
+    (hMono : MonotonePost post)
+    (hInfl : InflationaryPost post)
+    {m n : Nat}
+    (hLe : m ≤ n)
+    (init : Set State) :
+    iterateNat post init m ⊆ iterateNat post init n := by
+  have hAdd :
+      ∀ k : Nat, iterateNat post init m ⊆ iterateNat post init (m + k) := by
+    intro k
+    induction k with
+    | zero =>
+        simp
+    | succ k ih =>
+        have hStep :
+            iterateNat post init (m + k) ⊆
+              iterateNat post init (m + k + 1) :=
+          iterateNat_chain_step
+            (post := post)
+            hMono
+            hInfl
+            (m + k)
+            init
+        exact Set.Subset.trans ih (by simpa [Nat.add_assoc] using hStep)
+  rcases Nat.exists_eq_add_of_le hLe with ⟨k, hk⟩
+  simpa [hk] using hAdd k
 
 end Iteration
 end Framework

--- a/Tests.lean
+++ b/Tests.lean
@@ -2,3 +2,4 @@ import Cslib.Init
 
 import AbsInterpLTS
 import Tests.Instances.LTS.Smoke
+import Tests.Framework.Iteration.NatIter

--- a/Tests/Framework/Iteration/NatIter.lean
+++ b/Tests/Framework/Iteration/NatIter.lean
@@ -1,0 +1,73 @@
+import Cslib.Init
+
+import AbsInterpLTS
+
+namespace Tests
+namespace FrameworkIterationNatIter
+
+open AbsInterpLTS
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Framework.Iteration
+
+def postAddZero : Post Nat :=
+  fun states => states ∪ {0}
+
+theorem postAddZero_monotone : MonotonePost postAddZero := by
+  intro s t hSubset x hx
+  rcases hx with hs | hz
+  · exact Or.inl (hSubset hs)
+  · exact Or.inr hz
+
+theorem postAddZero_inflationary : InflationaryPost postAddZero := by
+  intro states x hx
+  exact Or.inl hx
+
+example (init1 init2 : Set Nat) (hInit : init1 ⊆ init2) (n : Nat) :
+    iterateNat postAddZero init1 n ⊆ iterateNat postAddZero init2 n := by
+  exact iterateNat_monotone_init (post := postAddZero) postAddZero_monotone n hInit
+
+example (init : Set Nat) (m n : Nat) (hLe : m ≤ n) :
+    iterateNat postAddZero init m ⊆ iterateNat postAddZero init n := by
+  exact iterateNat_chain_of_le
+    (post := postAddZero)
+    postAddZero_monotone
+    postAddZero_inflationary
+    hLe
+    init
+
+inductive OneAbs where
+  | top
+  deriving DecidableEq, Repr
+
+def gammaOne : OneAbs -> Set Nat
+  | .top => Set.univ
+
+def postId : Post Nat :=
+  fun states => states
+
+def postSharpId : PostSharp OneAbs :=
+  fun a => a
+
+theorem sound_postId : Sound postId gammaOne postSharpId := by
+  intro a s hs
+  simp [postId, gammaOne] at hs
+  simpa using hs
+
+theorem postId_monotone : MonotonePost postId := by
+  intro s t hSubset
+  simpa [postId] using hSubset
+
+example (n : Nat) :
+    iterateNat postId (gammaOne OneAbs.top) n ⊆
+      gammaOne (iterateNatSharp postSharpId OneAbs.top n) := by
+  exact sound_iterateNat_of_sound
+    (post := postId)
+    (gamma := gammaOne)
+    (postSharp := postSharpId)
+    sound_postId
+    postId_monotone
+    n
+    OneAbs.top
+
+end FrameworkIterationNatIter
+end Tests


### PR DESCRIPTION
## Summary
This PR implements issue #2 by extending the framework nat-iteration layer from a single definition into reusable iteration and proof scaffolding.

## What changed
1. Iteration core and chain lemmas (`AbsInterpLTS/Framework/Iteration/NatIter.lean`)
- added `InflationaryPost`
- added abstract-side iterator `iterateNatSharp`
- added simp lemmas for `iterateNat/iterateNatSharp` zero/succ unfoldings
- added reusable lemmas:
  - `iterateNat_monotone_init`
  - `iterateNat_chain_step`
  - `iterateNat_chain_of_le`

2. Soundness pipeline bridge (`AbsInterpLTS/Framework/Iteration/NatIter.lean`)
- added `sound_iterateNat_of_sound`
- lifts one-step `Sound post gamma postSharp` into n-step soundness over `iterateNat`/`iterateNatSharp`

3. Framework-level tests
- added `Tests/Framework/Iteration/NatIter.lean` with:
  - monotonicity-oriented iteration statement
  - chain inclusion by index statement
  - inclusion/soundness pipeline statement using `sound_iterateNat_of_sound`
- imported from `Tests.lean`

## Validation
- `lake build`
- `lake build Tests`
- `lake test`

## Commit structure
- `feat(iteration): add nat iteration core and chain lemmas`
- `feat(iteration): lift one-step soundness over nat iterations`
- `test(iteration): add nat iteration scaffold coverage`

Closes #2