### PR TITLE
feat(domains): add Preorder instances for Sign and Interval

### DIFF
--- a/AbsInterpLTS/Domains/Interval.lean
+++ b/AbsInterpLTS/Domains/Interval.lean
@@ -48,7 +48,7 @@ theorem leInterval_trans {a b c : Interval} (hAB : leInterval a b) (hBC : leInte
 instance : Preorder Interval where
   le := leInterval
   le_refl := leInterval_refl
-  le_trans := fun {_ _ _} hAB hBC => leInterval_trans hAB hBC
+  le_trans := @leInterval_trans
 
 theorem gammaInterval_monotone_of_leInterval {a b : Interval} (hAB : a ≤ b) :
     gammaInterval a ⊆ gammaInterval b :=

--- a/AbsInterpLTS/Domains/Interval.lean
+++ b/AbsInterpLTS/Domains/Interval.lean
@@ -38,14 +38,17 @@ def gammaInterval : Interval -> Set Int
 def leInterval (a b : Interval) : Prop :=
   gammaInterval a ⊆ gammaInterval b
 
-instance : LE Interval where
-  le := leInterval
-
-theorem leInterval_refl (a : Interval) : a ≤ a :=
+theorem leInterval_refl (a : Interval) : leInterval a a :=
   fun _ hn => hn
 
-theorem leInterval_trans {a b c : Interval} (hAB : a ≤ b) (hBC : b ≤ c) : a ≤ c :=
+theorem leInterval_trans {a b c : Interval} (hAB : leInterval a b) (hBC : leInterval b c) :
+    leInterval a c :=
   fun _ hn => hBC (hAB hn)
+
+instance : Preorder Interval where
+  le := leInterval
+  le_refl := leInterval_refl
+  le_trans := fun {_ _ _} hAB hBC => leInterval_trans hAB hBC
 
 theorem gammaInterval_monotone_of_leInterval {a b : Interval} (hAB : a ≤ b) :
     gammaInterval a ⊆ gammaInterval b :=

--- a/AbsInterpLTS/Domains/Sign.lean
+++ b/AbsInterpLTS/Domains/Sign.lean
@@ -42,7 +42,7 @@ theorem leSign_trans {a b c : Sign} (hAB : leSign a b) (hBC : leSign b c) : leSi
 instance : Preorder Sign where
   le := leSign
   le_refl := leSign_refl
-  le_trans := fun {_ _ _} hAB hBC => leSign_trans hAB hBC
+  le_trans := @leSign_trans
 
 theorem gammaSign_monotone_of_leSign {a b : Sign} (hAB : a ≤ b) :
     gammaSign a ⊆ gammaSign b :=

--- a/AbsInterpLTS/Domains/Sign.lean
+++ b/AbsInterpLTS/Domains/Sign.lean
@@ -33,14 +33,16 @@ def gammaSign : Sign -> Set Int
 def leSign (a b : Sign) : Prop :=
   gammaSign a ⊆ gammaSign b
 
-instance : LE Sign where
-  le := leSign
-
-theorem leSign_refl (a : Sign) : a ≤ a :=
+theorem leSign_refl (a : Sign) : leSign a a :=
   fun _ hn => hn
 
-theorem leSign_trans {a b c : Sign} (hAB : a ≤ b) (hBC : b ≤ c) : a ≤ c :=
+theorem leSign_trans {a b c : Sign} (hAB : leSign a b) (hBC : leSign b c) : leSign a c :=
   fun _ hn => hBC (hAB hn)
+
+instance : Preorder Sign where
+  le := leSign
+  le_refl := leSign_refl
+  le_trans := fun {_ _ _} hAB hBC => leSign_trans hAB hBC
 
 theorem gammaSign_monotone_of_leSign {a b : Sign} (hAB : a ≤ b) :
     gammaSign a ⊆ gammaSign b :=

--- a/Tests/Domains/Sign.lean
+++ b/Tests/Domains/Sign.lean
@@ -53,7 +53,7 @@ example (n : Int) (hn : n ∈ gammaSign Sign.nonneg) :
 open AbsInterpLTS.Framework
 
 /-- The identity abstract transformer is monotone over Sign. -/
-example : MonotonePostSharp (fun a : Sign => a) :=
+example : MonotonePostSharp (id : Sign → Sign) :=
   MonotonePostSharp.id
 
 end DomainsSign

--- a/Tests/Domains/Sign.lean
+++ b/Tests/Domains/Sign.lean
@@ -50,5 +50,11 @@ example (n : Int) (hn : n ∈ gammaSign Sign.nonneg) :
     -n ∈ gammaSign (negTransfer Sign.nonneg) := by
   exact negTransfer_sound hn
 
+open AbsInterpLTS.Framework
+
+/-- The identity abstract transformer is monotone over Sign. -/
+example : MonotonePostSharp (fun a : Sign => a) :=
+  MonotonePostSharp.id
+
 end DomainsSign
 end Tests


### PR DESCRIPTION
## Summary
- Replace `LE Sign` / `LE Interval` with `Preorder Sign` / `Preorder Interval` instances, unlocking `MonotonePostSharp` for these domains
- Move `leSign_refl`/`leSign_trans` (and interval counterparts) before the instance declarations, stating them in terms of the raw `leSign`/`leInterval` to avoid circular dependency
- Add `MonotonePostSharp` smoke test in `Tests/Domains/Sign.lean`

Closes #36

## Scope
| File | Change |
|---|---|
| `AbsInterpLTS/Domains/Sign.lean` | `LE` → `Preorder` |
| `AbsInterpLTS/Domains/Interval.lean` | `LE` → `Preorder` |
| `Tests/Domains/Sign.lean` | `MonotonePostSharp` smoke example |

## Validation
- [x] `lake build` — no downstream breakage
- [x] `lake build Tests` — tests compile
- [x] `lake test` — tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)