### PR TITLE
feat(interval): add meet soundness and trace bridge smoke checks

### DIFF
--- a/AbsInterpLTS/Domains/Interval.lean
+++ b/AbsInterpLTS/Domains/Interval.lean
@@ -188,6 +188,29 @@ def meetInterval (a b : Interval) : Interval :=
   | a', .top => a'
   | .range lo1 hi1, .range lo2 hi2 => mk (max lo1 lo2) (min hi1 hi2)
 
+/-- `meetInterval` soundly under-approximates intersection concretization. -/
+theorem meetInterval_sound (a b : Interval) :
+    gammaInterval (meetInterval a b) ⊆ gammaInterval a ∩ gammaInterval b := by
+  intro n hn
+  have hNorm :
+      n ∈ gammaInterval (normalize a) ∩ gammaInterval (normalize b) := by
+    cases hna : normalize a <;> cases hnb : normalize b <;>
+      simp [meetInterval, hna, hnb, gammaInterval] at hn ⊢
+    case range.top =>
+      exact hn
+    case top.range =>
+      exact hn
+    case range.range lo1 hi1 lo2 hi2 =>
+      have hBounds : max lo1 lo2 ≤ n ∧ n ≤ min hi1 hi2 :=
+        (mem_gammaInterval_mk_iff (max lo1 lo2) (min hi1 hi2) n).1 hn
+      have hA : lo1 ≤ n ∧ n ≤ hi1 := by omega
+      have hB : lo2 ≤ n ∧ n ≤ hi2 := by omega
+      exact
+        ⟨by simpa [hna, gammaInterval] using hA, by simpa [hnb, gammaInterval] using hB⟩
+  exact
+    ⟨by simpa [gammaInterval_normalize a] using hNorm.1,
+      by simpa [gammaInterval_normalize b] using hNorm.2⟩
+
 /-- Baseline unary transfer shape: abstract negation. -/
 def negIntervalTransfer (a : Interval) : Interval :=
   match normalize a with

--- a/AbsInterpLTS/Domains/Interval.lean
+++ b/AbsInterpLTS/Domains/Interval.lean
@@ -202,14 +202,12 @@ theorem meetInterval_sound (a b : Interval) :
       exact hn
     case range.range lo1 hi1 lo2 hi2 =>
       have hBounds : max lo1 lo2 ≤ n ∧ n ≤ min hi1 hi2 :=
-        (mem_gammaInterval_mk_iff (max lo1 lo2) (min hi1 hi2) n).1 hn
+        (mem_gammaInterval_mk_iff (max lo1 lo2) (min hi1 hi2) n).1 (by simpa [gammaInterval] using hn)
       have hA : lo1 ≤ n ∧ n ≤ hi1 := by omega
       have hB : lo2 ≤ n ∧ n ≤ hi2 := by omega
       exact
         ⟨by simpa [hna, gammaInterval] using hA, by simpa [hnb, gammaInterval] using hB⟩
-  exact
-    ⟨by simpa [gammaInterval_normalize a] using hNorm.1,
-      by simpa [gammaInterval_normalize b] using hNorm.2⟩
+  exact (gammaInterval_normalize a ▸ gammaInterval_normalize b ▸ hNorm)
 
 /-- Baseline unary transfer shape: abstract negation. -/
 def negIntervalTransfer (a : Interval) : Interval :=

--- a/AbsInterpLTS/Domains/Interval.lean
+++ b/AbsInterpLTS/Domains/Interval.lean
@@ -192,22 +192,15 @@ def meetInterval (a b : Interval) : Interval :=
 theorem meetInterval_sound (a b : Interval) :
     gammaInterval (meetInterval a b) ⊆ gammaInterval a ∩ gammaInterval b := by
   intro n hn
