### PR TITLE
refactor(framework): extract gamma-only domain contract and wire Sign/Interval

### DIFF
--- a/.github/workflows/lean_ci.yml
+++ b/.github/workflows/lean_ci.yml
@@ -2,8 +2,14 @@ name: Lean CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/AbsInterpLTS/Domains/Interval.lean
+++ b/AbsInterpLTS/Domains/Interval.lean
@@ -1,4 +1,6 @@
 import Cslib.Init
+import Mathlib.Data.Set.Lattice
+import AbsInterpLTS.Framework.Domains
 
 namespace AbsInterpLTS
 namespace Domains
@@ -49,6 +51,11 @@ theorem gammaInterval_monotone_of_leInterval {a b : Interval} (hAB : a ≤ b) :
     gammaInterval a ⊆ gammaInterval b :=
   hAB
 
+/-- `top` concretizes to all integers. -/
+theorem gammaInterval_top (n : Int) : n ∈ gammaInterval Interval.top := by
+  change True
+  trivial
+
 theorem mem_gammaInterval_mk_iff (lo hi n : Int) :
     n ∈ gammaInterval (mk lo hi) ↔ lo ≤ n ∧ n ≤ hi := by
   by_cases h : lo ≤ hi
@@ -62,10 +69,8 @@ theorem mem_gammaInterval_mk_iff (lo hi n : Int) :
       omega
     constructor
     · intro hn
-      have : n ∈ (∅ : Set Int) := by
-        simpa [mk, gammaInterval, h] using hn
       have : False := by
-        simpa using this
+        simp [mk, gammaInterval, h] at hn
       exact False.elim this
     · intro hRange
       exact False.elim (hRangeFalse hRange)
@@ -76,6 +81,17 @@ theorem gammaInterval_mk (lo hi : Int) :
   intro n
   simpa using mem_gammaInterval_mk_iff lo hi n
 
+/-- Normalization preserves concretization. -/
+theorem gammaInterval_normalize (a : Interval) :
+    gammaInterval (normalize a) = gammaInterval a := by
+  cases a with
+  | bot =>
+      rfl
+  | top =>
+      rfl
+  | range lo hi =>
+      simpa [normalize, gammaInterval] using gammaInterval_mk lo hi
+
 /-- Join on normalized intervals. -/
 def joinInterval (a b : Interval) : Interval :=
   match normalize a, normalize b with
@@ -84,6 +100,96 @@ def joinInterval (a b : Interval) : Interval :=
   | .top, _ => .top
   | _, .top => .top
   | .range lo1 hi1, .range lo2 hi2 => mk (min lo1 lo2) (max hi1 hi2)
