### PR TITLE
refactor(semantics): align Concrete/Abstract defs and isolate abstract order layer

### DIFF
--- a/AbsInterpLTS/Framework/Semantics/Abstract.lean
+++ b/AbsInterpLTS/Framework/Semantics/Abstract.lean
@@ -1,2 +1,3 @@
 import AbsInterpLTS.Framework.Semantics.Abstract.Defs
+import AbsInterpLTS.Framework.Semantics.Abstract.Order
 import AbsInterpLTS.Framework.Semantics.Abstract.Lemmas

--- a/AbsInterpLTS/Framework/Semantics/Abstract/Defs.lean
+++ b/AbsInterpLTS/Framework/Semantics/Abstract/Defs.lean
@@ -10,12 +10,15 @@ universe u v
 /-!
 # Abstract Semantic Transformers
 
-This file mirrors concrete trace lifting at the abstract level.
+This file mirrors `Concrete/Defs` at the abstract level, but keeps the core
+interface order-agnostic.
 
 For `stepPostSharp : Label -> (Abstract -> Abstract)`,
 `liftTracePostSharp stepPostSharp` composes abstract step transformers left-to-right
 along a label list.
 -/
+
+section Basic
 
 /-- Abstract semantic transformer on abstract states. -/
 abbrev PostSharp (Abstract : Type u) := Abstract -> Abstract
@@ -33,6 +36,10 @@ def composePostSharp
     PostSharp Abstract :=
   fun a => postSharp2 (postSharp1 a)
 
+end Basic
+
+section Trace
+
 /--
 Lift one-step abstract transfers to trace transfers by left-to-right composition.
 -/
@@ -42,6 +49,8 @@ def liftTracePostSharp
     (stepPostSharp : StepPostSharp Abstract Label) :
     TracePostSharp Abstract Label :=
   liftTrace composePostSharp (fun a => a) stepPostSharp
+
+end Trace
 
 end Framework
 end AbsInterpLTS

--- a/AbsInterpLTS/Framework/Semantics/Abstract/Order.lean
+++ b/AbsInterpLTS/Framework/Semantics/Abstract/Order.lean
@@ -19,18 +19,16 @@ def MonotonePostSharp (postSharp : PostSharp Abstract) : Prop :=
 
 /-- The identity abstract transformer is monotone. -/
 theorem MonotonePostSharp.id :
-    MonotonePostSharp (fun a : Abstract => a) := by
-  intro a b hAB
-  exact hAB
+    MonotonePostSharp (fun a : Abstract => a) :=
+  monotone_id
 
 /-- Composition of monotone abstract transformers is monotone. -/
 theorem MonotonePostSharp.compose
     {postSharp1 postSharp2 : PostSharp Abstract}
     (h1 : MonotonePostSharp postSharp1)
     (h2 : MonotonePostSharp postSharp2) :
-    MonotonePostSharp (composePostSharp postSharp1 postSharp2) := by
-  intro a b hAB
-  exact h2 (h1 hAB)
+    MonotonePostSharp (composePostSharp postSharp1 postSharp2) :=
+  h2.comp h1
 
 end Basic
 

--- a/AbsInterpLTS/Framework/Semantics/Abstract/Order.lean
+++ b/AbsInterpLTS/Framework/Semantics/Abstract/Order.lean
@@ -1,0 +1,38 @@
+import Cslib.Init
+import Mathlib.Order.Monotone.Defs
+
+import AbsInterpLTS.Framework.Semantics.Abstract.Defs
+
+namespace AbsInterpLTS
+namespace Framework
+
+universe u
+
+section Basic
+
+variable {Abstract : Type u}
+variable [Preorder Abstract]
+
+/-- Monotonicity predicate for abstract transformers over a preorder. -/
+def MonotonePostSharp (postSharp : PostSharp Abstract) : Prop :=
+  Monotone postSharp
+
+/-- The identity abstract transformer is monotone. -/
+theorem MonotonePostSharp.id :
+    MonotonePostSharp (fun a : Abstract => a) := by
+  intro a b hAB
+  exact hAB
+
+/-- Composition of monotone abstract transformers is monotone. -/
+theorem MonotonePostSharp.compose
+    {postSharp1 postSharp2 : PostSharp Abstract}
+    (h1 : MonotonePostSharp postSharp1)
+    (h2 : MonotonePostSharp postSharp2) :
+    MonotonePostSharp (composePostSharp postSharp1 postSharp2) := by
+  intro a b hAB
+  exact h2 (h1 hAB)
+
+end Basic
+
+end Framework
+end AbsInterpLTS

