### PR TITLE
refactor(framework): separate collecting semantics from iteration (#20)

### DIFF
--- a/AbsInterpLTS/Framework/Iteration.lean
+++ b/AbsInterpLTS/Framework/Iteration.lean
@@ -1,1 +1,2 @@
 import AbsInterpLTS.Framework.Iteration.NatIter
+import AbsInterpLTS.Framework.Iteration.Collecting

--- a/AbsInterpLTS/Framework/Iteration/Collecting.lean
+++ b/AbsInterpLTS/Framework/Iteration/Collecting.lean
@@ -1,0 +1,90 @@
+import Cslib.Init
+
+import AbsInterpLTS.Framework.Semantics.Collecting
+import AbsInterpLTS.Framework.Iteration.NatIter
+
+namespace AbsInterpLTS
+namespace Framework
+
+open AbsInterpLTS.Framework
+
+universe u
+
+namespace CollectingStep
+
+/--
+Nat-indexed Kleene iteration for collecting semantics:
+`X₀ = ∅`, `Xₙ₊₁ = init ∪ post Xₙ`.
+-/
+def kleeneNat
+    {State : Type u}
+    (cfg : CollectingStep State)
+    (init : Set State) :
+    Nat -> Set State :=
+  Iteration.iterateNat (cfg.reachF init) ∅
+
+@[simp] theorem kleeneNat_zero
+    {State : Type u}
+    (cfg : CollectingStep State)
+    (init : Set State) :
+    cfg.kleeneNat init 0 = ∅ :=
+  rfl
+
+@[simp] theorem kleeneNat_succ
+    {State : Type u}
+    (cfg : CollectingStep State)
+    (init : Set State)
+    (n : Nat) :
+    cfg.kleeneNat init (n + 1) = init ∪ cfg.post (cfg.kleeneNat init n) := by
+  simp [CollectingStep.kleeneNat, CollectingStep.reachF]
+
+/--
+Successor-chain step for collecting Kleene iteration.
+-/
+theorem kleeneNat_chain_step
+    {State : Type u}
+    (cfg : CollectingStep State) :
+    ∀ (n : Nat) (init : Set State),
+      cfg.kleeneNat init n ⊆ cfg.kleeneNat init (n + 1)
+  | 0, init => by
+      simp
+  | n + 1, init => by
+      simpa [cfg.kleeneNat_succ] using
+        (Set.union_subset_union
+          (Set.Subset.refl init)
+          (cfg.monotone (cfg.kleeneNat_chain_step n init)))
+
+/--
+Collecting Kleene iteration chain monotonicity along natural-number indices.
+-/
+theorem kleeneNat_chain_of_le
+    {State : Type u}
+    (cfg : CollectingStep State)
+    {m n : Nat}
+    (hLe : m ≤ n)
+    (init : Set State) :
+    cfg.kleeneNat init m ⊆ cfg.kleeneNat init n := by
+  have hAdd :
+      ∀ k : Nat, cfg.kleeneNat init m ⊆ cfg.kleeneNat init (m + k) := by
+    intro k
+    induction k with
+    | zero =>
+        simp
+    | succ k ih =>
+        exact Set.Subset.trans ih (cfg.kleeneNat_chain_step (m + k) init)
+  rcases Nat.exists_eq_add_of_le hLe with ⟨k, hk⟩
+  simpa [hk] using hAdd k
+
+/--
+Every successor Kleene iterate contains the initial states.
+-/
+theorem init_subset_kleeneNat_succ
+    {State : Type u}
+    (cfg : CollectingStep State) :
+    ∀ (n : Nat) (init : Set State), init ⊆ cfg.kleeneNat init (n + 1)
+  | n, init => by simp
+
+end CollectingStep
+
+end Framework
+end AbsInterpLTS

--- a/AbsInterpLTS/Framework/Iteration/NatIter.lean
+++ b/AbsInterpLTS/Framework/Iteration/NatIter.lean
@@ -14,36 +14,6 @@ universe u
 /-- Widening interface for abstract iterative solvers. -/
 abbrev Widen (Abstract : Type u) := Abstract -> Abstract -> Abstract
 
-/--
-Collecting-style fixpoint operator for reachability:
-`reachF init post states = init ∪ post states`.
--/
-def reachF
-    {State : Type u}
-    (init : Set State)
-    (post : Post State) :
-    Post State :=
-  fun states => init ∪ post states
-
-@[simp] theorem reachF_apply
-    {State : Type u}
-    (init : Set State)
-    (post : Post State)
-    (states : Set State) :
-    reachF init post states = init ∪ post states :=
-  rfl
-
-theorem reachF_monotone_of_post_monotone
-    {State : Type u}
-    {init : Set State}
-    {post : Post State}
-    (hMono : MonotonePost post) :
-    MonotonePost (reachF init post) := by
-  intro states states' hSubset s hs
-  rcases hs with hsInit | hsPost
-  · exact Or.inl hsInit
-  · exact Or.inr (hMono hSubset hsPost)
-
 /-- Natural-number iterate scaffold for concrete next-step operators. -/
 def iterateNat
     {State : Type u}
@@ -52,17 +22,6 @@ def iterateNat
     Nat -> Set State
   | 0 => init
   | n + 1 => next (iterateNat next init n)
-
-/--
-Nat-indexed Kleene iteration for collecting semantics:
-`X₀ = ∅`, `Xₙ₊₁ = init ∪ post Xₙ`.
--/
-def kleeneNat
-    {State : Type u}
-    (init : Set State)
-    (post : Post State) :
-    Nat -> Set State :=
-  iterateNat (reachF init post) ∅
 
 /-- Natural-number iterate scaffold for abstract next-step transformers. -/
 def iterateNatSharp
@@ -104,21 +63,6 @@ def iterateNatSharp
       nextSharp (iterateNatSharp nextSharp init n) :=
   rfl
 
-@[simp] theorem kleeneNat_zero
-    {State : Type u}
-    (init : Set State)
-    (post : Post State) :
-    kleeneNat init post 0 = ∅ :=
-  rfl
-
-@[simp] theorem kleeneNat_succ
-    {State : Type u}
-    (init : Set State)
-    (post : Post State)
-    (n : Nat) :
-    kleeneNat init post (n + 1) = init ∪ post (kleeneNat init post n) := by
-  simp [kleeneNat, reachF]
-
 /--
 Monotonicity of natural-number iteration in the initial set.
 
@@ -140,67 +84,6 @@ theorem iterateNat_monotone_init
   | n + 1, init1, init2, hInit => by
       simpa using
         hMono (iterateNat_monotone_init (hMono := hMono) n hInit)
-
-/--
-Successor-chain step for collecting Kleene iteration.
-
-Assumptions:
-- `hMono : MonotonePost post`
-
-Conclusion:
-- `kleeneNat init post n ⊆ kleeneNat init post (n + 1)`.
--/
-theorem kleeneNat_chain_step
-    {State : Type u}
-    {post : Post State}
-    (hMono : MonotonePost post) :
-    ∀ (n : Nat) (init : Set State),
-      kleeneNat init post n ⊆ kleeneNat init post (n + 1)
-  | 0, init => by
-      simp
-  | n + 1, init => by
-      simpa [kleeneNat_succ] using
-        (Set.union_subset_union
-          (Set.Subset.refl init)
-          (hMono (kleeneNat_chain_step (hMono := hMono) n init)))
-
-/--
-Collecting Kleene iteration chain monotonicity along natural-number indices.
-
-Assumptions:
-- `hMono : MonotonePost post`
-- `hLe : m ≤ n`
-
-Conclusion:
-- `kleeneNat init post m ⊆ kleeneNat init post n`.
--/
-theorem kleeneNat_chain_of_le
-    {State : Type u}
-    {post : Post State}
-    (hMono : MonotonePost post)
-    {m n : Nat}
-    (hLe : m ≤ n)
-    (init : Set State) :
-    kleeneNat init post m ⊆ kleeneNat init post n := by
-  have hAdd :
-      ∀ k : Nat, kleeneNat init post m ⊆ kleeneNat init post (m + k) := by
-    intro k
-    induction k with
-    | zero =>
-        simp
-    | succ k ih =>
-        exact Set.Subset.trans ih (kleeneNat_chain_step (post := post) hMono (m + k) init)
-  rcases Nat.exists_eq_add_of_le hLe with ⟨k, hk⟩
-  simpa [hk] using hAdd k
-
-/--
-Every successor Kleene iterate contains the initial states.
--/
-theorem init_subset_kleeneNat_succ
-    {State : Type u}
-    {post : Post State} :
-    ∀ (n : Nat) (init : Set State), init ⊆ kleeneNat init post (n + 1)
-  | n, init => by simp [kleeneNat_succ]
 
 /--
 Lift one-step soundness to natural-number iteration soundness.

--- a/AbsInterpLTS/Framework/Semantics.lean
+++ b/AbsInterpLTS/Framework/Semantics.lean
@@ -1,3 +1,4 @@
 import AbsInterpLTS.Framework.Semantics.TraceLift
 import AbsInterpLTS.Framework.Semantics.Concrete
+import AbsInterpLTS.Framework.Semantics.Collecting
 import AbsInterpLTS.Framework.Semantics.Abstract

--- a/AbsInterpLTS/Framework/Semantics/Collecting.lean
+++ b/AbsInterpLTS/Framework/Semantics/Collecting.lean
@@ -1,0 +1,2 @@
+import AbsInterpLTS.Framework.Semantics.Collecting.Defs
+import AbsInterpLTS.Framework.Semantics.Collecting.Lemmas

--- a/AbsInterpLTS/Framework/Semantics/Collecting/Defs.lean
+++ b/AbsInterpLTS/Framework/Semantics/Collecting/Defs.lean
@@ -1,0 +1,33 @@
+import Cslib.Init
+
+import AbsInterpLTS.Framework.Semantics.Concrete.Defs
+
+namespace AbsInterpLTS
+namespace Framework
+
+universe u
+
+/--
+Monotone one-step collecting semantics packaged as a reusable interface.
+-/
+structure CollectingStep (State : Type u) where
+  post : Post State
+  monotone : MonotonePost post
+
+namespace CollectingStep
+
+/--
+Collecting-style fixpoint operator for reachability:
+`reachF init states = init ∪ post states`.
+-/
+def reachF
+    {State : Type u}
+    (cfg : CollectingStep State)
+    (init : Set State) :
+    Post State :=
+  fun states => init ∪ cfg.post states
+
+end CollectingStep
+
+end Framework
+end AbsInterpLTS

--- a/AbsInterpLTS/Framework/Semantics/Collecting/Lemmas.lean
+++ b/AbsInterpLTS/Framework/Semantics/Collecting/Lemmas.lean
@@ -1,0 +1,33 @@
+import Cslib.Init
+
+import AbsInterpLTS.Framework.Semantics.Collecting.Defs
+
+namespace AbsInterpLTS
+namespace Framework
+
+universe u
+
+namespace CollectingStep
+
+@[simp] theorem reachF_apply
+    {State : Type u}
+    (cfg : CollectingStep State)
+    (init : Set State)
+    (states : Set State) :
+    cfg.reachF init states = init ∪ cfg.post states :=
+  rfl
+
+theorem reachF_monotone
+    {State : Type u}
+    (cfg : CollectingStep State)
+    (init : Set State) :
+    MonotonePost (cfg.reachF init) := by
+  intro states states' hSubset s hs
+  rcases hs with hsInit | hsPost
+  · exact Or.inl hsInit
+  · exact Or.inr (cfg.monotone hSubset hsPost)
+
+end CollectingStep
+
+end Framework
+end AbsInterpLTS

--- a/AbsInterpLTS/Instances/LTS/Semantics/Collecting.lean
+++ b/AbsInterpLTS/Instances/LTS/Semantics/Collecting.lean
@@ -1,7 +1,7 @@
 import Cslib.Init
 import Cslib.Foundations.Semantics.LTS.Basic
 
-import AbsInterpLTS.Framework.Iteration
+import AbsInterpLTS.Framework.Semantics
 import AbsInterpLTS.Instances.LTS.Semantics.Concrete
 
 namespace AbsInterpLTS
@@ -10,7 +10,6 @@ namespace LTS
 
 open Cslib
 open AbsInterpLTS.Framework
-open AbsInterpLTS.Framework.Iteration
 
 universe u v
 
@@ -20,7 +19,7 @@ def postAny
     {Label : Type v}
     (lts : Cslib.LTS State Label) :
     Post State :=
-  fun states => { s' : State | ∃ s ∈ states, ∃ label : Label, lts.Tr s label s' }
+  fun states => { s' : State | ∃ label : Label, s' ∈ postStep lts label states }
 
 @[simp] theorem mem_postAny
     {State : Type u}
@@ -28,8 +27,25 @@ def postAny
     {lts : Cslib.LTS State Label}
     {states : Set State}
     {s' : State} :
-    s' ∈ postAny lts states ↔ ∃ s ∈ states, ∃ label : Label, lts.Tr s label s' :=
-  Iff.rfl
+    s' ∈ postAny lts states ↔ ∃ s ∈ states, ∃ label : Label, lts.Tr s label s' := by
+  constructor
+  · intro hs
+    rcases hs with ⟨label, hsLabel⟩
+    rcases (Cslib.LTS.mem_setImage
+      (lts := lts)
+      (S := states)
+      (μ := label)
+      (s' := s')).1 (by simpa [postStep] using hsLabel) with ⟨s, hsMem, htr⟩
+    exact ⟨s, hsMem, label, htr⟩
+  · intro hs
+    rcases hs with ⟨s, hsMem, label, htr⟩
+    refine ⟨label, ?_⟩
+    exact
+      (Cslib.LTS.mem_setImage
+        (lts := lts)
+        (S := states)
+        (μ := label)
+        (s' := s')).2 ⟨s, hsMem, htr⟩
 
 theorem tr_mem_postAny
     {State : Type u}
@@ -41,7 +57,13 @@ theorem tr_mem_postAny
     (hs : s ∈ states)
     (htr : lts.Tr s label s') :
     s' ∈ postAny lts states := by
-  exact ⟨s, hs, label, htr⟩
+  refine ⟨label, ?_⟩
+  exact
+    (Cslib.LTS.mem_setImage
+      (lts := lts)
+      (S := states)
+      (μ := label)
+      (s' := s')).2 ⟨s, hs, htr⟩
 
 theorem postAny_monotone
     {State : Type u}
@@ -49,8 +71,28 @@ theorem postAny_monotone
     (lts : Cslib.LTS State Label) :
     MonotonePost (postAny lts) := by
   intro states states' hSubset s' hs'
-  rcases hs' with ⟨s, hs, label, htr⟩
-  exact ⟨s, hSubset hs, label, htr⟩
+  rcases hs' with ⟨label, hsLabel⟩
+  rcases (Cslib.LTS.mem_setImage
+    (lts := lts)
+    (S := states)
+    (μ := label)
+    (s' := s')).1 (by simpa [postStep] using hsLabel) with ⟨s, hsMem, htr⟩
+  refine ⟨label, ?_⟩
+  exact
+    (Cslib.LTS.mem_setImage
+      (lts := lts)
+      (S := states')
+      (μ := label)
+      (s' := s')).2 ⟨s, hSubset hsMem, htr⟩
+
+/-- Pack unlabeled LTS collecting semantics as a framework `CollectingStep`. -/
+def postAny_collectingStep
+    {State : Type u}
+    {Label : Type v}
+    (lts : Cslib.LTS State Label) :
+    CollectingStep State where
+  post := postAny lts
+  monotone := postAny_monotone lts
 
 theorem mem_postAny_iff_exists_mem_setImage
     {State : Type u}
@@ -59,9 +101,7 @@ theorem mem_postAny_iff_exists_mem_setImage
     {states : Set State}
     {s' : State} :
     s' ∈ postAny lts states ↔ ∃ label : Label, s' ∈ lts.setImage states label := by
-  constructor <;> intro hs
-  · simpa [Cslib.LTS.mem_setImage, exists_comm, and_left_comm, and_assoc] using hs
-  · simpa [Cslib.LTS.mem_setImage, exists_comm, and_left_comm, and_assoc] using hs
+  simp [postAny, postStep]
 
 @[simp] theorem mem_postAny_singleton_iff
     {State : Type u}
@@ -69,7 +109,7 @@ theorem mem_postAny_iff_exists_mem_setImage
     {lts : Cslib.LTS State Label}
     {s s' : State} :
     s' ∈ postAny lts ({s} : Set State) ↔ ∃ label : Label, lts.Tr s label s' := by
-  simp [postAny]
+  simp [postAny, postStep, Cslib.LTS.mem_setImage]
 
 theorem canReach_of_mem_postAny_singleton
     {State : Type u}
@@ -82,16 +122,13 @@ theorem canReach_of_mem_postAny_singleton
     ⟨label, htr⟩
   exact ⟨[label], Cslib.LTS.MTr.single (lts := lts) htr⟩
 
-theorem reachF_postAny_monotone
+theorem postAny_reachF_monotone
     {State : Type u}
     {Label : Type v}
     (lts : Cslib.LTS State Label)
     (init : Set State) :
-    MonotonePost (reachF init (postAny lts)) :=
-  reachF_monotone_of_post_monotone
-    (init := init)
-    (post := postAny lts)
-    (postAny_monotone lts)
+    MonotonePost ((postAny_collectingStep lts).reachF init) :=
+  (postAny_collectingStep lts).reachF_monotone init
 
 end LTS
 end Instances

--- a/Tests/Framework/Iteration/NatIter.lean
+++ b/Tests/Framework/Iteration/NatIter.lean
@@ -18,29 +18,31 @@ theorem postAddZero_monotone : MonotonePost postAddZero := by
   · exact Or.inl (hSubset hs)
   · exact Or.inr hz
 
+def postAddZeroCollecting : CollectingStep Nat where
+  post := postAddZero
+  monotone := postAddZero_monotone
+
 example (init1 init2 : Set Nat) (hInit : init1 ⊆ init2) (n : Nat) :
     iterateNat postAddZero init1 n ⊆ iterateNat postAddZero init2 n := by
   exact iterateNat_monotone_init (next := postAddZero) postAddZero_monotone n hInit
 
 example (init : Set Nat) (n : Nat) :
-    kleeneNat init postAddZero n ⊆ kleeneNat init postAddZero (n + 1) := by
-  exact kleeneNat_chain_step (post := postAddZero) postAddZero_monotone n init
+    postAddZeroCollecting.kleeneNat init n ⊆
+      postAddZeroCollecting.kleeneNat init (n + 1) := by
+  exact postAddZeroCollecting.kleeneNat_chain_step n init
 
 example (init : Set Nat) (m n : Nat) (hLe : m ≤ n) :
-    kleeneNat init postAddZero m ⊆ kleeneNat init postAddZero n := by
-  exact kleeneNat_chain_of_le
-    (post := postAddZero)
-    postAddZero_monotone
-    hLe
-    init
+    postAddZeroCollecting.kleeneNat init m ⊆
+      postAddZeroCollecting.kleeneNat init n := by
+  exact postAddZeroCollecting.kleeneNat_chain_of_le hLe init
 
 example (init states : Set Nat) :
-    reachF init postAddZero states = init ∪ postAddZero states := by
+    postAddZeroCollecting.reachF init states = init ∪ postAddZero states := by
   rfl
 
-example (init : Set Nat) (post : Post Nat) (n : Nat) :
-    init ⊆ kleeneNat init post (n + 1) := by
-  exact init_subset_kleeneNat_succ (post := post) n init
+example (cfg : CollectingStep Nat) (init : Set Nat) (n : Nat) :
+    init ⊆ cfg.kleeneNat init (n + 1) := by
+  exact cfg.init_subset_kleeneNat_succ n init
 
 inductive OneAbs where
   | top

--- a/Tests/Instances/LTS/Collecting.lean
+++ b/Tests/Instances/LTS/Collecting.lean
@@ -20,11 +20,34 @@ abbrev postToy : Post Nat := postAny toyLTS
 
 def initZero : Set Nat := {0}
 
+abbrev collectingToy : CollectingStep Nat := postAny_collectingStep toyLTS
+
+abbrev kleeneToy : Nat -> Set Nat := collectingToy.kleeneNat initZero
+
+@[simp] theorem kleeneToy_zero : kleeneToy 0 = ∅ := by
+  simp [kleeneToy, CollectingStep.kleeneNat_zero]
+
+@[simp] theorem kleeneToy_succ (n : Nat) :
+    kleeneToy (n + 1) = initZero ∪ postToy (kleeneToy n) := by
+  simp [kleeneToy, CollectingStep.kleeneNat_succ, collectingToy, postAny_collectingStep, postToy]
+
 theorem mem_postToy_from_zero_false : 1 ∈ postToy ({0} : Set Nat) := by
-  exact ⟨0, by simp, false, Or.inl ⟨rfl, rfl, rfl⟩⟩
+  exact tr_mem_postAny
+    (lts := toyLTS)
+    (states := ({0} : Set Nat))
+    (s := 0)
+    (label := false)
+    (by simp)
+    (Or.inl ⟨rfl, rfl, rfl⟩)
 
 theorem mem_postToy_from_zero_true : 2 ∈ postToy ({0} : Set Nat) := by
-  exact ⟨0, by simp, true, Or.inr (Or.inl ⟨rfl, rfl, rfl⟩)⟩
+  exact tr_mem_postAny
+    (lts := toyLTS)
+    (states := ({0} : Set Nat))
+    (s := 0)
+    (label := true)
+    (by simp)
+    (Or.inr (Or.inl ⟨rfl, rfl, rfl⟩))
 
 theorem not_mem_postToy_from_zero_three : 3 ∉ postToy ({0} : Set Nat) := by
   intro hMem
@@ -37,57 +60,96 @@ theorem not_mem_postToy_from_zero_three : 3 ∉ postToy ({0} : Set Nat) := by
 example (S T : Set Nat) (hST : S ⊆ T) : postToy S ⊆ postToy T := by
   exact postAny_monotone toyLTS hST
 
-theorem kleeneNat_one_eq_initZero :
-    kleeneNat initZero postToy 1 = initZero := by
+theorem postToy_empty : postToy (∅ : Set Nat) = (∅ : Set Nat) := by
   ext x
-  simp [kleeneNat_succ, kleeneNat_zero, postToy, postAny, initZero]
+  constructor
+  · intro hx
+    rcases (mem_postAny
+      (lts := toyLTS)
+      (states := (∅ : Set Nat))
+      (s' := x)).1 hx with ⟨s, hs, label, htr⟩
+    simp at hs
+  · intro hx
+    simp at hx
 
-theorem mem_zero_kleeneNat_one : 0 ∈ kleeneNat initZero postToy 1 := by
-  exact (init_subset_kleeneNat_succ (post := postToy) 0 initZero) (by simp [initZero])
+theorem kleeneNat_one_eq_initZero :
+    collectingToy.kleeneNat initZero 1 = initZero := by
+  calc
+    collectingToy.kleeneNat initZero 1
+        = initZero ∪ postToy (kleeneToy 0) := by
+            simpa [kleeneToy] using kleeneToy_succ 0
+    _ = initZero := by
+      simp [postToy_empty]
 
-theorem mem_one_kleeneNat_two : 1 ∈ kleeneNat initZero postToy 2 := by
+@[simp] theorem kleeneToy_one : kleeneToy 1 = initZero := by
+  simpa [kleeneToy] using kleeneNat_one_eq_initZero
+
+theorem mem_zero_kleeneNat_one : 0 ∈ collectingToy.kleeneNat initZero 1 := by
+  rw [kleeneNat_one_eq_initZero]
+  simp [initZero]
+
+theorem mem_one_kleeneNat_two : 1 ∈ collectingToy.kleeneNat initZero 2 := by
   have hPost : 1 ∈ postToy initZero := by
     simpa [initZero] using mem_postToy_from_zero_false
-  have hUnion : 1 ∈ initZero ∪ postToy (kleeneNat initZero postToy 1) := by
-    exact Or.inr (by simpa [kleeneNat_one_eq_initZero] using hPost)
-  simpa [kleeneNat_succ] using hUnion
+  have hPostAtOne : 1 ∈ postToy (kleeneToy 1) := by
+    rw [kleeneToy_one]
+    exact hPost
+  have hUnion : 1 ∈ initZero ∪ postToy (kleeneToy 1) := by
+    exact Or.inr hPostAtOne
+  have hk2 : collectingToy.kleeneNat initZero 2 = initZero ∪ postToy (kleeneToy 1) := by
+    simpa [kleeneToy] using kleeneToy_succ 1
+  rw [hk2]
+  exact hUnion
 
-theorem mem_two_kleeneNat_two : 2 ∈ kleeneNat initZero postToy 2 := by
+theorem mem_two_kleeneNat_two : 2 ∈ collectingToy.kleeneNat initZero 2 := by
   have hPost : 2 ∈ postToy initZero := by
     simpa [initZero] using mem_postToy_from_zero_true
-  have hUnion : 2 ∈ initZero ∪ postToy (kleeneNat initZero postToy 1) := by
-    exact Or.inr (by simpa [kleeneNat_one_eq_initZero] using hPost)
-  simpa [kleeneNat_succ] using hUnion
+  have hPostAtOne : 2 ∈ postToy (kleeneToy 1) := by
+    rw [kleeneToy_one]
+    exact hPost
+  have hUnion : 2 ∈ initZero ∪ postToy (kleeneToy 1) := by
+    exact Or.inr hPostAtOne
+  have hk2 : collectingToy.kleeneNat initZero 2 = initZero ∪ postToy (kleeneToy 1) := by
+    simpa [kleeneToy] using kleeneToy_succ 1
+  rw [hk2]
+  exact hUnion
 
-theorem mem_three_kleeneNat_three : 3 ∈ kleeneNat initZero postToy 3 := by
-  have hTwo : 2 ∈ kleeneNat initZero postToy 2 := mem_two_kleeneNat_two
-  have hPost : 3 ∈ postToy (kleeneNat initZero postToy 2) := by
+theorem mem_three_kleeneNat_three : 3 ∈ collectingToy.kleeneNat initZero 3 := by
+  have hTwo : 2 ∈ collectingToy.kleeneNat initZero 2 := mem_two_kleeneNat_two
+  have hPost : 3 ∈ postToy (kleeneToy 2) := by
     exact tr_mem_postAny
       (lts := toyLTS)
-      (states := kleeneNat initZero postToy 2)
+      (states := kleeneToy 2)
       (s := 2)
       (label := false)
       hTwo
       (Or.inr (Or.inr ⟨rfl, rfl, rfl⟩))
-  have hUnion : 3 ∈ initZero ∪ postToy (kleeneNat initZero postToy 2) := Or.inr hPost
-  simpa [kleeneNat_succ] using hUnion
+  have hUnion : 3 ∈ initZero ∪ postToy (kleeneToy 2) := Or.inr hPost
+  have hk3 : collectingToy.kleeneNat initZero 3 = initZero ∪ postToy (kleeneToy 2) := by
+    simpa [kleeneToy] using kleeneToy_succ 2
+  rw [hk3]
+  exact hUnion
 
-theorem not_mem_three_kleeneNat_two : 3 ∉ kleeneNat initZero postToy 2 := by
+theorem not_mem_three_kleeneNat_two : 3 ∉ collectingToy.kleeneNat initZero 2 := by
   intro hThree
-  have hThree' : 3 ∈ initZero ∪ postToy (kleeneNat initZero postToy 1) := by
-    simpa [kleeneNat_succ] using hThree
+  have hk2 : collectingToy.kleeneNat initZero 2 = initZero ∪ postToy (kleeneToy 1) := by
+    simpa [kleeneToy] using kleeneToy_succ 1
+  have hThree' : 3 ∈ initZero ∪ postToy (kleeneToy 1) := by
+    rw [← hk2]
+    exact hThree
   rcases hThree' with hInit | hPost
   · simp [initZero] at hInit
   · have hPost' : 3 ∈ postToy initZero := by
-      simpa [kleeneNat_one_eq_initZero] using hPost
+      rw [kleeneToy_one] at hPost
+      exact hPost
     have hNot : 3 ∉ postToy ({0} : Set Nat) := not_mem_postToy_from_zero_three
     exact hNot (by simpa [initZero] using hPost')
 
-example : 0 ∈ kleeneNat initZero postToy 1 := mem_zero_kleeneNat_one
-example : 1 ∈ kleeneNat initZero postToy 2 := mem_one_kleeneNat_two
-example : 2 ∈ kleeneNat initZero postToy 2 := mem_two_kleeneNat_two
-example : 3 ∈ kleeneNat initZero postToy 3 := mem_three_kleeneNat_three
-example : 3 ∉ kleeneNat initZero postToy 2 := not_mem_three_kleeneNat_two
+example : 0 ∈ collectingToy.kleeneNat initZero 1 := mem_zero_kleeneNat_one
+example : 1 ∈ collectingToy.kleeneNat initZero 2 := mem_one_kleeneNat_two
+example : 2 ∈ collectingToy.kleeneNat initZero 2 := mem_two_kleeneNat_two
+example : 3 ∈ collectingToy.kleeneNat initZero 3 := mem_three_kleeneNat_three
+example : 3 ∉ collectingToy.kleeneNat initZero 2 := not_mem_three_kleeneNat_two
 
 example (x : Nat) (hx : x ∈ postToy ({0} : Set Nat)) :
     toyLTS.CanReach 0 x := by
@@ -98,9 +160,8 @@ example (x : Nat) (hx : x ∈ postToy ({0} : Set Nat)) :
     (by simpa [postToy] using hx)
 
 example :
-    MonotonePost (reachF initZero postToy) := by
-  change MonotonePost (reachF initZero (postAny toyLTS))
-  exact reachF_postAny_monotone (lts := toyLTS) (init := initZero)
+    MonotonePost (collectingToy.reachF initZero) := by
+  exact postAny_reachF_monotone (lts := toyLTS) (init := initZero)
 
 end InstancesLTSCollecting
 end Tests


### PR DESCRIPTION
## Summary
- introduce reusable collecting semantics interface under `AbsInterpLTS/Framework/Semantics/Collecting`
- move `CollectingStep`, `reachF`, and related monotonicity lemmas out of iteration scaffold
- keep `AbsInterpLTS/Framework/Iteration/Collecting.lean` focused on nat-indexed Kleene iteration laws
- rewire `AbsInterpLTS/Instances/LTS/Semantics/Collecting.lean` to use framework collecting semantics interface
- update framework/instance tests to use the new interface shape

## Validation
- `lake build`
- `lake test`

## Issues
- Refs: #20
- Context: #4 (follow-up work)