### PR TITLE
feat(instances/lts): add unlabeled collecting postAny bridge

### DIFF
--- a/AbsInterpLTS/Instances/LTS.lean
+++ b/AbsInterpLTS/Instances/LTS.lean
@@ -1,5 +1,6 @@
 import AbsInterpLTS.Instances.LTS.Semantics.Concrete
 import AbsInterpLTS.Instances.LTS.Semantics.Lemmas
+import AbsInterpLTS.Instances.LTS.Semantics.Collecting
 import AbsInterpLTS.Instances.LTS.Instantiation.Interface
 import AbsInterpLTS.Instances.LTS.Instantiation.Soundness
 import AbsInterpLTS.Instances.LTS.Analyses.Sign

--- a/AbsInterpLTS/Instances/LTS/Semantics/Collecting.lean
+++ b/AbsInterpLTS/Instances/LTS/Semantics/Collecting.lean
@@ -1,0 +1,103 @@
+import Cslib.Init
+import Cslib.Foundations.Semantics.LTS.Basic
+
+import AbsInterpLTS.Framework.Iteration
+import AbsInterpLTS.Instances.LTS.Semantics.Concrete
+
+namespace AbsInterpLTS
+namespace Instances
+namespace LTS
+
+open Cslib
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Framework.Iteration
+
+universe u v
+
+/-- One-step unlabeled collecting post operator induced by an LTS. -/
+def postAny
+    {State : Type u}
+    {Label : Type v}
+    (lts : Cslib.LTS State Label) :
+    Post State :=
+  fun states => { s' : State | ∃ s ∈ states, ∃ label : Label, lts.Tr s label s' }
+
+@[simp] theorem mem_postAny
+    {State : Type u}
+    {Label : Type v}
+    {lts : Cslib.LTS State Label}
+    {states : Set State}
+    {s' : State} :
+    s' ∈ postAny lts states ↔ ∃ s ∈ states, ∃ label : Label, lts.Tr s label s' :=
+  Iff.rfl
+
+theorem tr_mem_postAny
+    {State : Type u}
+    {Label : Type v}
+    {lts : Cslib.LTS State Label}
+    {states : Set State}
+    {s s' : State}
+    {label : Label}
+    (hs : s ∈ states)
+    (htr : lts.Tr s label s') :
+    s' ∈ postAny lts states := by
+  exact ⟨s, hs, label, htr⟩
+
+theorem postAny_monotone
+    {State : Type u}
+    {Label : Type v}
+    (lts : Cslib.LTS State Label) :
+    MonotonePost (postAny lts) := by
+  intro states states' hSubset s' hs'
+  rcases hs' with ⟨s, hs, label, htr⟩
+  exact ⟨s, hSubset hs, label, htr⟩
+
+theorem mem_postAny_iff_exists_mem_setImage
+    {State : Type u}
+    {Label : Type v}
+    {lts : Cslib.LTS State Label}
+    {states : Set State}
+    {s' : State} :
+    s' ∈ postAny lts states ↔ ∃ label : Label, s' ∈ lts.setImage states label := by
+  constructor
+  · intro hs
+    rcases hs with ⟨s, hsMem, label, htr⟩
+    exact ⟨label, (Cslib.LTS.mem_setImage).2 ⟨s, hsMem, htr⟩⟩
+  · intro hs
+    rcases hs with ⟨label, hsMem⟩
+    rcases (Cslib.LTS.mem_setImage).1 hsMem with ⟨s, hsStates, htr⟩
+    exact ⟨s, hsStates, label, htr⟩
+
+@[simp] theorem mem_postAny_singleton_iff
+    {State : Type u}
+    {Label : Type v}
+    {lts : Cslib.LTS State Label}
+    {s s' : State} :
+    s' ∈ postAny lts ({s} : Set State) ↔ ∃ label : Label, lts.Tr s label s' := by
+  simp [postAny]
+
+theorem canReach_of_mem_postAny_singleton
+    {State : Type u}
+    {Label : Type v}
+    {lts : Cslib.LTS State Label}
+    {s s' : State}
+    (hMem : s' ∈ postAny lts ({s} : Set State)) :
+    lts.CanReach s s' := by
+  rcases (mem_postAny_singleton_iff (lts := lts) (s := s) (s' := s')).1 hMem with
+    ⟨label, htr⟩
+  exact ⟨[label], Cslib.LTS.MTr.single (lts := lts) htr⟩
+
+theorem reachF_postAny_monotone
+    {State : Type u}
+    {Label : Type v}
+    (lts : Cslib.LTS State Label)
+    (init : Set State) :
+    MonotonePost (reachF init (postAny lts)) :=
+  reachF_monotone_of_post_monotone
+    (init := init)
+    (post := postAny lts)
+    (postAny_monotone lts)
+
+end LTS
+end Instances
+end AbsInterpLTS

--- a/AbsInterpLTS/Instances/LTS/Semantics/Collecting.lean
+++ b/AbsInterpLTS/Instances/LTS/Semantics/Collecting.lean
@@ -59,14 +59,9 @@ theorem mem_postAny_iff_exists_mem_setImage
     {states : Set State}
     {s' : State} :
     s' ∈ postAny lts states ↔ ∃ label : Label, s' ∈ lts.setImage states label := by
-  constructor
-  · intro hs
-    rcases hs with ⟨s, hsMem, label, htr⟩
-    exact ⟨label, (Cslib.LTS.mem_setImage).2 ⟨s, hsMem, htr⟩⟩
-  · intro hs
-    rcases hs with ⟨label, hsMem⟩
-    rcases (Cslib.LTS.mem_setImage).1 hsMem with ⟨s, hsStates, htr⟩
-    exact ⟨s, hsStates, label, htr⟩
+  constructor <;> intro hs
+  · simpa [Cslib.LTS.mem_setImage, exists_comm, and_left_comm, and_assoc] using hs
+  · simpa [Cslib.LTS.mem_setImage, exists_comm, and_left_comm, and_assoc] using hs
 
 @[simp] theorem mem_postAny_singleton_iff
     {State : Type u}

--- a/Tests.lean
+++ b/Tests.lean
@@ -2,4 +2,5 @@ import Cslib.Init
 
 import AbsInterpLTS
 import Tests.Instances.LTS.Smoke
+import Tests.Instances.LTS.Collecting
 import Tests.Framework.Iteration.NatIter

--- a/Tests/Instances/LTS/Collecting.lean
+++ b/Tests/Instances/LTS/Collecting.lean
@@ -1,0 +1,120 @@
+import Cslib.Init
+
+import AbsInterpLTS
+
+namespace Tests
+namespace InstancesLTSCollecting
+
+open AbsInterpLTS
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Framework.Iteration
+open AbsInterpLTS.Instances.LTS
+
+def toyLTS : Cslib.LTS Nat Bool where
+  Tr s label s' :=
+    (s = 0 ∧ label = false ∧ s' = 1) ∨
+    (s = 0 ∧ label = true ∧ s' = 2) ∨
+    (s = 2 ∧ label = false ∧ s' = 3)
+
+abbrev postToy : Post Nat := postAny toyLTS
+
+def initZero : Set Nat := {0}
+
+theorem mem_postToy_from_zero_false : 1 ∈ postToy ({0} : Set Nat) := by
+  exact ⟨0, by simp, false, Or.inl ⟨rfl, rfl, rfl⟩⟩
+
+theorem mem_postToy_from_zero_true : 2 ∈ postToy ({0} : Set Nat) := by
+  exact ⟨0, by simp, true, Or.inr (Or.inl ⟨rfl, rfl, rfl⟩)⟩
+
+theorem not_mem_postToy_from_zero_three : 3 ∉ postToy ({0} : Set Nat) := by
+  intro hMem
+  rcases (mem_postAny (lts := toyLTS) (states := ({0} : Set Nat)) (s' := 3)).1 hMem with
+    ⟨s, hs, label, htr⟩
+  have hsZero : s = 0 := by simpa using hs
+  subst hsZero
+  cases label <;> simp [toyLTS] at htr
+
+example (S T : Set Nat) (hST : S ⊆ T) : postToy S ⊆ postToy T := by
+  exact postAny_monotone toyLTS hST
+
+theorem kleeneNat_one_eq_initZero :
+    kleeneNat initZero postToy 1 = initZero := by
+  ext x
+  constructor
+  · intro hx
+    have hx' : x ∈ initZero ∪ postToy (kleeneNat initZero postToy 0) := by
+      simpa [kleeneNat_succ] using hx
+    rcases hx' with hxInit | hxPost
+    · exact hxInit
+    · rcases (mem_postAny (lts := toyLTS)
+        (states := kleeneNat initZero postToy 0)
+        (s' := x)).1 hxPost with
+        ⟨s, hs, label, _⟩
+      exfalso
+      simp [kleeneNat_zero] at hs
+  · intro hx
+    have hx' : x ∈ initZero ∪ postToy (kleeneNat initZero postToy 0) := Or.inl hx
+    simpa [kleeneNat_succ] using hx'
+
+theorem mem_zero_kleeneNat_one : 0 ∈ kleeneNat initZero postToy 1 := by
+  exact (init_subset_kleeneNat_succ (post := postToy) 0 initZero) (by simp [initZero])
+
+theorem mem_one_kleeneNat_two : 1 ∈ kleeneNat initZero postToy 2 := by
+  have hPost : 1 ∈ postToy initZero := by
+    simpa [initZero] using mem_postToy_from_zero_false
+  have hUnion : 1 ∈ initZero ∪ postToy (kleeneNat initZero postToy 1) := by
+    exact Or.inr (by simpa [kleeneNat_one_eq_initZero] using hPost)
+  simpa [kleeneNat_succ] using hUnion
+
+theorem mem_two_kleeneNat_two : 2 ∈ kleeneNat initZero postToy 2 := by
+  have hPost : 2 ∈ postToy initZero := by
+    simpa [initZero] using mem_postToy_from_zero_true
+  have hUnion : 2 ∈ initZero ∪ postToy (kleeneNat initZero postToy 1) := by
+    exact Or.inr (by simpa [kleeneNat_one_eq_initZero] using hPost)
+  simpa [kleeneNat_succ] using hUnion
+
+theorem mem_three_kleeneNat_three : 3 ∈ kleeneNat initZero postToy 3 := by
+  have hTwo : 2 ∈ kleeneNat initZero postToy 2 := mem_two_kleeneNat_two
+  have hPost : 3 ∈ postToy (kleeneNat initZero postToy 2) := by
+    exact tr_mem_postAny
+      (lts := toyLTS)
+      (states := kleeneNat initZero postToy 2)
+      (s := 2)
+      (label := false)
+      hTwo
+      (Or.inr (Or.inr ⟨rfl, rfl, rfl⟩))
+  have hUnion : 3 ∈ initZero ∪ postToy (kleeneNat initZero postToy 2) := Or.inr hPost
+  simpa [kleeneNat_succ] using hUnion
+
+theorem not_mem_three_kleeneNat_two : 3 ∉ kleeneNat initZero postToy 2 := by
+  intro hThree
+  have hThree' : 3 ∈ initZero ∪ postToy (kleeneNat initZero postToy 1) := by
+    simpa [kleeneNat_succ] using hThree
+  rcases hThree' with hInit | hPost
+  · simp [initZero] at hInit
+  · have hPost' : 3 ∈ postToy initZero := by
+      simpa [kleeneNat_one_eq_initZero] using hPost
+    have hNot : 3 ∉ postToy ({0} : Set Nat) := not_mem_postToy_from_zero_three
+    exact hNot (by simpa [initZero] using hPost')
+
+example : 0 ∈ kleeneNat initZero postToy 1 := mem_zero_kleeneNat_one
+example : 1 ∈ kleeneNat initZero postToy 2 := mem_one_kleeneNat_two
+example : 2 ∈ kleeneNat initZero postToy 2 := mem_two_kleeneNat_two
+example : 3 ∈ kleeneNat initZero postToy 3 := mem_three_kleeneNat_three
+example : 3 ∉ kleeneNat initZero postToy 2 := not_mem_three_kleeneNat_two
+
+example (x : Nat) (hx : x ∈ postToy ({0} : Set Nat)) :
+    toyLTS.CanReach 0 x := by
+  exact canReach_of_mem_postAny_singleton
+    (lts := toyLTS)
+    (s := 0)
+    (s' := x)
+    (by simpa [postToy] using hx)
+
+example :
+    MonotonePost (reachF initZero postToy) := by
+  change MonotonePost (reachF initZero (postAny toyLTS))
+  exact reachF_postAny_monotone (lts := toyLTS) (init := initZero)
+
+end InstancesLTSCollecting
+end Tests

--- a/Tests/Instances/LTS/Collecting.lean
+++ b/Tests/Instances/LTS/Collecting.lean
@@ -40,21 +40,7 @@ example (S T : Set Nat) (hST : S ⊆ T) : postToy S ⊆ postToy T := by
 theorem kleeneNat_one_eq_initZero :
     kleeneNat initZero postToy 1 = initZero := by
   ext x
-  constructor
-  · intro hx
-    have hx' : x ∈ initZero ∪ postToy (kleeneNat initZero postToy 0) := by
-      simpa [kleeneNat_succ] using hx
-    rcases hx' with hxInit | hxPost
-    · exact hxInit
-    · rcases (mem_postAny (lts := toyLTS)
-        (states := kleeneNat initZero postToy 0)
-        (s' := x)).1 hxPost with
-        ⟨s, hs, label, _⟩
-      exfalso
-      simp [kleeneNat_zero] at hs
-  · intro hx
-    have hx' : x ∈ initZero ∪ postToy (kleeneNat initZero postToy 0) := Or.inl hx
-    simpa [kleeneNat_succ] using hx'
+  simp [kleeneNat_succ, kleeneNat_zero, postToy, postAny, initZero]
 
 theorem mem_zero_kleeneNat_one : 0 ∈ kleeneNat initZero postToy 1 := by
   exact (init_subset_kleeneNat_succ (post := postToy) 0 initZero) (by simp [initZero])


### PR DESCRIPTION
## Summary
- add LTS unlabeled collecting step operator `postAny : Set State -> Set State`
- prove core bridge lemmas (`mem_postAny`, `postAny_monotone`, `Tr`/`setImage`/`CanReach` links)
- connect LTS collecting step to framework collecting iteration via `reachF_postAny_monotone`
- add LTS collecting tests for `postAny` membership and `kleeneNat` reachability growth

## Validation
- lake build
- lake build Tests
- lake test

Refs: #17