--- a/AbsInterpLTS/Framework/Semantics/Collecting/Defs.lean
+++ b/AbsInterpLTS/Framework/Semantics/Collecting/Defs.lean
@@ -9,6 +9,9 @@ universe u
 
 /--
 Monotone one-step collecting semantics packaged as a reusable interface.
+
+`CollectingStep` is intentionally concrete: it ranges over concrete-state sets
+(`Set State`) and uses set inclusion as its order.
 -/
 structure CollectingStep (State : Type u) where
   post : Post State
@@ -19,6 +22,9 @@ namespace CollectingStep
 /--
 Collecting-style fixpoint operator for reachability:
 `reachF init states = init ∪ post states`.
+
+This operator is concrete-set based; abstract-domain lifting belongs in a
+separate layer.
 -/
 def reachF
     {State : Type u}

--- a/AbsInterpLTS/Framework/Semantics/Collecting/Lemmas.lean
+++ b/AbsInterpLTS/Framework/Semantics/Collecting/Lemmas.lean
@@ -9,6 +9,12 @@ universe u
 
 namespace CollectingStep
 
+/-!
+Lemmas in this namespace operate on concrete collecting transformers
+(`Set State -> Set State`), matching the concrete-only contract in
+`Collecting/Defs`.
+-/
+
 @[simp] theorem reachF_apply
     {State : Type u}
     (cfg : CollectingStep State)

--- a/AbsInterpLTS/Framework/Semantics/Concrete/Defs.lean
+++ b/AbsInterpLTS/Framework/Semantics/Concrete/Defs.lean
@@ -10,7 +10,8 @@ universe u v
 /-!
 # Concrete Semantic Transformers
 
-This file defines concrete transformers on `Set State` and monotonicity predicates.
+This file defines concrete transformers on `Set State`, with one-step and
+trace-indexed aliases and monotonicity predicates.
 
 Trace lifting is obtained via the generic combinator `liftTrace`.
 -/
@@ -19,6 +20,12 @@ section Basic
 
 /-- Concrete semantic transformer over concrete state properties. -/
 abbrev Post (State : Type u) := Set State -> Set State
+
+/-- Label-indexed one-step concrete transformers. -/
+abbrev StepPost (State : Type u) (Label : Type v) := Label -> Post State
+
+/-- Trace-indexed concrete transformers. -/
+abbrev TracePost (State : Type u) (Label : Type v) := List Label -> Post State
 
 /-- Monotonicity predicate for concrete transformers. -/
 def MonotonePost {State : Type u} (post : Post State) : Prop :=
@@ -42,8 +49,8 @@ Lift a one-step concrete transformer family to trace transformers.
 def liftTracePost
     {State : Type u}
     {Label : Type v}
-    (stepPost : Label -> Post State) :
-    List Label -> Post State :=
+    (stepPost : StepPost State Label) :
+    TracePost State Label :=
   liftTrace composePost (fun states => states) stepPost
 
 end Trace

--- a/AbsInterpLTS/Framework/Soundness/Defs.lean
+++ b/AbsInterpLTS/Framework/Soundness/Defs.lean
@@ -37,7 +37,7 @@ def SoundStep
     {State : Type u}
     {Label : Type v}
     {Abstract : Type w}
-    (stepPost : Label -> Post State)
+    (stepPost : StepPost State Label)
     (gamma : Gamma Abstract State)
     (stepPostSharp : StepPostSharp Abstract Label) : Prop :=
   forall label : Label, forall a : Abstract,
@@ -51,7 +51,7 @@ def SoundTrace
     {State : Type u}
     {Label : Type v}
     {Abstract : Type w}
