### PR TITLE
feat(iteration): add widening/narrowing policy layer

### DIFF
--- a/AbsInterpLTS/Framework/Iteration/Widening.lean
+++ b/AbsInterpLTS/Framework/Iteration/Widening.lean
@@ -1,1 +1,2 @@
 import AbsInterpLTS.Framework.Iteration.Widening.Defs
+import AbsInterpLTS.Framework.Iteration.Widening.Lemmas

--- a/AbsInterpLTS/Framework/Iteration/Widening/Defs.lean
+++ b/AbsInterpLTS/Framework/Iteration/Widening/Defs.lean
@@ -9,6 +9,70 @@ universe u
 /-- Widening interface for abstract iterative solvers. -/
 abbrev Widen (Abstract : Type u) := Abstract -> Abstract -> Abstract
 
+/-- Narrowing interface for abstract iterative solvers. -/
+abbrev Narrow (Abstract : Type u) := Abstract -> Abstract -> Abstract
+
+/-- Post-fixpoint property: `f(a) ⊑ a`. -/
+def IsPostFixpoint
+    {Abstract : Type u}
+    (le : Abstract -> Abstract -> Prop)
+    (f : Abstract -> Abstract)
+    (a : Abstract) : Prop :=
+  le (f a) a
+
+/-- Widening upper-bound contract: `widen a b` is above both `a` and `b`. -/
+structure WidenUpperBound
+    {Abstract : Type u}
+    (le : Abstract -> Abstract -> Prop)
+    (widen : Widen Abstract) : Prop where
+  left : ∀ a b, le a (widen a b)
+  right : ∀ a b, le b (widen a b)
+
+/-- Widened accessibility predicate (N40AI WAcc).
+    Constructive termination witness for widened iteration.
+    `WAcc le f widen x y` means: starting from `x ⊑ y`,
+    any widened chain reaches a post-fixpoint in finitely many steps. -/
+inductive WAcc
+    {Abstract : Type u}
+    (le : Abstract -> Abstract -> Prop)
+    (f : Abstract -> Abstract)
+    (widen : Widen Abstract) :
+    Abstract -> Abstract -> Type u where
+  | intro : ∀ x y,
+      (le x y ->
+       ¬ le (f y) y ->
+       WAcc le f widen (f y) (widen y (f y))) ->
+      WAcc le f widen x y
+
+/-- Widened iteration: computes post-fixpoint by structural recursion on WAcc. -/
+def witer
+    {Abstract : Type u}
+    {le : Abstract -> Abstract -> Prop}
+    {f : Abstract -> Abstract}
+    {widen : Widen Abstract}
+    (le_dec : ∀ a b : Abstract, Decidable (le a b))
+    (hWiden : WidenUpperBound le widen)
+    {x y : Abstract}
+    (hLe : le x y)
+    (acc : WAcc le f widen x y) : Abstract :=
+  match acc with
+  | .intro _ _ ih =>
+    if h : le (f y) y then y
+    else witer le_dec hWiden (hWiden.right y (f y)) (ih hLe h)
+
+/-- Post-fixpoint entry point: `witer` starting from `bot`. -/
+def pfp
+    {Abstract : Type u}
+    {le : Abstract -> Abstract -> Prop}
+    {f : Abstract -> Abstract}
+    {widen : Widen Abstract}
+    (le_dec : ∀ a b : Abstract, Decidable (le a b))
+    (hWiden : WidenUpperBound le widen)
+    (bot : Abstract)
+    (hBot : ∀ a : Abstract, le bot a)
+    (acc : WAcc le f widen bot bot) : Abstract :=
+  witer le_dec hWiden (hBot bot) acc
+
 end Iteration
 end Framework
 end AbsInterpLTS

--- a/AbsInterpLTS/Framework/Iteration/Widening/Lemmas.lean
+++ b/AbsInterpLTS/Framework/Iteration/Widening/Lemmas.lean
@@ -44,8 +44,8 @@ theorem isPostFixpoint_pfp
     (bot : Abstract)
     (hBot : ∀ a : Abstract, le bot a)
     (acc : WAcc le f widen bot bot) :
-    IsPostFixpoint le f (pfp le_dec hWiden bot hBot acc) := by
-  exact isPostFixpoint_witer le_dec hWiden (hBot bot) acc
+    IsPostFixpoint le f (pfp le_dec hWiden bot hBot acc) :=
+  isPostFixpoint_witer le_dec hWiden (hBot bot) acc
 
 /--
 Gamma soundness from post-fixpoint property.

