### PR TITLE
feat(sign): add 7-point sign baseline and LTS hook (#4)

### DIFF
--- a/AbsInterpLTS/Domains/Sign.lean
+++ b/AbsInterpLTS/Domains/Sign.lean
@@ -25,7 +25,7 @@ def gammaSign : Sign -> Set Int
   | .pos => { n : Int | 0 < n }
   | .nonpos => { n : Int | n < 0 ∨ n = 0 }
   | .nonneg => { n : Int | n = 0 ∨ 0 < n }
-  | .top => { n : Int | n < 0 ∨ n = 0 ∨ 0 < n }
+  | .top => (Set.univ : Set Int)
 
 /-- Domain order induced by concretization inclusion. -/
 def leSign (a b : Sign) : Prop :=
@@ -110,7 +110,7 @@ theorem negTransfer_sound {a : Sign} {n : Int} (hn : n ∈ gammaSign a) :
   | neg =>
       change n < 0 at hn
       change 0 < -n
-      exact (Int.neg_pos.mpr hn)
+      omega
   | zero =>
       change n = 0 at hn
       change -n = 0
@@ -122,19 +122,15 @@ theorem negTransfer_sound {a : Sign} {n : Int} (hn : n ∈ gammaSign a) :
   | nonpos =>
       change n < 0 ∨ n = 0 at hn
       change -n = 0 ∨ 0 < -n
-      rcases hn with hNeg | hZero
-      · exact Or.inr (Int.neg_pos.mpr hNeg)
-      · exact Or.inl (by omega)
+      omega
   | nonneg =>
       change n = 0 ∨ 0 < n at hn
       change -n < 0 ∨ -n = 0
-      rcases hn with hZero | hPos
-      · exact Or.inr (by omega)
-      · exact Or.inl (by omega)
-  | top =>
-      change n < 0 ∨ n = 0 ∨ 0 < n at hn
-      change -n < 0 ∨ -n = 0 ∨ 0 < -n
       omega
+  | top =>
+      change True at hn
+      change True
+      trivial
 
 end Domains
 end AbsInterpLTS

--- a/AbsInterpLTS/Domains/Sign.lean
+++ b/AbsInterpLTS/Domains/Sign.lean
@@ -34,13 +34,11 @@ def leSign (a b : Sign) : Prop :=
 instance : LE Sign where
   le := leSign
 
-theorem leSign_refl (a : Sign) : a ≤ a := by
-  intro n hn
-  exact hn
+theorem leSign_refl (a : Sign) : a ≤ a :=
+  fun _ hn => hn
 
-theorem leSign_trans {a b c : Sign} (hAB : a ≤ b) (hBC : b ≤ c) : a ≤ c := by
-  intro n hn
-  exact hBC (hAB hn)
+theorem leSign_trans {a b c : Sign} (hAB : a ≤ b) (hBC : b ≤ c) : a ≤ c :=
+  fun _ hn => hBC (hAB hn)
 
 theorem gammaSign_monotone_of_leSign {a b : Sign} (hAB : a ≤ b) :
     gammaSign a ⊆ gammaSign b :=

--- a/AbsInterpLTS/Domains/Sign.lean
+++ b/AbsInterpLTS/Domains/Sign.lean
@@ -3,19 +3,138 @@ import Cslib.Init
 namespace AbsInterpLTS
 namespace Domains
 
-/-- Placeholder sign domain interface. Detailed semantics are added in staged issues. -/
+/--
+Seven-point sign domain:
+`⊥`, singletons (`neg`, `zero`, `pos`), pair-wise joins (`nonpos`, `nonneg`), and `⊤`.
+-/
 inductive Sign where
   | bot
   | neg
   | zero
   | pos
+  | nonpos
+  | nonneg
   | top
   deriving DecidableEq, Repr
 
-/-- Concretization hook for sign domain (bootstrap version). -/
+/-- Concretization map from abstract signs to sets of integers. -/
 def gammaSign : Sign -> Set Int
   | .bot => ∅
-  | _ => Set.univ
+  | .neg => { n : Int | n < 0 }
+  | .zero => { n : Int | n = 0 }
+  | .pos => { n : Int | 0 < n }
+  | .nonpos => { n : Int | n < 0 ∨ n = 0 }
+  | .nonneg => { n : Int | n = 0 ∨ 0 < n }
+  | .top => { n : Int | n < 0 ∨ n = 0 ∨ 0 < n }
+
+/-- Domain order induced by concretization inclusion. -/
+def leSign (a b : Sign) : Prop :=
+  gammaSign a ⊆ gammaSign b
+
+instance : LE Sign where
+  le := leSign
+
+theorem leSign_refl (a : Sign) : a ≤ a := by
+  intro n hn
+  exact hn
+
+theorem leSign_trans {a b c : Sign} (hAB : a ≤ b) (hBC : b ≤ c) : a ≤ c := by
+  intro n hn
+  exact hBC (hAB hn)
+
+theorem gammaSign_monotone_of_leSign {a b : Sign} (hAB : a ≤ b) :
+    gammaSign a ⊆ gammaSign b :=
+  hAB
+
+private def hasNeg : Sign -> Bool
+  | .bot => false
+  | .neg => true
+  | .zero => false
+  | .pos => false
+  | .nonpos => true
+  | .nonneg => false
+  | .top => true
+
+private def hasZero : Sign -> Bool
+  | .bot => false
+  | .neg => false
+  | .zero => true
+  | .pos => false
+  | .nonpos => true
+  | .nonneg => true
+  | .top => true
+
+private def hasPos : Sign -> Bool
+  | .bot => false
+  | .neg => false
+  | .zero => false
+  | .pos => true
+  | .nonpos => false
+  | .nonneg => true
+  | .top => true
+
+private def signOfFlags (neg zero pos : Bool) : Sign :=
+  match neg, zero, pos with
+  | false, false, false => .bot
+  | true, false, false => .neg
+  | false, true, false => .zero
+  | false, false, true => .pos
+  | true, true, false => .nonpos
+  | false, true, true => .nonneg
+  | true, false, true => .top
+  | true, true, true => .top
+
+/-- Join on signs, with `{neg,pos}` normalized to `top`. -/
+def joinSign (a b : Sign) : Sign :=
+  signOfFlags
+    (hasNeg a || hasNeg b)
+    (hasZero a || hasZero b)
+    (hasPos a || hasPos b)
+
+/-- Baseline unary transfer shape: abstract negation. -/
+def negTransfer : Sign -> Sign
+  | .bot => .bot
+  | .neg => .pos
+  | .zero => .zero
+  | .pos => .neg
+  | .nonpos => .nonneg
+  | .nonneg => .nonpos
+  | .top => .top
+
+theorem negTransfer_sound {a : Sign} {n : Int} (hn : n ∈ gammaSign a) :
+    -n ∈ gammaSign (negTransfer a) := by
+  cases a with
+  | bot =>
+      change False at hn
+      exact False.elim hn
+  | neg =>
+      change n < 0 at hn
+      change 0 < -n
+      exact (Int.neg_pos.mpr hn)
+  | zero =>
+      change n = 0 at hn
+      change -n = 0
+      omega
+  | pos =>
+      change 0 < n at hn
+      change -n < 0
+      omega
+  | nonpos =>
+      change n < 0 ∨ n = 0 at hn
+      change -n = 0 ∨ 0 < -n
+      rcases hn with hNeg | hZero
+      · exact Or.inr (Int.neg_pos.mpr hNeg)
+      · exact Or.inl (by omega)
+  | nonneg =>
+      change n = 0 ∨ 0 < n at hn
+      change -n < 0 ∨ -n = 0
+      rcases hn with hZero | hPos
+      · exact Or.inr (by omega)
+      · exact Or.inl (by omega)
+  | top =>
+      change n < 0 ∨ n = 0 ∨ 0 < n at hn
+      change -n < 0 ∨ -n = 0 ∨ 0 < -n
+      omega
 
 end Domains
 end AbsInterpLTS

--- a/AbsInterpLTS/Instances/LTS/Analyses/Sign.lean
+++ b/AbsInterpLTS/Instances/LTS/Analyses/Sign.lean
@@ -21,10 +21,9 @@ abbrev SignGamma (State : Type u) := (State -> Int) -> Gamma Sign State
 
 /-- Lift `gammaSign` to concrete states using a readout `State -> Int`. -/
 def gammaSignState
-    {State : Type u}
-    (read : State -> Int) :
-    Gamma Sign State :=
-  fun a => { s : State | read s ∈ gammaSign a }
+    {State : Type u} :
+    SignGamma State :=
+  fun read a => { s : State | read s ∈ gammaSign a }
 
 /-- Label-indexed sign transfer family. -/
 abbrev SignTransfer (Label : Type v) := Label -> Sign -> Sign

--- a/AbsInterpLTS/Instances/LTS/Analyses/Sign.lean
+++ b/AbsInterpLTS/Instances/LTS/Analyses/Sign.lean
@@ -1,16 +1,81 @@
 import Cslib.Init
+import Cslib.Foundations.Semantics.LTS.Basic
 
 import AbsInterpLTS.Domains.Sign
+import AbsInterpLTS.Framework.Soundness
+import AbsInterpLTS.Instances.LTS.Semantics.Concrete
+import AbsInterpLTS.Instances.LTS.Instantiation.Interface
 
 namespace AbsInterpLTS
 namespace Instances
 namespace LTS
 namespace Analyses
 
-/-
-Staged placeholder: LTS + Sign domain analysis instance will be implemented in a
-dedicated issue.
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Domains
+
+universe u v
+
+/-- State concretization for the sign domain via an integer observation function. -/
+abbrev SignGamma (State : Type u) := (State -> Int) -> Gamma Sign State
+
+/-- Lift `gammaSign` to concrete states using a readout `State -> Int`. -/
+def gammaSignState
+    {State : Type u}
+    (read : State -> Int) :
+    Gamma Sign State :=
+  fun a => { s : State | read s ∈ gammaSign a }
+
+/-- Label-indexed sign transfer family. -/
+abbrev SignTransfer (Label : Type v) := Label -> Sign -> Sign
+
+/--
+Local one-step sign soundness condition over LTS transitions.
+
+This can be discharged by language-specific transition/transfer lemmas, then
+lifted to framework `SoundStep`.
 -/
+def SignStepSound
+    {State : Type u}
+    {Label : Type v}
+    (lts : Cslib.LTS State Label)
+    (read : State -> Int)
+    (transfer : SignTransfer Label) : Prop :=
+  ∀ (label : Label) (a : Sign) (s s' : State),
+    s ∈ gammaSignState read a ->
+    lts.Tr s label s' ->
+    s' ∈ gammaSignState read (transfer label a)
+
+/-- Bridge from local sign-transition soundness to framework `SoundStep`. -/
+theorem soundStep_postStep_sign_of_stepSound
+    {State : Type u}
+    {Label : Type v}
+    (lts : Cslib.LTS State Label)
+    (read : State -> Int)
+    (transfer : SignTransfer Label)
+    (hStep : SignStepSound lts read transfer) :
+    SoundStep (postStep lts) (gammaSignState read) transfer := by
+  intro label a s' hs'
+  rcases (Cslib.LTS.mem_setImage
+    (lts := lts)
+    (S := gammaSignState read a)
+    (μ := label)
+    (s' := s')).1 (by simpa [postStep] using hs') with ⟨s, hsMem, htr⟩
+  exact hStep label a s s' hsMem htr
+
+/-- Build an LTS abstraction from local sign-step soundness obligations. -/
+def signAbstractionOfStepSound
+    {State : Type u}
+    {Label : Type v}
+    (lts : Cslib.LTS State Label)
+    (read : State -> Int)
+    (transfer : SignTransfer Label)
+    (hStep : SignStepSound lts read transfer) :
+    LTSAbstraction State Label Sign where
+  lts := lts
+  gamma := gammaSignState read
+  transfer := transfer
+  soundStep := soundStep_postStep_sign_of_stepSound lts read transfer hStep
 
 end Analyses
 end LTS

--- a/Tests.lean
+++ b/Tests.lean
@@ -1,6 +1,8 @@
 import Cslib.Init
 
 import AbsInterpLTS
+import Tests.Domains.Sign
 import Tests.Instances.LTS.Smoke
 import Tests.Instances.LTS.Collecting
+import Tests.Instances.LTS.SignHook
 import Tests.Framework.Iteration.NatIter

--- a/Tests/Domains/Sign.lean
+++ b/Tests/Domains/Sign.lean
@@ -1,0 +1,54 @@
+import Cslib.Init
+
+import AbsInterpLTS
+
+namespace Tests
+namespace DomainsSign
+
+open AbsInterpLTS
+open AbsInterpLTS.Domains
+
+example : (-3 : Int) ∈ gammaSign Sign.neg := by
+  simp [gammaSign]
+
+example : (0 : Int) ∈ gammaSign Sign.zero := by
+  simp [gammaSign]
+
+example : (5 : Int) ∈ gammaSign Sign.pos := by
+  simp [gammaSign]
+
+example : (4 : Int) ∉ gammaSign Sign.nonpos := by
+  simp [gammaSign]
+
+example : Sign.neg ≤ Sign.nonpos := by
+  intro n hn
+  change n < 0 at hn
+  change n < 0 ∨ n = 0
+  exact Or.inl hn
+
+example : Sign.zero ≤ Sign.nonneg := by
+  intro n hn
+  simp [gammaSign] at hn ⊢
+  omega
+
+example (a : Sign) : a ≤ a := by
+  exact leSign_refl a
+
+example (a b c : Sign) (hAB : a ≤ b) (hBC : b ≤ c) : a ≤ c := by
+  exact leSign_trans hAB hBC
+
+example : joinSign Sign.neg Sign.zero = Sign.nonpos := by
+  rfl
+
+example : joinSign Sign.neg Sign.pos = Sign.top := by
+  rfl
+
+example : negTransfer Sign.nonpos = Sign.nonneg := by
+  rfl
+
+example (n : Int) (hn : n ∈ gammaSign Sign.nonneg) :
+    -n ∈ gammaSign (negTransfer Sign.nonneg) := by
+  exact negTransfer_sound hn
+
+end DomainsSign
+end Tests

--- a/Tests/Instances/LTS/SignHook.lean
+++ b/Tests/Instances/LTS/SignHook.lean
@@ -1,0 +1,51 @@
+import Cslib.Init
+
+import AbsInterpLTS
+
+namespace Tests
+namespace InstancesLTSSignHook
+
+open AbsInterpLTS
+open AbsInterpLTS.Domains
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Instances.LTS
+open AbsInterpLTS.Instances.LTS.Analyses
+
+def toyLTS : Cslib.LTS Int Bool where
+  Tr s label s' := (label = false ∧ s' = s) ∨ (label = true ∧ s' = 0)
+
+def readId : Int -> Int := fun s => s
+
+def transferToy : Bool -> Sign -> Sign
+  | false, a => a
+  | true, _ => .zero
+
+theorem stepSoundToy :
+    SignStepSound toyLTS readId transferToy := by
+  intro label a s s' hs htr
+  rcases htr with hKeep | hZero
+  · rcases hKeep with ⟨hLabel, hEq⟩
+    subst hLabel
+    subst hEq
+    simpa [gammaSignState, readId, transferToy] using hs
+  · rcases hZero with ⟨hLabel, hEq⟩
+    subst hLabel
+    subst hEq
+    simp [gammaSignState, readId, transferToy, gammaSign]
+
+example :
+    SoundStep (postStep toyLTS) (gammaSignState readId) transferToy := by
+  exact soundStep_postStep_sign_of_stepSound toyLTS readId transferToy stepSoundToy
+
+def toySignAbstraction : LTSAbstraction Int Bool Sign :=
+  signAbstractionOfStepSound toyLTS readId transferToy stepSoundToy
+
+example :
+    SoundTrace
+      (liftTracePost (postStep toyLTS))
+      (gammaSignState readId)
+      (liftTracePostSharp transferToy) := by
+  exact toySignAbstraction.soundTraceLifted
+
+end InstancesLTSSignHook
+end Tests


### PR DESCRIPTION
## Summary

- implement a 7-point sign domain baseline in `AbsInterpLTS/Domains/Sign.lean`
- add concretization/order/join/negation-transfer core definitions and soundness-facing lemmas
- implement LTS-facing sign analysis hooks in `AbsInterpLTS/Instances/LTS/Analyses/Sign.lean`
- add bridge theorem from local step obligations to framework `SoundStep`
- add tests for domain behavior and LTS hook soundness wiring

## Linked issue

- Closes #4

## Scope

- In scope:
  - sign domain baseline
  - LTS analysis hook + `SoundStep` bridge
  - tests and test wiring
- Out of scope:
  - end-to-end sign analysis execution pipeline (#6)
  - widening/narrowing policy work (#3)

## Validation

- [x] `lake build`
- [x] `lake build Tests`
- [x] `lake test`

## Checklist

- [x] Branch name follows `issue-<n>-<short-slug>`
- [x] PR title uses Conventional format
- [x] Changes are limited to this issue scope
- [x] Tests/docs updated for behavior changes