+
+/-- `joinInterval` soundly over-approximates union concretization. -/
+theorem joinInterval_sound (a b : Interval) :
+    gammaInterval a ∪ gammaInterval b ⊆ gammaInterval (joinInterval a b) := by
+  intro n hn
+  cases a with
+  | bot =>
+      cases b with
+      | bot =>
+          have : False := by
+            simp [gammaInterval] at hn
+          exact False.elim this
+      | range lo hi =>
+          by_cases h : lo ≤ hi
+          · have hRange : lo ≤ n ∧ n ≤ hi := by
+              simpa [gammaInterval] using hn
+            simpa [joinInterval, normalize, mk, h] using
+              (mem_gammaInterval_mk_iff lo hi n).2 hRange
+          · have hRange : lo ≤ n ∧ n ≤ hi := by
+              simpa [gammaInterval] using hn
+            have : False := by
+              omega
+            exact False.elim this
+      | top =>
+          simp [joinInterval, normalize, gammaInterval]
+  | range lo1 hi1 =>
+      cases b with
+      | bot =>
+          by_cases h1 : lo1 ≤ hi1
+          · have hRange : lo1 ≤ n ∧ n ≤ hi1 := by
+              simpa [gammaInterval] using hn
+            simpa [joinInterval, normalize, mk, h1] using
+              (mem_gammaInterval_mk_iff lo1 hi1 n).2 hRange
+          · have hRange : lo1 ≤ n ∧ n ≤ hi1 := by
+              simpa [gammaInterval] using hn
+            have : False := by
+              omega
+            exact False.elim this
+      | range lo2 hi2 =>
+          have hRange :
+              (lo1 ≤ n ∧ n ≤ hi1) ∨ (lo2 ≤ n ∧ n ≤ hi2) := by
+            simpa [gammaInterval] using hn
+          by_cases h1 : lo1 ≤ hi1
+          · by_cases h2 : lo2 ≤ hi2
+            · have hBounds : min lo1 lo2 ≤ n ∧ n ≤ max hi1 hi2 := by
+                rcases hRange with hR1 | hR2
+                · rcases hR1 with ⟨hLo1, hHi1⟩
+                  exact ⟨by omega, by omega⟩
+                · rcases hR2 with ⟨hLo2, hHi2⟩
+                  exact ⟨by omega, by omega⟩
+              simpa [joinInterval, normalize, mk, h1, h2] using
+                (mem_gammaInterval_mk_iff (min lo1 lo2) (max hi1 hi2) n).2 hBounds
+            · have hR1 : lo1 ≤ n ∧ n ≤ hi1 := by
+                rcases hRange with hR1 | hR2
+                · exact hR1
+                · exfalso
+                  rcases hR2 with ⟨hLo2, hHi2⟩
+                  omega
+              simpa [joinInterval, normalize, mk, h1, h2] using
+                (mem_gammaInterval_mk_iff lo1 hi1 n).2 hR1
+          · by_cases h2 : lo2 ≤ hi2
+            · have hR2 : lo2 ≤ n ∧ n ≤ hi2 := by
+                rcases hRange with hR1 | hR2
+                · exfalso
+                  rcases hR1 with ⟨hLo1, hHi1⟩
+                  omega
+                · exact hR2
+              simpa [joinInterval, normalize, mk, h1, h2] using
+                (mem_gammaInterval_mk_iff lo2 hi2 n).2 hR2
+            · have : False := by
+                rcases hRange with hR1 | hR2
+                · rcases hR1 with ⟨hLo1, hHi1⟩
+                  omega
+                · rcases hR2 with ⟨hLo2, hHi2⟩
+                  omega
+              exact False.elim this
+      | top =>
+          by_cases h1 : lo1 ≤ hi1
+          · simp [joinInterval, normalize, mk, gammaInterval, h1]
+          · simp [joinInterval, normalize, mk, gammaInterval, h1]
+  | top =>
+      cases b with
+      | bot =>
+          simp [joinInterval, normalize, gammaInterval]
+      | range lo hi =>
+          by_cases h : lo ≤ hi
+          · simp [joinInterval, normalize, mk, gammaInterval, h]
+          · simp [joinInterval, normalize, mk, gammaInterval, h]
+      | top =>
+          simp [joinInterval, normalize, gammaInterval]
 
 /-- Meet on normalized intervals. -/
 def meetInterval (a b : Interval) : Interval :=