--- a/AbsInterpLTS/Framework/Iteration/Widening/Lemmas.lean
+++ b/AbsInterpLTS/Framework/Iteration/Widening/Lemmas.lean
@@ -1,0 +1,80 @@
+import Cslib.Init
+
+import AbsInterpLTS.Framework.Iteration.Widening.Defs
+import AbsInterpLTS.Framework.Iteration.NatIter
+import AbsInterpLTS.Framework.Soundness.Defs
+
+namespace AbsInterpLTS
+namespace Framework
+namespace Iteration
+
+open AbsInterpLTS.Framework
+
+universe u v
+
+/-- `witer` returns a post-fixpoint of `f`. -/
+theorem isPostFixpoint_witer
+    {Abstract : Type u}
+    {le : Abstract -> Abstract -> Prop}
+    {f : Abstract -> Abstract}
+    {widen : Widen Abstract}
+    (le_dec : ∀ a b : Abstract, Decidable (le a b))
+    (hWiden : WidenUpperBound le widen)
+    {x y : Abstract}
+    (hLe : le x y)
+    (acc : WAcc le f widen x y) :
+    IsPostFixpoint le f (witer le_dec hWiden hLe acc) := by
+  match acc with
+  | .intro _ _ ih_acc =>
+    simp [witer]
+    split
+    case isTrue h => exact h
+    case isFalse h =>
+      exact isPostFixpoint_witer le_dec hWiden
+        (hWiden.right y (f y)) (ih_acc hLe h)
+
+/-- `pfp` returns a post-fixpoint of `f`. -/
+theorem isPostFixpoint_pfp
+    {Abstract : Type u}
+    {le : Abstract -> Abstract -> Prop}
+    {f : Abstract -> Abstract}
+    {widen : Widen Abstract}
+    (le_dec : ∀ a b : Abstract, Decidable (le a b))
+    (hWiden : WidenUpperBound le widen)
+    (bot : Abstract)
+    (hBot : ∀ a : Abstract, le bot a)
+    (acc : WAcc le f widen bot bot) :
+    IsPostFixpoint le f (pfp le_dec hWiden bot hBot acc) := by
+  exact isPostFixpoint_witer le_dec hWiden (hBot bot) acc
+
+/--
+Gamma soundness from post-fixpoint property.
+
+If `postSharp` has a post-fixpoint `a` and `Sound` holds,
+then `∀ n, iterateNat post (gamma a) n ⊆ gamma a`.
+-/
+theorem sound_of_isPostFixpoint
+    {State : Type u} {Abstract : Type v}
+    {post : Post State}
+    {gamma : Gamma Abstract State}
+    {postSharp : PostSharp Abstract}
+    {le : Abstract -> Abstract -> Prop}
+    (hSound : Sound post gamma postSharp)
+    (hMono : MonotonePost post)
+    (gamma_mono : ∀ {a b : Abstract}, le a b -> gamma a ⊆ gamma b)
+    {a : Abstract}
+    (hFix : IsPostFixpoint le postSharp a) :
+    ∀ n, iterateNat post (gamma a) n ⊆ gamma a := by
+  intro n
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    simp only [iterateNat_succ]
+    calc post (iterateNat post (gamma a) n)
+        ⊆ post (gamma a) := hMono ih
+      _ ⊆ gamma (postSharp a) := hSound a
+      _ ⊆ gamma a := gamma_mono hFix
+
+end Iteration
+end Framework
+end AbsInterpLTS

--- a/Tests/Framework/Iteration/Widening.lean
+++ b/Tests/Framework/Iteration/Widening.lean
@@ -88,7 +88,7 @@ def flat3_acc : WAcc le f w .bot .bot := by
   -- Step 1: x=mid, y=top. f(top)=top, le top top, so done (vacuously)
   apply WAcc.intro
   intro _ h
-  exact absurd (by simp [f, le] : le (f .top) .top) h
+  exact absurd (le_refl (f .top)) h
 
 theorem hBot : ∀ a : Flat3, le .bot a := by
   intro a; cases a <;> simp [le]

