### PR TITLE
feat(interval): add baseline domain and LTS hook (#5)

### DIFF
--- a/AbsInterpLTS/Domains/Interval.lean
+++ b/AbsInterpLTS/Domains/Interval.lean
@@ -54,19 +54,21 @@ theorem mem_gammaInterval_mk_iff (lo hi n : Int) :
   by_cases h : lo <= hi
   · constructor
     · intro hn
-      simpa [mk, h, gammaInterval] using hn
+      simpa [mk, gammaInterval, h] using hn
     · intro hRange
-      simpa [mk, h, gammaInterval] using hRange
-  · constructor
+      simpa [mk, gammaInterval, h] using hRange
+  · have hRangeFalse : ¬ (lo <= n ∧ n <= hi) := by
+      intro hRange
+      omega
+    constructor
     · intro hn
       have : n ∈ (∅ : Set Int) := by
-        simpa [mk, h, gammaInterval] using hn
+        simpa [mk, gammaInterval, h] using hn
       have : False := by
         simpa using this
       exact False.elim this
     · intro hRange
-      have hLe : lo <= hi := by omega
-      exact False.elim (h hLe)
+      exact False.elim (hRangeFalse hRange)
 
 theorem gammaInterval_mk (lo hi : Int) :
     gammaInterval (mk lo hi) = { n : Int | lo <= n ∧ n <= hi } := by
@@ -110,16 +112,13 @@ theorem negIntervalTransfer_sound {a : Interval} {n : Int} (hn : n ∈ gammaInte
       change True
       trivial
   | range lo hi =>
-      by_cases hNorm : lo <= hi
-      · rcases hn with ⟨hLo, hHi⟩
-        have hNegNorm : -hi <= -lo := by omega
-        have hLow : -hi <= -n := by omega
-        have hHigh : -n <= -lo := by omega
-        simp [negIntervalTransfer, normalize, mk, hNorm, hNegNorm, gammaInterval]
-        exact ⟨hLow, hHigh⟩
-      · rcases hn with ⟨hLo, hHi⟩
-        have : False := by omega
-        exact False.elim this
+      rcases hn with ⟨hLo, hHi⟩
+      have hNorm : lo <= hi := by omega
+      have hNegNorm : -hi <= -lo := by omega
+      have hLow : -hi <= -n := by omega
+      have hHigh : -n <= -lo := by omega
+      simp [negIntervalTransfer, normalize, mk, hNorm, hNegNorm, gammaInterval]
+      exact ⟨hLow, hHigh⟩
 
 end Domains
 end AbsInterpLTS

--- a/AbsInterpLTS/Domains/Interval.lean
+++ b/AbsInterpLTS/Domains/Interval.lean
@@ -3,17 +3,123 @@ import Cslib.Init
 namespace AbsInterpLTS
 namespace Domains
 
-/-- Placeholder interval domain interface. Detailed semantics are added in staged issues. -/
+/--
+Baseline interval domain:
+`⊥`, bounded interval (`range lo hi`), and `⊤`.
+-/
 inductive Interval where
   | bot
   | range (lo hi : Int)
   | top
   deriving DecidableEq, Repr
 
-/-- Concretization hook for interval domain (bootstrap version). -/
+/--
+Public smart constructor.
+Invalid bounds (`lo > hi`) are normalized to `⊥`.
+-/
+def mk (lo hi : Int) : Interval :=
+  if lo <= hi then .range lo hi else .bot
+
+/-- Normalize intervals so invalid ranges collapse to `⊥`. -/
+def normalize : Interval -> Interval
+  | .bot => .bot
+  | .top => .top
+  | .range lo hi => mk lo hi
+
+/-- Concretization map from abstract intervals to sets of integers. -/
 def gammaInterval : Interval -> Set Int
   | .bot => ∅
-  | _ => Set.univ
+  | .range lo hi => { n : Int | lo <= n ∧ n <= hi }
+  | .top => (Set.univ : Set Int)
+
+/-- Domain order induced by concretization inclusion. -/
+def leInterval (a b : Interval) : Prop :=
+  gammaInterval a ⊆ gammaInterval b
+
+instance : LE Interval where
+  le := leInterval
+
+theorem leInterval_refl (a : Interval) : a <= a :=
+  fun _ hn => hn
+
+theorem leInterval_trans {a b c : Interval} (hAB : a <= b) (hBC : b <= c) : a <= c :=
+  fun _ hn => hBC (hAB hn)
+
+theorem gammaInterval_monotone_of_leInterval {a b : Interval} (hAB : a <= b) :
+    gammaInterval a ⊆ gammaInterval b :=
+  hAB
+
+theorem mem_gammaInterval_mk_iff (lo hi n : Int) :
+    n ∈ gammaInterval (mk lo hi) ↔ lo <= n ∧ n <= hi := by
+  by_cases h : lo <= hi
+  · constructor
+    · intro hn
+      simpa [mk, h, gammaInterval] using hn
+    · intro hRange
+      simpa [mk, h, gammaInterval] using hRange
+  · constructor
+    · intro hn
+      have : n ∈ (∅ : Set Int) := by
+        simpa [mk, h, gammaInterval] using hn
+      have : False := by
+        simpa using this
+      exact False.elim this
+    · intro hRange
+      have hLe : lo <= hi := by omega
+      exact False.elim (h hLe)
+
+theorem gammaInterval_mk (lo hi : Int) :
+    gammaInterval (mk lo hi) = { n : Int | lo <= n ∧ n <= hi } := by
+  apply Set.ext
+  intro n
+  simpa using mem_gammaInterval_mk_iff lo hi n
+
+/-- Join on normalized intervals. -/
+def joinInterval (a b : Interval) : Interval :=
+  match normalize a, normalize b with
+  | .bot, b' => b'
+  | a', .bot => a'
+  | .top, _ => .top
+  | _, .top => .top
+  | .range lo1 hi1, .range lo2 hi2 => mk (min lo1 lo2) (max hi1 hi2)
+
+/-- Meet on normalized intervals. -/
+def meetInterval (a b : Interval) : Interval :=
+  match normalize a, normalize b with
+  | .bot, _ => .bot
+  | _, .bot => .bot
+  | .top, b' => b'
+  | a', .top => a'
+  | .range lo1 hi1, .range lo2 hi2 => mk (max lo1 lo2) (min hi1 hi2)
+
+/-- Baseline unary transfer shape: abstract negation. -/
+def negIntervalTransfer (a : Interval) : Interval :=
+  match normalize a with
+  | .bot => .bot
+  | .top => .top
+  | .range lo hi => mk (-hi) (-lo)
+
+theorem negIntervalTransfer_sound {a : Interval} {n : Int} (hn : n ∈ gammaInterval a) :
+    -n ∈ gammaInterval (negIntervalTransfer a) := by
+  cases a with
+  | bot =>
+      change False at hn
+      exact False.elim hn
+  | top =>
+      change True at hn
+      change True
+      trivial
+  | range lo hi =>
+      by_cases hNorm : lo <= hi
+      · rcases hn with ⟨hLo, hHi⟩
+        have hNegNorm : -hi <= -lo := by omega
+        have hLow : -hi <= -n := by omega
+        have hHigh : -n <= -lo := by omega
+        simp [negIntervalTransfer, normalize, mk, hNorm, hNegNorm, gammaInterval]
+        exact ⟨hLow, hHigh⟩
+      · rcases hn with ⟨hLo, hHi⟩
+        have : False := by omega
+        exact False.elim this
 
 end Domains
 end AbsInterpLTS

--- a/AbsInterpLTS/Domains/Interval.lean
+++ b/AbsInterpLTS/Domains/Interval.lean
@@ -18,7 +18,7 @@ Public smart constructor.
 Invalid bounds (`lo > hi`) are normalized to `⊥`.
 -/
 def mk (lo hi : Int) : Interval :=
-  if lo <= hi then .range lo hi else .bot
+  if lo ≤ hi then .range lo hi else .bot
 
 /-- Normalize intervals so invalid ranges collapse to `⊥`. -/
 def normalize : Interval -> Interval
@@ -29,7 +29,7 @@ def normalize : Interval -> Interval
 /-- Concretization map from abstract intervals to sets of integers. -/
 def gammaInterval : Interval -> Set Int
   | .bot => ∅
-  | .range lo hi => { n : Int | lo <= n ∧ n <= hi }
+  | .range lo hi => { n : Int | lo ≤ n ∧ n ≤ hi }
   | .top => (Set.univ : Set Int)
 
 /-- Domain order induced by concretization inclusion. -/
@@ -39,25 +39,25 @@ def leInterval (a b : Interval) : Prop :=
 instance : LE Interval where
   le := leInterval
 
-theorem leInterval_refl (a : Interval) : a <= a :=
+theorem leInterval_refl (a : Interval) : a ≤ a :=
   fun _ hn => hn
 
-theorem leInterval_trans {a b c : Interval} (hAB : a <= b) (hBC : b <= c) : a <= c :=
+theorem leInterval_trans {a b c : Interval} (hAB : a ≤ b) (hBC : b ≤ c) : a ≤ c :=
   fun _ hn => hBC (hAB hn)
 
-theorem gammaInterval_monotone_of_leInterval {a b : Interval} (hAB : a <= b) :
+theorem gammaInterval_monotone_of_leInterval {a b : Interval} (hAB : a ≤ b) :
     gammaInterval a ⊆ gammaInterval b :=
   hAB
 
 theorem mem_gammaInterval_mk_iff (lo hi n : Int) :
-    n ∈ gammaInterval (mk lo hi) ↔ lo <= n ∧ n <= hi := by
-  by_cases h : lo <= hi
+    n ∈ gammaInterval (mk lo hi) ↔ lo ≤ n ∧ n ≤ hi := by
+  by_cases h : lo ≤ hi
   · constructor
     · intro hn
       simpa [mk, gammaInterval, h] using hn
     · intro hRange
       simpa [mk, gammaInterval, h] using hRange
-  · have hRangeFalse : ¬ (lo <= n ∧ n <= hi) := by
+  · have hRangeFalse : ¬ (lo ≤ n ∧ n ≤ hi) := by
       intro hRange
       omega
     constructor
@@ -71,7 +71,7 @@ theorem mem_gammaInterval_mk_iff (lo hi n : Int) :
       exact False.elim (hRangeFalse hRange)
 
 theorem gammaInterval_mk (lo hi : Int) :
-    gammaInterval (mk lo hi) = { n : Int | lo <= n ∧ n <= hi } := by
+    gammaInterval (mk lo hi) = { n : Int | lo ≤ n ∧ n ≤ hi } := by
   apply Set.ext
   intro n
   simpa using mem_gammaInterval_mk_iff lo hi n
@@ -113,10 +113,10 @@ theorem negIntervalTransfer_sound {a : Interval} {n : Int} (hn : n ∈ gammaInte
       trivial
   | range lo hi =>
       rcases hn with ⟨hLo, hHi⟩
-      have hNorm : lo <= hi := by omega
-      have hNegNorm : -hi <= -lo := by omega
-      have hLow : -hi <= -n := by omega
-      have hHigh : -n <= -lo := by omega
+      have hNorm : lo ≤ hi := by omega
+      have hNegNorm : -hi ≤ -lo := by omega
+      have hLow : -hi ≤ -n := by omega
+      have hHigh : -n ≤ -lo := by omega
       simp [negIntervalTransfer, normalize, mk, hNorm, hNegNorm, gammaInterval]
       exact ⟨hLow, hHigh⟩
 

--- a/AbsInterpLTS/Instances/LTS/Analyses/Interval.lean
+++ b/AbsInterpLTS/Instances/LTS/Analyses/Interval.lean
@@ -1,16 +1,80 @@
 import Cslib.Init
+import Cslib.Foundations.Semantics.LTS.Basic
 
 import AbsInterpLTS.Domains.Interval
+import AbsInterpLTS.Framework.Soundness
+import AbsInterpLTS.Instances.LTS.Semantics.Concrete
+import AbsInterpLTS.Instances.LTS.Instantiation.Interface
 
 namespace AbsInterpLTS
 namespace Instances
 namespace LTS
 namespace Analyses
 
-/-
-Staged placeholder: LTS + Interval domain analysis instance will be implemented in a
-dedicated issue.
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Domains
+
+universe u v
+
+/-- State concretization for the interval domain via an integer observation function. -/
+abbrev IntervalGamma (State : Type u) := (State -> Int) -> Gamma Interval State
+
+/-- Lift `gammaInterval` to concrete states using a readout `State -> Int`. -/
+def gammaIntervalState
+    {State : Type u} :
+    IntervalGamma State :=
+  fun read a => { s : State | read s ∈ gammaInterval a }
+
+/-- Label-indexed interval transfer family. -/
+abbrev IntervalTransfer (Label : Type v) := Label -> Interval -> Interval
+
+/--
+Local one-step interval soundness condition over LTS transitions.
+
+This can be discharged by language-specific transition/transfer lemmas, then
+lifted to framework `SoundStep`.
 -/
+def IntervalStepSound
+    {State : Type u}
+    {Label : Type v}
+    (lts : Cslib.LTS State Label)
+    (read : State -> Int)
+    (transfer : IntervalTransfer Label) : Prop :=
+  ∀ (label : Label) (a : Interval) (s s' : State),
+    s ∈ gammaIntervalState read a ->
+    lts.Tr s label s' ->
+    s' ∈ gammaIntervalState read (transfer label a)
+
+/-- Bridge from local interval-transition soundness to framework `SoundStep`. -/
+theorem soundStep_postStep_interval_of_stepSound
+    {State : Type u}
+    {Label : Type v}
+    (lts : Cslib.LTS State Label)
+    (read : State -> Int)
+    (transfer : IntervalTransfer Label)
+    (hStep : IntervalStepSound lts read transfer) :
+    SoundStep (postStep lts) (gammaIntervalState read) transfer := by
+  intro label a s' hs'
+  rcases (Cslib.LTS.mem_setImage
+    (lts := lts)
+    (S := gammaIntervalState read a)
+    (μ := label)
+    (s' := s')).1 (by simpa [postStep] using hs') with ⟨s, hsMem, htr⟩
+  exact hStep label a s s' hsMem htr
+
+/-- Build an LTS abstraction from local interval-step soundness obligations. -/
+def intervalAbstractionOfStepSound
+    {State : Type u}
+    {Label : Type v}
+    (lts : Cslib.LTS State Label)
+    (read : State -> Int)
+    (transfer : IntervalTransfer Label)
+    (hStep : IntervalStepSound lts read transfer) :
+    LTSAbstraction State Label Interval where
+  lts := lts
+  gamma := gammaIntervalState read
+  transfer := transfer
+  soundStep := soundStep_postStep_interval_of_stepSound lts read transfer hStep
 
 end Analyses
 end LTS

--- a/Tests.lean
+++ b/Tests.lean
@@ -1,8 +1,10 @@
 import Cslib.Init
 
 import AbsInterpLTS
+import Tests.Domains.Interval
 import Tests.Domains.Sign
 import Tests.Instances.LTS.Smoke
 import Tests.Instances.LTS.Collecting
+import Tests.Instances.LTS.IntervalHook
 import Tests.Instances.LTS.SignHook
 import Tests.Framework.Iteration.NatIter

--- a/Tests/Domains/Interval.lean
+++ b/Tests/Domains/Interval.lean
@@ -1,0 +1,61 @@
+import Cslib.Init
+
+import AbsInterpLTS
+
+namespace Tests
+namespace DomainsInterval
+
+open AbsInterpLTS
+open AbsInterpLTS.Domains
+
+example : (2 : Int) ∈ gammaInterval (mk 1 3) := by
+  simp [gammaInterval, mk]
+
+example : (4 : Int) ∉ gammaInterval (mk 1 3) := by
+  simp [gammaInterval, mk]
+
+example : mk 3 1 = Interval.bot := by
+  simp [mk]
+
+example : normalize (Interval.range 3 1) = Interval.bot := by
+  simp [normalize, mk]
+
+example : (0 : Int) ∈ gammaInterval Interval.top := by
+  simp [gammaInterval]
+
+example : Interval.range 1 2 <= Interval.range 0 3 := by
+  intro n hn
+  rcases hn with ⟨hLo, hHi⟩
+  exact ⟨by omega, by omega⟩
+
+example (a : Interval) : a <= a := by
+  exact leInterval_refl a
+
+example (a b c : Interval) (hAB : a <= b) (hBC : b <= c) : a <= c := by
+  exact leInterval_trans hAB hBC
+
+example (lo hi n : Int) :
+    n ∈ gammaInterval (mk lo hi) ↔ lo <= n ∧ n <= hi := by
+  simpa using mem_gammaInterval_mk_iff lo hi n
+
+example : joinInterval (mk 1 2) (mk 4 5) = mk 1 5 := by
+  simp [joinInterval, normalize, mk]
+
+example : joinInterval (Interval.range 3 1) (mk 0 0) = mk 0 0 := by
+  simp [joinInterval, normalize, mk]
+
+example : meetInterval (mk 1 4) (mk 3 6) = mk 3 4 := by
+  simp [meetInterval, normalize, mk]
+
+example : meetInterval (mk 1 2) (mk 4 5) = Interval.bot := by
+  simp [meetInterval, normalize, mk]
+
+example : negIntervalTransfer (mk 1 4) = mk (-4) (-1) := by
+  simp [negIntervalTransfer, normalize, mk]
+
+example (n : Int) (hn : n ∈ gammaInterval (mk (-2) 5)) :
+    -n ∈ gammaInterval (negIntervalTransfer (mk (-2) 5)) := by
+  exact negIntervalTransfer_sound hn
+
+end DomainsInterval
+end Tests

--- a/Tests/Domains/Interval.lean
+++ b/Tests/Domains/Interval.lean
@@ -23,19 +23,19 @@ example : normalize (Interval.range 3 1) = Interval.bot := by
 example : (0 : Int) ∈ gammaInterval Interval.top := by
   simp [gammaInterval]
 
-example : Interval.range 1 2 <= Interval.range 0 3 := by
+example : Interval.range 1 2 ≤ Interval.range 0 3 := by
   intro n hn
   rcases hn with ⟨hLo, hHi⟩
   exact ⟨by omega, by omega⟩
 
-example (a : Interval) : a <= a := by
+example (a : Interval) : a ≤ a := by
   exact leInterval_refl a
 
-example (a b c : Interval) (hAB : a <= b) (hBC : b <= c) : a <= c := by
+example (a b c : Interval) (hAB : a ≤ b) (hBC : b ≤ c) : a ≤ c := by
   exact leInterval_trans hAB hBC
 
 example (lo hi n : Int) :
-    n ∈ gammaInterval (mk lo hi) ↔ lo <= n ∧ n <= hi := by
+    n ∈ gammaInterval (mk lo hi) ↔ lo ≤ n ∧ n ≤ hi := by
   simpa using mem_gammaInterval_mk_iff lo hi n
 
 example : joinInterval (mk 1 2) (mk 4 5) = mk 1 5 := by

--- a/Tests/Instances/LTS/IntervalHook.lean
+++ b/Tests/Instances/LTS/IntervalHook.lean
@@ -1,0 +1,51 @@
+import Cslib.Init
+
+import AbsInterpLTS
+
+namespace Tests
+namespace InstancesLTSIntervalHook
+
+open AbsInterpLTS
+open AbsInterpLTS.Domains
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Instances.LTS
+open AbsInterpLTS.Instances.LTS.Analyses
+
+def toyLTS : Cslib.LTS Int Bool where
+  Tr s label s' := (label = false ∧ s' = s) ∨ (label = true ∧ s' = 0)
+
+def readId : Int -> Int := fun s => s
+
+def transferToy : Bool -> Interval -> Interval
+  | false, a => a
+  | true, _ => mk 0 0
+
+theorem stepSoundToy :
+    IntervalStepSound toyLTS readId transferToy := by
+  intro label a s s' hs htr
+  rcases htr with hKeep | hZero
+  · rcases hKeep with ⟨hLabel, hEq⟩
+    subst hLabel
+    subst hEq
+    simpa [gammaIntervalState, readId, transferToy] using hs
+  · rcases hZero with ⟨hLabel, hEq⟩
+    subst hLabel
+    subst hEq
+    simp [gammaIntervalState, readId, transferToy, gammaInterval, mk]
+
+example :
+    SoundStep (postStep toyLTS) (gammaIntervalState readId) transferToy := by
+  exact soundStep_postStep_interval_of_stepSound toyLTS readId transferToy stepSoundToy
+
+def toyIntervalAbstraction : LTSAbstraction Int Bool Interval :=
+  intervalAbstractionOfStepSound toyLTS readId transferToy stepSoundToy
+
+example :
+    SoundTrace
+      (liftTracePost (postStep toyLTS))
+      (gammaIntervalState readId)
+      (liftTracePostSharp transferToy) := by
+  exact toyIntervalAbstraction.soundTraceLifted
+
+end InstancesLTSIntervalHook
+end Tests


### PR DESCRIPTION
## Summary

- implement interval baseline domain in `AbsInterpLTS/Domains/Interval.lean`
- add LTS interval analysis hook in `AbsInterpLTS/Instances/LTS/Analyses/Interval.lean`
- add domain/hook tests and wire them into `Tests.lean`

## Linked issue

- Closes #5

## Scope

- In scope:
  - `Interval` smart constructor/normalization/concretization/order
  - `joinInterval`/`meetInterval` and `negIntervalTransfer` soundness baseline
  - LTS bridge (`IntervalStepSound` -> `SoundStep`) and abstraction constructor
  - test coverage for domain behavior and LTS hook compatibility
- Out of scope:
  - interval arithmetic transfer (`add/sub/mul`)
  - widening/narrowing policy implementation
  - end-to-end interval analysis workflow (`#7`)

## Validation

- [x] `lake build`
- [x] `lake build Tests`
- [x] `lake test`

## Checklist

- [x] Branch name follows `issue-<n>-<short-slug>`
- [x] PR title uses Conventional format
- [x] Changes are limited to this issue scope
- [x] Tests/docs updated for behavior changes
