### PR TITLE
refactor(instances): factor out common LTS analysis adapter

### DIFF
--- a/AbsInterpLTS/Instances/LTS.lean
+++ b/AbsInterpLTS/Instances/LTS.lean
@@ -3,5 +3,6 @@ import AbsInterpLTS.Instances.LTS.Semantics.Lemmas
 import AbsInterpLTS.Instances.LTS.Semantics.Collecting
 import AbsInterpLTS.Instances.LTS.Instantiation.Interface
 import AbsInterpLTS.Instances.LTS.Instantiation.Soundness
+import AbsInterpLTS.Instances.LTS.Analyses.Common
 import AbsInterpLTS.Instances.LTS.Analyses.Sign
 import AbsInterpLTS.Instances.LTS.Analyses.Interval

--- a/AbsInterpLTS/Instances/LTS/Analyses/Common.lean
+++ b/AbsInterpLTS/Instances/LTS/Analyses/Common.lean
@@ -1,0 +1,105 @@
+import Cslib.Init
+import Cslib.Foundations.Semantics.LTS.Basic
+
+import AbsInterpLTS.Framework.Soundness
+import AbsInterpLTS.Instances.LTS.Semantics.Concrete
+import AbsInterpLTS.Instances.LTS.Instantiation.Interface
+
+namespace AbsInterpLTS
+namespace Instances
+namespace LTS
+namespace Analyses
+
+open AbsInterpLTS.Framework
+
+universe u v w x
+
+/-- State concretization via an observation function into a domain concretization. -/
+abbrev ReadGamma
+    (Abstract : Type u)
+    (Observation : Type v)
+    (State : Type w) :=
+  (State -> Observation) -> Gamma Abstract State
+
+/-- Lift a concretization through a state observation function. -/
+def gammaStateOfRead
+    {Abstract : Type u}
+    {Observation : Type v}
+    {State : Type w}
+    (gamma : Abstract -> Set Observation) :
+    ReadGamma Abstract Observation State :=
+  fun read a => { s : State | read s ∈ gamma a }
+
+@[simp] theorem mem_gammaStateOfRead
+    {Abstract : Type u}
+    {Observation : Type v}
+    {State : Type w}
+    {gamma : Abstract -> Set Observation}
+    {read : State -> Observation}
+    {a : Abstract}
+    {s : State} :
+    s ∈ gammaStateOfRead gamma read a ↔ read s ∈ gamma a :=
+  Iff.rfl
+
+/--
+Local one-step soundness condition for readout-based abstract LTS analyses.
+
+This can be discharged by language-specific transition/transfer lemmas, then
+lifted to framework `SoundStep`.
+-/
+def StepSoundOfRead
+    {State : Type u}
+    {Label : Type v}
+    {Abstract : Type w}
+    {Observation : Type x}
+    (gamma : Abstract -> Set Observation)
+    (lts : Cslib.LTS State Label)
+    (read : State -> Observation)
+    (transfer : StepPostSharp Abstract Label) : Prop :=
+  ∀ (label : Label) (a : Abstract) (s s' : State),
+    s ∈ gammaStateOfRead gamma read a ->
+    lts.Tr s label s' ->
+    s' ∈ gammaStateOfRead gamma read (transfer label a)
+
+/-- Bridge from local readout-based soundness to framework `SoundStep`. -/
+theorem soundStep_postStep_of_stepSound
+    {State : Type u}
+    {Label : Type v}
+    {Abstract : Type w}
+    {Observation : Type x}
+    (gamma : Abstract -> Set Observation)
+    (lts : Cslib.LTS State Label)
+    (read : State -> Observation)
+    (transfer : StepPostSharp Abstract Label)
+    (hStep : StepSoundOfRead gamma lts read transfer) :
+    SoundStep (postStep lts) (gammaStateOfRead gamma read) transfer := by
+  intro label a s' hs'
+  rcases (Cslib.LTS.mem_setImage
+    (lts := lts)
+    (S := gammaStateOfRead gamma read a)
+    (μ := label)
+    (s' := s')).1 (by simpa [postStep] using hs') with ⟨s, hsMem, htr⟩
+  exact hStep label a s s' hsMem htr
+
+/-- Build an LTS abstraction from local readout-based soundness obligations. -/
+def abstractionOfStepSound
+    {State : Type u}
+    {Label : Type v}
+    {Abstract : Type w}
+    {Observation : Type x}
+    (gamma : Abstract -> Set Observation)
+    (lts : Cslib.LTS State Label)
+    (read : State -> Observation)
+    (transfer : StepPostSharp Abstract Label)
+    (hStep : StepSoundOfRead gamma lts read transfer) :
+    LTSAbstraction State Label Abstract :=
+  LTSAbstraction.ofExplicit
+    lts
+    (gammaStateOfRead gamma read)
+    transfer
+    (soundStep_postStep_of_stepSound gamma lts read transfer hStep)
+
+end Analyses
+end LTS
+end Instances
+end AbsInterpLTS

--- a/AbsInterpLTS/Instances/LTS/Analyses/Interval.lean
+++ b/AbsInterpLTS/Instances/LTS/Analyses/Interval.lean
@@ -1,10 +1,7 @@
 import Cslib.Init
-import Cslib.Foundations.Semantics.LTS.Basic
 
 import AbsInterpLTS.Domains.Interval
-import AbsInterpLTS.Framework.Soundness
-import AbsInterpLTS.Instances.LTS.Semantics.Concrete
-import AbsInterpLTS.Instances.LTS.Instantiation.Interface
+import AbsInterpLTS.Instances.LTS.Analyses.Common
 
 namespace AbsInterpLTS
 namespace Instances
@@ -17,13 +14,13 @@ open AbsInterpLTS.Domains
 universe u v
 
 /-- State concretization for the interval domain via an integer observation function. -/
-abbrev IntervalGamma (State : Type u) := (State -> Int) -> Gamma Interval State
+abbrev IntervalGamma (State : Type u) := ReadGamma Interval Int State
 
 /-- Lift `gammaInterval` to concrete states using a readout `State -> Int`. -/
 def gammaIntervalState
     {State : Type u} :
     IntervalGamma State :=
-  fun read a => { s : State | read s ∈ gammaInterval a }
+  gammaStateOfRead gammaInterval
 
 /-- Label-indexed interval transfer family. -/
 abbrev IntervalTransfer (Label : Type v) := Label -> Interval -> Interval
@@ -40,10 +37,7 @@ def IntervalStepSound
     (lts : Cslib.LTS State Label)
     (read : State -> Int)
     (transfer : IntervalTransfer Label) : Prop :=
-  ∀ (label : Label) (a : Interval) (s s' : State),
-    s ∈ gammaIntervalState read a ->
-    lts.Tr s label s' ->
-    s' ∈ gammaIntervalState read (transfer label a)
+  StepSoundOfRead gammaInterval lts read transfer
 
 /-- Bridge from local interval-transition soundness to framework `SoundStep`. -/
 theorem soundStep_postStep_interval_of_stepSound
@@ -54,13 +48,8 @@ theorem soundStep_postStep_interval_of_stepSound
     (transfer : IntervalTransfer Label)
     (hStep : IntervalStepSound lts read transfer) :
     SoundStep (postStep lts) (gammaIntervalState read) transfer := by
-  intro label a s' hs'
-  rcases (Cslib.LTS.mem_setImage
-    (lts := lts)
-    (S := gammaIntervalState read a)
-    (μ := label)
-    (s' := s')).1 (by simpa [postStep] using hs') with ⟨s, hsMem, htr⟩
-  exact hStep label a s s' hsMem htr
+  simpa [IntervalStepSound, gammaIntervalState] using
+    (soundStep_postStep_of_stepSound (gamma := gammaInterval) lts read transfer hStep)
 
 /-- Build an LTS abstraction from local interval-step soundness obligations. -/
 def intervalAbstractionOfStepSound
@@ -70,11 +59,8 @@ def intervalAbstractionOfStepSound
     (read : State -> Int)
     (transfer : IntervalTransfer Label)
     (hStep : IntervalStepSound lts read transfer) :
-    LTSAbstraction State Label Interval where
-  lts := lts
-  gamma := gammaIntervalState read
-  transfer := transfer
-  soundStep := soundStep_postStep_interval_of_stepSound lts read transfer hStep
+    LTSAbstraction State Label Interval :=
+  abstractionOfStepSound (gamma := gammaInterval) lts read transfer hStep
 
 end Analyses
 end LTS

--- a/AbsInterpLTS/Instances/LTS/Analyses/Sign.lean
+++ b/AbsInterpLTS/Instances/LTS/Analyses/Sign.lean
@@ -1,10 +1,7 @@
 import Cslib.Init
-import Cslib.Foundations.Semantics.LTS.Basic
 
 import AbsInterpLTS.Domains.Sign
-import AbsInterpLTS.Framework.Soundness
-import AbsInterpLTS.Instances.LTS.Semantics.Concrete
-import AbsInterpLTS.Instances.LTS.Instantiation.Interface
+import AbsInterpLTS.Instances.LTS.Analyses.Common
 
 namespace AbsInterpLTS
 namespace Instances
@@ -17,13 +14,13 @@ open AbsInterpLTS.Domains
 universe u v
 
 /-- State concretization for the sign domain via an integer observation function. -/
-abbrev SignGamma (State : Type u) := (State -> Int) -> Gamma Sign State
+abbrev SignGamma (State : Type u) := ReadGamma Sign Int State
 
 /-- Lift `gammaSign` to concrete states using a readout `State -> Int`. -/
 def gammaSignState
     {State : Type u} :
     SignGamma State :=
-  fun read a => { s : State | read s ∈ gammaSign a }
+  gammaStateOfRead gammaSign
 
 /-- Label-indexed sign transfer family. -/
 abbrev SignTransfer (Label : Type v) := Label -> Sign -> Sign
@@ -40,10 +37,7 @@ def SignStepSound
     (lts : Cslib.LTS State Label)
     (read : State -> Int)
     (transfer : SignTransfer Label) : Prop :=
-  ∀ (label : Label) (a : Sign) (s s' : State),
-    s ∈ gammaSignState read a ->
-    lts.Tr s label s' ->
-    s' ∈ gammaSignState read (transfer label a)
+  StepSoundOfRead gammaSign lts read transfer
 
 /-- Bridge from local sign-transition soundness to framework `SoundStep`. -/
 theorem soundStep_postStep_sign_of_stepSound
@@ -54,13 +48,8 @@ theorem soundStep_postStep_sign_of_stepSound
     (transfer : SignTransfer Label)
     (hStep : SignStepSound lts read transfer) :
     SoundStep (postStep lts) (gammaSignState read) transfer := by
-  intro label a s' hs'
-  rcases (Cslib.LTS.mem_setImage
-    (lts := lts)
-    (S := gammaSignState read a)
-    (μ := label)
-    (s' := s')).1 (by simpa [postStep] using hs') with ⟨s, hsMem, htr⟩
-  exact hStep label a s s' hsMem htr
+  simpa [SignStepSound, gammaSignState] using
+    (soundStep_postStep_of_stepSound (gamma := gammaSign) lts read transfer hStep)
 
 /-- Build an LTS abstraction from local sign-step soundness obligations. -/
 def signAbstractionOfStepSound
@@ -70,11 +59,8 @@ def signAbstractionOfStepSound
     (read : State -> Int)
     (transfer : SignTransfer Label)
     (hStep : SignStepSound lts read transfer) :
-    LTSAbstraction State Label Sign where
-  lts := lts
-  gamma := gammaSignState read
-  transfer := transfer
-  soundStep := soundStep_postStep_sign_of_stepSound lts read transfer hStep
+    LTSAbstraction State Label Sign :=
+  abstractionOfStepSound (gamma := gammaSign) lts read transfer hStep
 
 end Analyses
 end LTS

--- a/Tests/Instances/LTS/IntervalHook.lean
+++ b/Tests/Instances/LTS/IntervalHook.lean
@@ -31,7 +31,7 @@ theorem stepSoundToy :
   · rcases hZero with ⟨hLabel, hEq⟩
     subst hLabel
     subst hEq
-    simp [gammaIntervalState, readId, transferToy, gammaInterval, mk]
+    simp [readId, transferToy, gammaInterval, mk]
 
 example :
     SoundStep (postStep toyLTS) (gammaIntervalState readId) transferToy := by

--- a/Tests/Instances/LTS/SignHook.lean
+++ b/Tests/Instances/LTS/SignHook.lean
@@ -31,7 +31,7 @@ theorem stepSoundToy :
   · rcases hZero with ⟨hLabel, hEq⟩
     subst hLabel
     subst hEq
-    simp [gammaSignState, readId, transferToy, gammaSign]
+    simp [readId, transferToy, gammaSign]
 
 example :
     SoundStep (postStep toyLTS) (gammaSignState readId) transferToy := by


### PR DESCRIPTION
## Summary
- add a shared `Analyses/Common.lean` module for readout-based gamma lifting, local step soundness, and `LTSAbstraction` construction
- reduce the Sign and Interval LTS analysis adapters to thin compatibility wrappers over the shared bridge
- keep umbrella imports and hook tests aligned with the shared `simp` behavior

Closes #30

## Validation
- [x] `lake build`
- [x] `lake build Tests`
- [x] `lake test`