--- a/Tests/Framework/Iteration/Widening.lean
+++ b/Tests/Framework/Iteration/Widening.lean
@@ -1,0 +1,134 @@
+import Cslib.Init
+
+import AbsInterpLTS
+
+namespace Tests
+namespace FrameworkIterationWidening
+
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Framework.Iteration
+
+/-! # Flat3 smoke test for widening/narrowing interfaces
+
+A toy 3-element flat lattice `{bot, mid, top}` exercising
+`WAcc`, `witer`, `pfp`, `IsPostFixpoint`, and `sound_of_isPostFixpoint`.
+-/
+
+/-- Three-element flat lattice. -/
+inductive Flat3 where
+  | bot
+  | mid
+  | top
+  deriving DecidableEq, Repr
+
+namespace Flat3
+
+/-- Flat order on `Flat3`. -/
+def le : Flat3 -> Flat3 -> Prop
+  | .bot, _ => True
+  | .mid, .mid => True
+  | .mid, .top => True
+  | .top, .top => True
+  | _, _ => False
+
+instance : DecidableRel le := by
+  intro a b
+  cases a <;> cases b <;> simp [le] <;> exact inferInstance
+
+theorem le_refl : ∀ a : Flat3, le a a := by
+  intro a; cases a <;> simp [le]
+
+theorem le_trans : ∀ a b c : Flat3, le a b -> le b c -> le a c := by
+  intro a b c hab hbc
+  cases a <;> cases b <;> cases c <;> simp_all [le]
+
+/-- Gamma concretization for Flat3 over Nat. -/
+def gamma : Flat3 -> Set Nat
+  | .bot => ∅
+  | .mid => {0}
+  | .top => Set.univ
+
+theorem gamma_mono : ∀ {a b : Flat3}, le a b -> gamma a ⊆ gamma b := by
+  intro a b hab
+  cases a <;> cases b <;> simp_all [le, gamma]
+
+/-- Abstract transfer: bot→mid, mid→top, top→top. -/
+def f : Flat3 -> Flat3
+  | .bot => .mid
+  | .mid => .top
+  | .top => .top
+
+/-- Widening: always jump to top (unless both equal). -/
+def w : Widen Flat3
+  | a, b => if a == b then a else .top
+
+@[simp] theorem w_ne {a b : Flat3} (h : a ≠ b) : w a b = .top := by
+  simp [w, h]
+
+@[simp] theorem w_eq {a : Flat3} : w a a = a := by
+  simp [w]
+
+theorem w_upper_bound : WidenUpperBound le w where
+  left := by
+    intro a b
+    by_cases h : a = b
+    · subst h; simp [le_refl]
+    · simp [h]; cases a <;> simp [le]
+  right := by
+    intro a b
+    by_cases h : a = b
+    · subst h; simp [le_refl]
+    · simp [h]; cases b <;> simp [le]
+
+/-- WAcc witness for the Flat3 example starting from bot. -/
+def flat3_acc : WAcc le f w .bot .bot := by
+  -- Step 0: x=bot, y=bot. f(bot)=mid, ¬ le mid bot, widen bot mid = top
+  apply WAcc.intro
+  intro _ _
+  -- Step 1: x=mid, y=top. f(top)=top, le top top, so done (vacuously)
+  apply WAcc.intro
+  intro _ h
+  exact absurd (by simp [f, le] : le (f .top) .top) h
+
+theorem hBot : ∀ a : Flat3, le .bot a := by
+  intro a; cases a <;> simp [le]
+
+/-- pfp on the Flat3 example yields top. -/
+theorem pfp_eq_top :
+    pfp (inferInstance) w_upper_bound .bot hBot flat3_acc = .top := by
+  native_decide
+
+/-- pfp result is indeed a post-fixpoint. -/
+theorem pfp_is_postfixpoint :
+    IsPostFixpoint le f
+      (pfp (inferInstance) w_upper_bound .bot hBot flat3_acc) := by
+  exact isPostFixpoint_pfp (inferInstance) w_upper_bound .bot hBot flat3_acc
+
+/-- Concrete post: add 0 to the set. -/
+def post : Post Nat :=
+  fun states => states ∪ {0}
+
+theorem post_monotone : MonotonePost post := by
+  intro s t hSubset x hx
+  rcases hx with hs | hz
+  · exact Or.inl (hSubset hs)
+  · exact Or.inr hz
+
+/-- Abstract post is sound w.r.t. concrete post and gamma. -/
+theorem post_sound : Sound post gamma (fun _ => Flat3.top) := by
+  intro a s hs
+  simp [gamma]
+
+/-- Exercise sound_of_isPostFixpoint: top is a post-fixpoint of (fun _ => top),
+    so all iterates stay within gamma top = univ. -/
+example : ∀ n, iterateNat post (gamma .top) n ⊆ gamma .top := by
+  apply sound_of_isPostFixpoint
+    (postSharp := fun _ => Flat3.top)
+    post_sound post_monotone
+    (fun h => gamma_mono h)
+  simp [IsPostFixpoint, le]
+
+end Flat3
+
+end FrameworkIterationWidening
+end Tests


### PR DESCRIPTION
## Summary
- Add widening/narrowing interfaces and iteration framework following N40AI paper's constructive approach (`WAcc`/`witer`/`pfp`)
- `WAcc` is a `Type u` inductive (not `Prop`) to allow structural recursion producing values
- `WidenUpperBound` contract ensures `widen a b` is above both `a` and `b`
- `IsPostFixpoint`, `isPostFixpoint_witer`, `isPostFixpoint_pfp` prove the iteration result is a post-fixpoint
- `sound_of_isPostFixpoint` connects post-fixpoint property to gamma soundness for all `iterateNat` steps
- Flat3 smoke test exercises the full pipeline (WAcc witness, pfp computation, soundness)

## Linked issue
Closes #3

## Scope
| File | Action |
|---|---|
| `Framework/Iteration/Widening/Defs.lean` | Edit: add Narrow, IsPostFixpoint, WidenUpperBound, WAcc, witer, pfp |
| `Framework/Iteration/Widening/Lemmas.lean` | Create: isPostFixpoint_witer, isPostFixpoint_pfp, sound_of_isPostFixpoint |
| `Framework/Iteration/Widening.lean` | Edit: add Lemmas barrel import |
| `Tests/Framework/Iteration/Widening.lean` | Create: Flat3 smoke test |

## Validation checklist
- [x] `lake build` passes
- [x] `lake build Tests` passes
- [x] `lake test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)