### PR TITLE
refactor(iteration): separate Widen interface from NatIter

### DIFF
--- a/AbsInterpLTS/Framework/Iteration.lean
+++ b/AbsInterpLTS/Framework/Iteration.lean
@@ -1,2 +1,3 @@
 import AbsInterpLTS.Framework.Iteration.NatIter
 import AbsInterpLTS.Framework.Iteration.Collecting
+import AbsInterpLTS.Framework.Iteration.Widening

--- a/AbsInterpLTS/Framework/Iteration/NatIter.lean
+++ b/AbsInterpLTS/Framework/Iteration/NatIter.lean
@@ -13,9 +13,6 @@ open AbsInterpLTS.Framework
 
 universe u
 
-/-- Widening interface for abstract iterative solvers. -/
-abbrev Widen (Abstract : Type u) := Abstract -> Abstract -> Abstract
-
 /-- Natural-number iterate scaffold for concrete next-step operators. -/
 def iterateNat
     {State : Type u}

--- a/AbsInterpLTS/Framework/Iteration/Widening.lean
+++ b/AbsInterpLTS/Framework/Iteration/Widening.lean
@@ -1,0 +1,1 @@
+import AbsInterpLTS.Framework.Iteration.Widening.Defs

--- a/AbsInterpLTS/Framework/Iteration/Widening/Defs.lean
+++ b/AbsInterpLTS/Framework/Iteration/Widening/Defs.lean
@@ -1,0 +1,14 @@
+import Cslib.Init
+
+namespace AbsInterpLTS
+namespace Framework
+namespace Iteration
+
+universe u
+
+/-- Widening interface for abstract iterative solvers. -/
+abbrev Widen (Abstract : Type u) := Abstract -> Abstract -> Abstract
+
+end Iteration
+end Framework
+end AbsInterpLTS


### PR DESCRIPTION
## Summary
- Move `Widen` abbrev from `NatIter.lean` into dedicated `Framework/Iteration/Widening/Defs.lean` module
- Add barrel import `Framework/Iteration/Widening.lean`
- Wire into `Framework/Iteration.lean` barrel
- Establishes clean boundary between raw iteration scaffolding and widening policy ahead of #3

## Linked issue
Closes #31

## Scope
- `Framework/Iteration/Widening/Defs.lean` — **new**: `Widen` abbrev
- `Framework/Iteration/Widening.lean` — **new**: barrel import
- `Framework/Iteration/NatIter.lean` — **edit**: remove `Widen` abbrev
- `Framework/Iteration.lean` — **edit**: add Widening import

## Validation checklist
- [x] `lake build` passes
- [x] `lake build Tests` passes
- [x] `lake test` passes
- [x] `Widen` accessible via `AbsInterpLTS.Framework.Iteration.Widen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)