-    (tracePost : List Label -> Post State)
+    (tracePost : TracePost State Label)
     (gamma : Gamma Abstract State)
     (tracePostSharp : TracePostSharp Abstract Label) : Prop :=
   forall labels : List Label, forall a : Abstract,

--- a/Tests.lean
+++ b/Tests.lean
@@ -8,3 +8,4 @@ import Tests.Instances.LTS.Collecting
 import Tests.Instances.LTS.IntervalHook
 import Tests.Instances.LTS.SignHook
 import Tests.Framework.Iteration.NatIter
+import Tests.Framework.Semantics.AbstractOrder

--- a/Tests/Framework/Semantics/AbstractOrder.lean
+++ b/Tests/Framework/Semantics/AbstractOrder.lean
@@ -1,0 +1,60 @@
+import Cslib.Init
+
+import AbsInterpLTS
+
+namespace Tests
+namespace FrameworkSemanticsAbstractOrder
+
+open AbsInterpLTS
+open AbsInterpLTS.Framework
+
+def stepId : StepPost Nat Bool :=
+  fun _ states => states
+
+example : TracePost Nat Bool := liftTracePost stepId
+
+def addOne : PostSharp Nat :=
+  fun n => n + 1
+
+def addTwo : PostSharp Nat :=
+  fun n => n + 2
+
+theorem addOne_monotone : MonotonePostSharp addOne := by
+  intro a b hAB
+  simpa [addOne] using Nat.succ_le_succ hAB
+
+theorem addTwo_monotone : MonotonePostSharp addTwo := by
+  intro a b hAB
+  simpa [addTwo] using Nat.add_le_add_right hAB 2
+
+example : MonotonePostSharp (fun n : Nat => n) :=
+  MonotonePostSharp.id
+
+example : MonotonePostSharp (composePostSharp addOne addTwo) :=
+  MonotonePostSharp.compose addOne_monotone addTwo_monotone
+
+def gammaTop : Unit -> Set Nat :=
+  fun _ => Set.univ
+
+def postId : Post Nat :=
+  fun states => states
+
+def postSharpUnit : PostSharp Unit :=
+  fun _ => ()
+
+theorem sound_postId_unit : Sound postId gammaTop postSharpUnit := by
+  intro _ s hs
+  simp [postId, gammaTop] at hs ⊢
+
+def stepPostId : StepPost Nat Bool :=
+  fun _ => postId
+
+def stepSharpUnit : StepPostSharp Unit Bool :=
+  fun _ => postSharpUnit
+
+example : SoundStep stepPostId gammaTop stepSharpUnit := by
+  intro _ _ s hs
+  simp [stepPostId, postId, gammaTop] at hs ⊢
+
+end FrameworkSemanticsAbstractOrder
+end Tests


### PR DESCRIPTION
## Summary
- add `StepPost`/`TracePost` aliases in concrete semantics defs
- align abstract defs layout with concrete (`Basic`/`Trace` sections)
- add preorder-based abstract monotonicity layer in `Abstract/Order.lean`
- use concrete aliases in `SoundStep`/`SoundTrace` signatures
- clarify that collecting semantics remains concrete-set based
- add framework tests for abstract-order monotonicity and alias compatibility

## Linked issue
- Closes #27

## Scope
- In scope:
  - interface symmetry improvements between concrete/abstract defs
  - order-dependent abstract monotonicity predicates in separate layer
  - collecting boundary documentation clarification
  - framework-level tests for new API surface
- Out of scope:
  - collecting generalization to abstract domains
  - widening/narrowing implementation
  - weak/τ and ω-trace extension

## Validation
- [x] `lake build`
- [x] `lake build Tests`
- [x] `lake test`

## Commit structure
1. `refactor(semantics): add concrete step/trace aliases`
2. `refactor(semantics): mirror abstract defs section layout`
3. `feat(semantics): add abstract order monotonicity layer`
4. `refactor(soundness): use concrete step/trace aliases`
5. `docs(collecting): clarify concrete-only semantics boundary`
6. `test(framework): add abstract order and alias coverage`