### PR TITLE
refactor(iteration): use next/reachF naming in NatIter (#13)

### DIFF
--- a/AbsInterpLTS/Framework/Iteration/NatIter.lean
+++ b/AbsInterpLTS/Framework/Iteration/NatIter.lean
@@ -16,79 +16,90 @@ abbrev Widen (Abstract : Type u) := Abstract -> Abstract -> Abstract
 
 /--
 Inflationary concrete transformer predicate:
-`states ⊆ post states`.
+`states ⊆ next states`.
 -/
 def InflationaryPost
     {State : Type u}
-    (post : Post State) : Prop :=
-  ∀ states : Set State, states ⊆ post states
+    (next : Post State) : Prop :=
+  ∀ states : Set State, states ⊆ next states
 
-/-- Natural-number iterate scaffold for concrete post operators. -/
+/--
+Collecting-style fixpoint operator for reachability:
+`reachF init stepPost states = init ∪ stepPost states`.
+-/
+def reachF
+    {State : Type u}
+    (init : Set State)
+    (stepPost : Post State) :
+    Post State :=
+  fun states => init ∪ stepPost states
+
+/-- Natural-number iterate scaffold for concrete next-step operators. -/
 def iterateNat
     {State : Type u}
-    (post : Post State)
+    (next : Post State)
     (init : Set State) :
     Nat -> Set State
   | 0 => init
-  | n + 1 => post (iterateNat post init n)
+  | n + 1 => next (iterateNat next init n)
 
-/-- Natural-number iterate scaffold for abstract transformers. -/
+/-- Natural-number iterate scaffold for abstract next-step transformers. -/
 def iterateNatSharp
     {Abstract : Type u}
-    (postSharp : PostSharp Abstract)
+    (nextSharp : PostSharp Abstract)
     (init : Abstract) :
     Nat -> Abstract
   | 0 => init
-  | n + 1 => postSharp (iterateNatSharp postSharp init n)
+  | n + 1 => nextSharp (iterateNatSharp nextSharp init n)
 
 @[simp] theorem iterateNat_zero
     {State : Type u}
-    (post : Post State)
+    (next : Post State)
     (init : Set State) :
-    iterateNat post init 0 = init :=
+    iterateNat next init 0 = init :=
   rfl
 
 @[simp] theorem iterateNat_succ
     {State : Type u}
-    (post : Post State)
+    (next : Post State)
     (init : Set State)
     (n : Nat) :
-    iterateNat post init (n + 1) = post (iterateNat post init n) :=
+    iterateNat next init (n + 1) = next (iterateNat next init n) :=
   rfl
 
 @[simp] theorem iterateNatSharp_zero
     {Abstract : Type u}
-    (postSharp : PostSharp Abstract)
+    (nextSharp : PostSharp Abstract)
     (init : Abstract) :
-    iterateNatSharp postSharp init 0 = init :=
+    iterateNatSharp nextSharp init 0 = init :=
   rfl
 
 @[simp] theorem iterateNatSharp_succ
     {Abstract : Type u}
-    (postSharp : PostSharp Abstract)
+    (nextSharp : PostSharp Abstract)
     (init : Abstract)
     (n : Nat) :
-    iterateNatSharp postSharp init (n + 1) =
-      postSharp (iterateNatSharp postSharp init n) :=
+    iterateNatSharp nextSharp init (n + 1) =
+      nextSharp (iterateNatSharp nextSharp init n) :=
   rfl
 
 /--
 Monotonicity of natural-number iteration in the initial set.
 
 Assumptions:
-- `hMono : MonotonePost post`
+- `hMono : MonotonePost next`
 - `hInit : init1 ⊆ init2`
 
 Conclusion:
-- `iterateNat post init1 n ⊆ iterateNat post init2 n`.
+- `iterateNat next init1 n ⊆ iterateNat next init2 n`.
 -/
 theorem iterateNat_monotone_init
     {State : Type u}
-    {post : Post State}
-    (hMono : MonotonePost post) :
+    {next : Post State}
+    (hMono : MonotonePost next) :
     ∀ n : Nat, ∀ {init1 init2 : Set State},
       init1 ⊆ init2 ->
-      iterateNat post init1 n ⊆ iterateNat post init2 n
+      iterateNat next init1 n ⊆ iterateNat next init2 n
   | 0, init1, init2, hInit => hInit
   | n + 1, init1, init2, hInit => by
       simpa using
@@ -98,19 +109,19 @@ theorem iterateNat_monotone_init
 Successor-chain step for natural-number iteration.
 
 Assumptions:
-- `hMono : MonotonePost post`
-- `hInfl : InflationaryPost post`
+- `hMono : MonotonePost next`
+- `hInfl : InflationaryPost next`
 
 Conclusion:
-- `iterateNat post init n ⊆ iterateNat post init (n + 1)`.
+- `iterateNat next init n ⊆ iterateNat next init (n + 1)`.
 -/
 theorem iterateNat_chain_step
     {State : Type u}
-    {post : Post State}
-    (hMono : MonotonePost post)
-    (hInfl : InflationaryPost post) :
+    {next : Post State}
+    (hMono : MonotonePost next)
+    (hInfl : InflationaryPost next) :
     ∀ (n : Nat) (init : Set State),
-      iterateNat post init n ⊆ iterateNat post init (n + 1)
+      iterateNat next init n ⊆ iterateNat next init (n + 1)
   | 0, init => by
       simpa using hInfl init
   | n + 1, init => by
@@ -121,30 +132,30 @@ theorem iterateNat_chain_step
 Iteration chain monotonicity along natural-number indices.
 
 Assumptions:
-- `hMono : MonotonePost post`
-- `hInfl : InflationaryPost post`
+- `hMono : MonotonePost next`
+- `hInfl : InflationaryPost next`
 - `hLe : m ≤ n`
 
 Conclusion:
-- `iterateNat post init m ⊆ iterateNat post init n`.
+- `iterateNat next init m ⊆ iterateNat next init n`.
 -/
 theorem iterateNat_chain_of_le
     {State : Type u}
-    {post : Post State}
-    (hMono : MonotonePost post)
-    (hInfl : InflationaryPost post)
+    {next : Post State}
+    (hMono : MonotonePost next)
+    (hInfl : InflationaryPost next)
     {m n : Nat}
     (hLe : m ≤ n)
     (init : Set State) :
-    iterateNat post init m ⊆ iterateNat post init n := by
+    iterateNat next init m ⊆ iterateNat next init n := by
   have hAdd :
-      ∀ k : Nat, iterateNat post init m ⊆ iterateNat post init (m + k) := by
+      ∀ k : Nat, iterateNat next init m ⊆ iterateNat next init (m + k) := by
     intro k
     induction k with
     | zero =>
         simp
     | succ k ih =>
-        exact Set.Subset.trans ih (iterateNat_chain_step (post := post) hMono hInfl (m + k) init)
+        exact Set.Subset.trans ih (iterateNat_chain_step (next := next) hMono hInfl (m + k) init)
   rcases Nat.exists_eq_add_of_le hLe with ⟨k, hk⟩
   simpa [hk] using hAdd k
 
@@ -152,33 +163,33 @@ theorem iterateNat_chain_of_le
 Lift one-step soundness to natural-number iteration soundness.
 
 Assumptions:
-- `hSound : Sound post gamma postSharp`
-- `hMono : MonotonePost post`
+- `hSound : Sound next gamma nextSharp`
+- `hMono : MonotonePost next`
 
 Conclusion:
-- `iterateNat post (gamma a) n ⊆ gamma (iterateNatSharp postSharp a n)`.
+- `iterateNat next (gamma a) n ⊆ gamma (iterateNatSharp nextSharp a n)`.
 -/
 theorem sound_iterateNat_of_sound
     {State : Type u}
     {Abstract : Type _}
-    {post : Post State}
+    {next : Post State}
     {gamma : Gamma Abstract State}
-    {postSharp : PostSharp Abstract}
-    (hSound : Sound post gamma postSharp)
-    (hMono : MonotonePost post) :
+    {nextSharp : PostSharp Abstract}
+    (hSound : Sound next gamma nextSharp)
+    (hMono : MonotonePost next) :
     ∀ (n : Nat) (a : Abstract),
-      iterateNat post (gamma a) n ⊆
-        gamma (iterateNatSharp postSharp a n)
+      iterateNat next (gamma a) n ⊆
+        gamma (iterateNatSharp nextSharp a n)
   | 0, a => by
       simp
   | n + 1, a => by
       simp only [iterateNat_succ, iterateNatSharp_succ]
       calc
-        post (iterateNat post (gamma a) n)
-            ⊆ post (gamma (iterateNatSharp postSharp a n)) := by
+        next (iterateNat next (gamma a) n)
+            ⊆ next (gamma (iterateNatSharp nextSharp a n)) := by
               exact hMono (sound_iterateNat_of_sound (hSound := hSound) (hMono := hMono) n a)
-        _ ⊆ gamma (postSharp (iterateNatSharp postSharp a n)) := by
-              exact hSound (iterateNatSharp postSharp a n)
+        _ ⊆ gamma (nextSharp (iterateNatSharp nextSharp a n)) := by
+              exact hSound (iterateNatSharp nextSharp a n)
 
 end Iteration
 end Framework

--- a/Tests/Framework/Iteration/NatIter.lean
+++ b/Tests/Framework/Iteration/NatIter.lean
@@ -24,16 +24,20 @@ theorem postAddZero_inflationary : InflationaryPost postAddZero := by
 
 example (init1 init2 : Set Nat) (hInit : init1 ⊆ init2) (n : Nat) :
     iterateNat postAddZero init1 n ⊆ iterateNat postAddZero init2 n := by
-  exact iterateNat_monotone_init (post := postAddZero) postAddZero_monotone n hInit
+  exact iterateNat_monotone_init (next := postAddZero) postAddZero_monotone n hInit
 
 example (init : Set Nat) (m n : Nat) (hLe : m ≤ n) :
     iterateNat postAddZero init m ⊆ iterateNat postAddZero init n := by
   exact iterateNat_chain_of_le
-    (post := postAddZero)
+    (next := postAddZero)
     postAddZero_monotone
     postAddZero_inflationary
     hLe
     init
+
+example (init states : Set Nat) :
+    reachF init postAddZero states = init ∪ postAddZero states := by
+  rfl
 
 inductive OneAbs where
   | top
@@ -61,9 +65,9 @@ example (n : Nat) :
     iterateNat postId (gammaOne OneAbs.top) n ⊆
       gammaOne (iterateNatSharp postSharpId OneAbs.top n) := by
   exact sound_iterateNat_of_sound
-    (post := postId)
+    (next := postId)
     (gamma := gammaOne)
-    (postSharp := postSharpId)
+    (nextSharp := postSharpId)
     sound_postId
     postId_monotone
     n


### PR DESCRIPTION
## Summary
Clarify naming in `Framework/Iteration/NatIter` so generic iteration operators are distinct from collecting/fixpoint operators.

## Changes
- Renamed NatIter operator argument names:
  - concrete: `post` -> `next`
  - abstract: `postSharp` -> `nextSharp`
- Added collecting-style fixpoint operator helper:
  - `reachF init stepPost : Post State := fun states => init ∪ stepPost states`
- Updated theorem statements/comments and named-argument call sites in tests.
- Added a small test-level definitional check for `reachF`.

## Validation
- `lake build`
- `lake build Tests`
- `lake test`

## Notes
- This is a naming/API clarity refactor; no intended semantic behavior changes.

Closes #13