@@ -114,11 +220,30 @@ theorem negIntervalTransfer_sound {a : Interval} {n : Int} (hn : n ∈ gammaInte
   | range lo hi =>
       rcases hn with ⟨hLo, hHi⟩
       have hNorm : lo ≤ hi := by omega
-      have hNegNorm : -hi ≤ -lo := by omega
       have hLow : -hi ≤ -n := by omega
       have hHigh : -n ≤ -lo := by omega
-      simp [negIntervalTransfer, normalize, mk, hNorm, hNegNorm, gammaInterval]
-      exact ⟨hLow, hHigh⟩
+      have hMem : -hi ≤ -n ∧ -n ≤ -lo := ⟨hLow, hHigh⟩
+      have hMk : mk lo hi = Interval.range lo hi := by
+        simp [mk, hNorm]
+      simpa [negIntervalTransfer, normalize, hMk] using
+        (mem_gammaInterval_mk_iff (-hi) (-lo) (-n)).2 hMem
+
+/-- Gamma-only interface instance for the interval domain. -/
+def intervalGammaOnlyDomain :
+    AbsInterpLTS.Framework.Domains.GammaOnlyDomain Interval Int where
+  gamma := gammaInterval
+  le := leInterval
+  le_refl := leInterval_refl
+  le_trans := by
+    intro a b c hAB hBC
+    exact leInterval_trans hAB hBC
+  gamma_monotone := by
+    intro a b hAB
+    exact gammaInterval_monotone_of_leInterval hAB
+  top := Interval.top
+  gamma_top := gammaInterval_top
+  join := joinInterval
+  join_sound := joinInterval_sound
 
 end Domains
 end AbsInterpLTS

--- a/AbsInterpLTS/Domains/Interval.lean
+++ b/AbsInterpLTS/Domains/Interval.lean
@@ -107,24 +107,12 @@ theorem joinInterval_sound (a b : Interval) :
   intro n hn
   cases a with
   | bot =>
-      cases b with
-      | bot =>
-          have : False := by
-            simp [gammaInterval] at hn
-          exact False.elim this
-      | range lo hi =>
-          by_cases h : lo ≤ hi
-          · have hRange : lo ≤ n ∧ n ≤ hi := by
-              simpa [gammaInterval] using hn
-            simpa [joinInterval, normalize, mk, h] using
-              (mem_gammaInterval_mk_iff lo hi n).2 hRange
-          · have hRange : lo ≤ n ∧ n ≤ hi := by
-              simpa [gammaInterval] using hn
-            have : False := by
-              omega
-            exact False.elim this
-      | top =>
-          simp [joinInterval, normalize, gammaInterval]
+      have hb : n ∈ gammaInterval b := by
+        simpa [gammaInterval] using hn
+      have hbNorm : n ∈ gammaInterval (normalize b) := by
+        rw [gammaInterval_normalize b]
+        exact hb
+      simpa [joinInterval, normalize] using hbNorm
   | range lo1 hi1 =>
       cases b with
       | bot =>
@@ -234,12 +222,8 @@ def intervalGammaOnlyDomain :
   gamma := gammaInterval
   le := leInterval
   le_refl := leInterval_refl
-  le_trans := by
-    intro a b c hAB hBC
-    exact leInterval_trans hAB hBC
-  gamma_monotone := by
-    intro a b hAB
-    exact gammaInterval_monotone_of_leInterval hAB
+  le_trans := leInterval_trans
+  gamma_monotone := gammaInterval_monotone_of_leInterval
   top := Interval.top
   gamma_top := gammaInterval_top
   join := joinInterval

--- a/AbsInterpLTS/Domains/Sign.lean
+++ b/AbsInterpLTS/Domains/Sign.lean
@@ -1,4 +1,6 @@
 import Cslib.Init
+import Mathlib.Data.Set.Lattice
+import AbsInterpLTS.Framework.Domains
 
 namespace AbsInterpLTS
 namespace Domains
@@ -43,6 +45,11 @@ theorem leSign_trans {a b c : Sign} (hAB : a ≤ b) (hBC : b ≤ c) : a ≤ c :=
 theorem gammaSign_monotone_of_leSign {a b : Sign} (hAB : a ≤ b) :
     gammaSign a ⊆ gammaSign b :=
   hAB
+
+/-- `top` concretizes to all integers. -/
+theorem gammaSign_top (n : Int) : n ∈ gammaSign Sign.top := by
+  change True
+  trivial
 
 private def hasNeg : Sign -> Bool
   | .bot => false
@@ -89,6 +96,14 @@ def joinSign (a b : Sign) : Sign :=
     (hasZero a || hasZero b)
     (hasPos a || hasPos b)
 
+/-- `joinSign` soundly over-approximates union concretization. -/
+theorem joinSign_sound (a b : Sign) :
+    gammaSign a ∪ gammaSign b ⊆ gammaSign (joinSign a b) := by
+  intro n hn
+  cases a <;> cases b <;>
+    simp [gammaSign, joinSign, signOfFlags, hasNeg, hasZero, hasPos] at hn ⊢ <;>
+    tauto
+
 /-- Baseline unary transfer shape: abstract negation. -/
 def negTransfer : Sign -> Sign
   | .bot => .bot
@@ -129,6 +144,23 @@ theorem negTransfer_sound {a : Sign} {n : Int} (hn : n ∈ gammaSign a) :
       change True at hn
       change True
       trivial
+
+/-- Gamma-only interface instance for the sign domain. -/
+def signGammaOnlyDomain :
+    AbsInterpLTS.Framework.Domains.GammaOnlyDomain Sign Int where
+  gamma := gammaSign
+  le := leSign
+  le_refl := leSign_refl
+  le_trans := by
+    intro a b c hAB hBC
+    exact leSign_trans hAB hBC
+  gamma_monotone := by
+    intro a b hAB
+    exact gammaSign_monotone_of_leSign hAB
+  top := Sign.top
+  gamma_top := gammaSign_top
+  join := joinSign
+  join_sound := joinSign_sound
 
 end Domains
 end AbsInterpLTS

--- a/AbsInterpLTS/Domains/Sign.lean
+++ b/AbsInterpLTS/Domains/Sign.lean
@@ -151,12 +151,8 @@ def signGammaOnlyDomain :
   gamma := gammaSign
   le := leSign
   le_refl := leSign_refl
-  le_trans := by
-    intro a b c hAB hBC
-    exact leSign_trans hAB hBC
-  gamma_monotone := by
-    intro a b hAB
-    exact gammaSign_monotone_of_leSign hAB
+  le_trans := leSign_trans
+  gamma_monotone := gammaSign_monotone_of_leSign
   top := Sign.top
   gamma_top := gammaSign_top
   join := joinSign

--- a/AbsInterpLTS/Framework.lean
+++ b/AbsInterpLTS/Framework.lean
@@ -1,3 +1,4 @@
+import AbsInterpLTS.Framework.Domains
 import AbsInterpLTS.Framework.Semantics
 import AbsInterpLTS.Framework.Soundness
 import AbsInterpLTS.Framework.Iteration

--- a/AbsInterpLTS/Framework/Domains.lean
+++ b/AbsInterpLTS/Framework/Domains.lean
@@ -1,0 +1,1 @@
+import AbsInterpLTS.Framework.Domains.GammaOnly

--- a/AbsInterpLTS/Framework/Domains/GammaOnly.lean
+++ b/AbsInterpLTS/Framework/Domains/GammaOnly.lean
@@ -1,0 +1,59 @@
+import Cslib.Init
+
+namespace AbsInterpLTS
+namespace Framework
+namespace Domains
+
+universe u v
+
+/-- Concretization map from abstract elements to concrete sets. -/
+abbrev Gamma (Abstract : Type u) (Concrete : Type v) := Abstract -> Set Concrete
+
+/--
+`gamma`-only abstract-domain contract.
+
+This interface fixes the minimal obligations used by the current framework:
+order (`le`), concretization monotonicity, top coverage, and join soundness.
+It intentionally does not include `alpha` or Galois-connection fields.
+-/
+structure GammaOnlyDomain (Abstract : Type u) (Concrete : Type v) where
+  gamma : Gamma Abstract Concrete
+  le : Abstract -> Abstract -> Prop
+  le_refl : ∀ a : Abstract, le a a
+  le_trans : ∀ {a b c : Abstract}, le a b -> le b c -> le a c
+  gamma_monotone : ∀ {a b : Abstract}, le a b -> gamma a ⊆ gamma b
+  top : Abstract
+  gamma_top : ∀ c : Concrete, c ∈ gamma top
+  join : Abstract -> Abstract -> Abstract
+  join_sound :
+    ∀ a b : Abstract, gamma a ∪ gamma b ⊆ gamma (join a b)
+
+namespace GammaOnlyDomain
+
+variable {Abstract : Type u} {Concrete : Type v}
+variable (cfg : GammaOnlyDomain Abstract Concrete)
+
+/-- The order relation carried by a `GammaOnlyDomain`. -/
+abbrev LE : Abstract -> Abstract -> Prop :=
+  cfg.le
+
+/-- Concretization monotonicity as a named theorem. -/
+theorem gamma_monotone_of_le {a b : Abstract} (h : cfg.le a b) :
+    cfg.gamma a ⊆ cfg.gamma b :=
+  cfg.gamma_monotone h
+
+/-- Every concrete element is in the concretization of `top`. -/
+theorem mem_gamma_top (c : Concrete) :
+    c ∈ cfg.gamma cfg.top :=
+  cfg.gamma_top c
+
+/-- Join is sound w.r.t. concretization union. -/
+theorem gamma_union_subset_join (a b : Abstract) :
+    cfg.gamma a ∪ cfg.gamma b ⊆ cfg.gamma (cfg.join a b) :=
+  cfg.join_sound a b
+
+end GammaOnlyDomain
+
+end Domains
+end Framework
+end AbsInterpLTS

--- a/Tests.lean
+++ b/Tests.lean
@@ -8,4 +8,5 @@ import Tests.Instances.LTS.Collecting
 import Tests.Instances.LTS.IntervalHook
 import Tests.Instances.LTS.SignHook
 import Tests.Framework.Iteration.NatIter
+import Tests.Framework.Domains.GammaOnly
 import Tests.Framework.Semantics.AbstractOrder

--- a/Tests/Framework/Domains/GammaOnly.lean
+++ b/Tests/Framework/Domains/GammaOnly.lean
@@ -1,0 +1,37 @@
+import Cslib.Init
+
+import AbsInterpLTS
+
+namespace Tests
+namespace FrameworkDomainsGammaOnly
+
+open AbsInterpLTS
+open AbsInterpLTS.Domains
+
+example :
+    (0 : Int) ∈
+      Domains.signGammaOnlyDomain.gamma Domains.signGammaOnlyDomain.top := by
+  simpa using Domains.signGammaOnlyDomain.gamma_top 0
+
+example :
+    Domains.signGammaOnlyDomain.gamma Sign.neg ∪
+      Domains.signGammaOnlyDomain.gamma Sign.zero ⊆
+      Domains.signGammaOnlyDomain.gamma
+        (Domains.signGammaOnlyDomain.join Sign.neg Sign.zero) := by
+  simpa using Domains.signGammaOnlyDomain.join_sound Sign.neg Sign.zero
+
+example :
+    (3 : Int) ∈
+      Domains.intervalGammaOnlyDomain.gamma Domains.intervalGammaOnlyDomain.top := by
+  simpa using Domains.intervalGammaOnlyDomain.gamma_top 3
+
+example :
+    Domains.intervalGammaOnlyDomain.gamma (Domains.mk 1 2) ∪
+      Domains.intervalGammaOnlyDomain.gamma (Domains.mk 4 5) ⊆
+      Domains.intervalGammaOnlyDomain.gamma
+        (Domains.intervalGammaOnlyDomain.join (Domains.mk 1 2) (Domains.mk 4 5)) := by
+  simpa using
+    Domains.intervalGammaOnlyDomain.join_sound (Domains.mk 1 2) (Domains.mk 4 5)
+
+end FrameworkDomainsGammaOnly
+end Tests


### PR DESCRIPTION
## Summary
- add a framework-level gamma-only core contract in `Framework/Domains/GammaOnly`
- expose a framework domains barrel and wire it via `Framework.lean`
- connect `Sign` and `Interval` to the shared contract (`gamma_top`, `join_sound`, domain records)
- add gamma-only smoke tests and import them into `Tests.lean`

## Related Issue
- closes #29

## Validation
- `lake build`
- `lake build Tests`
- `lake test`

## Notes
- CI pass check intentionally skipped per request (current CI issue).