### PR TITLE
feat(process): add staged issue template (#8)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+

--- a/.github/ISSUE_TEMPLATE/staged-work-item.md
+++ b/.github/ISSUE_TEMPLATE/staged-work-item.md
@@ -1,0 +1,30 @@
+---
+name: Staged Work Item
+about: Plan one issue-scoped staged formalization task
+title: "<area>: <goal>"
+labels: enhancement
+assignees: ""
+---
+
+## Goal
+- 
+
+## Context
+- Optional background, architecture notes, or linked prior issues/PRs.
+
+## Scope
+- In scope:
+
+## Out of Scope
+- 
+
+## Deliverables
+- 
+
+## Dependencies
+- 
+
+## Acceptance Criteria
+- [ ] `lake build`, `lake build Tests`, and `lake test` pass.
+- [ ] Changes stay within this issue scope.
+- [ ] Framework/Instances layering is preserved where relevant.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ lake test
 
 ## Development workflow
 
-1. Create an issue.
+1. Create an issue from the staged work-item template.
 2. Create a branch `issue-<n>-<short-slug>`.
 3. Implement a single staged work item.
 4. Open a PR with a Conventional title.


### PR DESCRIPTION
## Summary

- add a staged issue template aligned with current roadmap issue structure
- disable blank issues to enforce template-based issue creation
- update README workflow wording to reference the staged work-item template

## Linked issue

- Closes #8

## Scope

- In scope:
  - `.github/ISSUE_TEMPLATE/staged-work-item.md`
  - `.github/ISSUE_TEMPLATE/config.yml`
  - README workflow wording update
- Out of scope:
  - CI workflow changes
  - PR template changes
  - any framework/instance/domain logic changes

## Validation

- [ ] `lake build`
- [ ] `lake build Tests`
- [ ] `lake test`

Note: This PR only changes repository process/docs assets. Local tree currently includes unrelated in-progress edits outside this PR scope, so lake checks were not re-run in this commit context.

## Checklist

- [x] Branch name follows `issue-<n>-<short-slug>`
- [x] PR title uses Conventional format
- [x] Changes are limited to this issue scope
- [x] Tests/docs updated for behavior changes
