### PR TITLE
refactor(semantics): remove PostHom/OrderHom concrete layer (#24)

### DIFF
--- a/AbsInterpLTS/Framework/Semantics/Concrete/Defs.lean
+++ b/AbsInterpLTS/Framework/Semantics/Concrete/Defs.lean
@@ -1,6 +1,5 @@
 import Cslib.Init
 import Mathlib.Data.Set.Lattice
-import Mathlib.Order.Hom.Basic
 
 import AbsInterpLTS.Framework.Semantics.TraceLift
 
@@ -12,8 +11,7 @@ universe u v
 /-!
 # Concrete Semantic Transformers
 
-This file defines concrete transformers on `Set State`, monotonicity predicates,
-and `OrderHom` encodings.
+This file defines concrete transformers on `Set State` and monotonicity predicates.
 
 Trace lifting is obtained via the generic combinator `liftTrace`.
 -/
@@ -36,44 +34,6 @@ def composePost
 
 end Basic
 
-section Hom
-
-/-- Order-hom encoding of concrete semantic transformers. -/
-abbrev PostHom (State : Type u) := OrderHom (Set State) (Set State)
-
-/-- Build an order-hom from a monotone concrete transformer. -/
-def Post.toHom
-    {State : Type u}
-    (post : Post State)
-    (hMono : MonotonePost post) :
-    PostHom State where
-  toFun := post
-  monotone' := by
-    intro s t hSubset
-    exact hMono hSubset
-
-/-- Forget the order-hom structure and view it as a plain transformer. -/
-def PostHom.toPost
-    {State : Type u}
-    (post : PostHom State) :
-    Post State :=
-  post.toFun
-
-/-- Composition of order-hom transformers. -/
-def composePostHom
-    {State : Type u}
-    (post1 post2 : PostHom State) :
-    PostHom State :=
-  OrderHom.comp post2 post1
-
-/-- Label-indexed concrete transformers represented as order homomorphisms. -/
-abbrev StepPostHom (State : Type u) (Label : Type v) := Label -> PostHom State
-
-/-- Trace-indexed concrete transformers represented as order homomorphisms. -/
-abbrev TracePostHom (State : Type u) (Label : Type v) := List Label -> PostHom State
-
-end Hom
-
 section Trace
 
 /--
@@ -86,16 +46,6 @@ def liftTracePost
     (stepPost : Label -> Post State) :
     List Label -> Post State :=
   liftTrace composePost (fun states => states) stepPost
-
-/--
-Lift a one-step order-hom family to trace transformers by composition.
--/
-def liftTracePostHom
-    {State : Type u}
-    {Label : Type v}
-    (stepPost : StepPostHom State Label) :
-    TracePostHom State Label :=
-  liftTrace composePostHom OrderHom.id stepPost
 
 end Trace
 

--- a/AbsInterpLTS/Framework/Semantics/Concrete/Lemmas.lean
+++ b/AbsInterpLTS/Framework/Semantics/Concrete/Lemmas.lean
@@ -28,24 +28,6 @@ theorem MonotonePost.compose
 
 end Basic
 
-section Hom
-
-/-- Any `PostHom` is monotone as a plain concrete transformer. -/
-theorem MonotonePost.ofPostHom
-    {State : Type u}
-    (post : PostHom State) :
-    MonotonePost post.toFun := by
-  intro s t hSubset
-  exact post.monotone' hSubset
-
-@[simp] theorem composePostHom_toPost
-    {State : Type u}
-    (post1 post2 : PostHom State) :
-    (composePostHom post1 post2).toPost = composePost post1.toPost post2.toPost :=
-  rfl
-
-end Hom
-
 section Trace
 
 private theorem composePost_assoc
@@ -110,73 +92,24 @@ is one concrete step followed by the lifted remainder:
       (fun states : Set State => states)
   simpa [liftTracePost, liftTrace, List.foldl] using hacc
 
-private theorem foldl_post_eq_foldl_postHom_of_monotone
-    {State : Type u}
-    {Label : Type v}
-    {stepPost : Label -> Post State}
-    (hStepMono : ∀ label : Label, MonotonePost (stepPost label)) :
-    ∀ (labels : List Label) (acc : Post State) (accHom : PostHom State),
-      acc = accHom.toPost ->
-      List.foldl (fun current label => composePost current (stepPost label)) acc labels =
-        (List.foldl
-          (fun current label => composePostHom current ((stepPost label).toHom (hStepMono label)))
-          accHom
-          labels).toPost
-  | [], acc, accHom, hAcc => by
-      simpa using hAcc
-  | label :: labels, acc, accHom, hAcc => by
-      have hAcc' :
-          composePost acc (stepPost label) =
-            (composePostHom accHom ((stepPost label).toHom (hStepMono label))).toPost := by
-        ext states
-        simp [composePost, composePostHom, PostHom.toPost, Post.toHom, hAcc, OrderHom.comp]
-      simpa [List.foldl] using
-        (foldl_post_eq_foldl_postHom_of_monotone
-          (hStepMono := hStepMono)
-          labels
-          (composePost acc (stepPost label))
-          (composePostHom accHom ((stepPost label).toHom (hStepMono label)))
-          hAcc')
-
-theorem liftTracePost_eq_liftTracePostHom_of_pointwise_monotone
-    {State : Type u}
-    {Label : Type v}
-    {stepPost : Label -> Post State}
-    (hStepMono : ∀ label : Label, MonotonePost (stepPost label)) :
-    liftTracePost stepPost =
-      fun labels =>
-        (liftTracePostHom
-          (fun label => (stepPost label).toHom (hStepMono label))
-          labels).toPost := by
-  funext labels
-  simpa [liftTracePost, liftTracePostHom] using
-    (foldl_post_eq_foldl_postHom_of_monotone
-      (hStepMono := hStepMono)
-      labels
-      (fun states => states)
-      OrderHom.id
-      rfl)
-
-theorem liftTracePost_monotone_of_postHom
-    {State : Type u}
-    {Label : Type v}
-    {stepPost : StepPostHom State Label} :
-    ∀ labels : List Label, MonotonePost (fun states => (liftTracePostHom stepPost labels).toPost states) := by
-  intro labels
-  exact MonotonePost.ofPostHom (liftTracePostHom stepPost labels)
-
 theorem liftTracePost_monotone_of_pointwise
     {State : Type u}
     {Label : Type v}
     {stepPost : Label -> Post State}
     (hStepMono : ∀ label : Label, MonotonePost (stepPost label)) :
     ∀ labels : List Label, MonotonePost (liftTracePost stepPost labels) := by
-  let stepPostHom : StepPostHom State Label :=
-    fun label => (stepPost label).toHom (hStepMono label)
-  have hEq :
-      liftTracePost stepPost = fun labels => (liftTracePostHom stepPostHom labels).toPost :=
-    liftTracePost_eq_liftTracePostHom_of_pointwise_monotone hStepMono
-  simpa [hEq] using (liftTracePost_monotone_of_postHom (stepPost := stepPostHom))
+  intro labels
+  induction labels with
+  | nil =>
+      intro s t hSubset
+      simpa [liftTracePost_nil] using hSubset
+  | cons label labels ih =>
+      intro s t hSubset
+      simpa [liftTracePost_cons] using
+        (MonotonePost.compose
+          (h1 := hStepMono label)
+          (h2 := ih)
+          hSubset)
 
 end Trace
 


### PR DESCRIPTION
## Summary
- remove `PostHom`/`OrderHom`-based concrete semantics layer from framework
- keep concrete semantics on the simpler `Post + MonotonePost` path
- keep `liftTracePost_monotone_of_pointwise` via direct `labels` induction + `MonotonePost.compose`

## Linked issue
- Closes #24

## Backup
- branch: `backup/posthom-orderhom-pre-removal`
- tag: `backup/posthom-orderhom-pre-removal-2026-02-26`

## Scope
- In scope:
  - remove `PostHom`-related definitions from `Concrete/Defs`
  - remove `PostHom` bridge lemmas from `Concrete/Lemmas`
  - update comments/imports accordingly
- Out of scope:
  - introducing new semantics interfaces
  - changing soundness theorem behavior beyond dependency cleanup

## Public API changes
Removed:
- `PostHom`
- `Post.toHom`
- `PostHom.toPost`
- `composePostHom`
- `StepPostHom`
- `TracePostHom`
- `liftTracePostHom`
- `MonotonePost.ofPostHom`
- `composePostHom_toPost`
- `liftTracePost_eq_liftTracePostHom_of_pointwise_monotone`
- `liftTracePost_monotone_of_postHom`

## Validation
- [x] `lake build`
- [x] `lake build Tests`
- [x] `lake test`
- [x] `rg -n "\bPostHom\b|\bStepPostHom\b|\bTracePostHom\b|OrderHom|toHom|toPost|composePostHom|liftTracePostHom" AbsInterpLTS Tests` returns no matches

## Checklist
- [x] Branch name follows `issue-<n>-<short-slug>`
- [x] PR title uses Conventional format
- [x] Changes are limited to this issue scope
- [x] Tests/docs updated for behavior changes