-  have hNorm :
-      n ∈ gammaInterval (normalize a) ∩ gammaInterval (normalize b) := by
-    cases hna : normalize a <;> cases hnb : normalize b <;>
-      simp [meetInterval, hna, hnb, gammaInterval] at hn ⊢
-    case range.top =>
-      exact hn
-    case top.range =>
-      exact hn
-    case range.range lo1 hi1 lo2 hi2 =>
-      have hBounds : max lo1 lo2 ≤ n ∧ n ≤ min hi1 hi2 :=
-        (mem_gammaInterval_mk_iff (max lo1 lo2) (min hi1 hi2) n).1 (by simpa [gammaInterval] using hn)
-      have hA : lo1 ≤ n ∧ n ≤ hi1 := by omega
-      have hB : lo2 ≤ n ∧ n ≤ hi2 := by omega
-      exact
-        ⟨by simpa [hna, gammaInterval] using hA, by simpa [hnb, gammaInterval] using hB⟩
-  exact (gammaInterval_normalize a ▸ gammaInterval_normalize b ▸ hNorm)
+  rw [← gammaInterval_normalize a, ← gammaInterval_normalize b]
+  cases hna : normalize a <;> cases hnb : normalize b <;>
+    simp (config := { contextual := true }) [meetInterval, hna, hnb, gammaInterval] at hn ⊢
+  case range.range lo1 hi1 lo2 hi2 =>
+    have hBounds : max lo1 lo2 ≤ n ∧ n ≤ min hi1 hi2 :=
+      (mem_gammaInterval_mk_iff (max lo1 lo2) (min hi1 hi2) n).1 (by simpa [gammaInterval] using hn)
+    omega
+  case range.top | top.range =>
+    exact hn
 
 /-- Baseline unary transfer shape: abstract negation. -/
 def negIntervalTransfer (a : Interval) : Interval :=

--- a/Tests/Domains/Interval.lean
+++ b/Tests/Domains/Interval.lean
@@ -50,6 +50,10 @@ example : meetInterval (mk 1 4) (mk 3 6) = mk 3 4 := by
 example : meetInterval (mk 1 2) (mk 4 5) = Interval.bot := by
   simp [meetInterval, normalize, mk]
 
+example (n : Int) (hn : n ∈ gammaInterval (meetInterval (mk 1 4) (mk 3 6))) :
+    n ∈ gammaInterval (mk 1 4) ∩ gammaInterval (mk 3 6) := by
+  exact meetInterval_sound (a := mk 1 4) (b := mk 3 6) hn
+
 example : negIntervalTransfer (mk 1 4) = mk (-4) (-1) := by
   simp [negIntervalTransfer, normalize, mk]
 

--- a/Tests/Instances/LTS/Smoke.lean
+++ b/Tests/Instances/LTS/Smoke.lean
@@ -41,6 +41,16 @@ example :
   exact AbsInterpLTS.Instances.LTS.postStep_monotone oneAbstraction.lts () hSubset
 
 example :
+    AbsInterpLTS.Instances.LTS.postTrace emptyNatLTS =
+      AbsInterpLTS.Framework.liftTracePost (AbsInterpLTS.Instances.LTS.postStep emptyNatLTS) := by
+  exact AbsInterpLTS.Instances.LTS.postTrace_eq_liftTracePost_postStep emptyNatLTS
+
+example :
+    AbsInterpLTS.Framework.MonotonePost
+      (AbsInterpLTS.Instances.LTS.postTrace emptyNatLTS [()]) := by
+  exact AbsInterpLTS.Instances.LTS.postTrace_monotone emptyNatLTS [()]
+
+example :
     AbsInterpLTS.Framework.SoundTrace
       (AbsInterpLTS.Framework.liftTracePost
         (AbsInterpLTS.Instances.LTS.postStep oneAbstraction.lts))


### PR DESCRIPTION
## Summary
This PR restores and strengthens two core contracts discussed in the roadmap alignment work:
- Interval meet now has an explicit semantic soundness theorem.
- LTS trace adapter behavior is covered by smoke tests to keep the bridge to framework trace lifting explicit.

## Why
- `meetInterval` should not exist as an unverified helper when we intend to use refinement-style reasoning later.
- `postTrace` bridge guarantees are important for cslib/LTS-facing readability and future maintenance.

## What
- Added `meetInterval_sound` in `AbsInterpLTS/Domains/Interval.lean`.
- Added interval-domain test coverage for the new theorem.
- Added smoke checks for:
  - `postTrace = liftTracePost (postStep ...)`
  - `postTrace_monotone`

## Validation
- `lake build`
- `lake test`

## Related
- #33
- #3
