### PR TITLE
feat(lts): connect collecting fixpoint with trace soundness

### DIFF
--- a/AbsInterpLTS/Framework/Semantics/Concrete/Lemmas.lean
+++ b/AbsInterpLTS/Framework/Semantics/Concrete/Lemmas.lean
@@ -30,7 +30,7 @@ end Basic
 
 section Trace
 
-private theorem composePost_assoc
+theorem composePost_assoc
     {State : Type u}
     (post1 post2 post3 : Post State) :
     composePost (composePost post1 post2) post3 =
@@ -110,6 +110,37 @@ theorem liftTracePost_monotone_of_pointwise
           (h1 := hStepMono label)
           (h2 := ih)
           hSubset)
+
+/--
+Trace lifting distributes over list append via `composePost`.
+-/
+theorem liftTracePost_append
+    {State : Type u}
+    {Label : Type v}
+    (stepPost : Label -> Post State)
+    (ls1 ls2 : List Label) :
+    liftTracePost stepPost (ls1 ++ ls2) =
+      composePost (liftTracePost stepPost ls1) (liftTracePost stepPost ls2) := by
+  induction ls1 with
+  | nil =>
+      ext states
+      simp [composePost]
+  | cons l ls1 ih =>
+      simp [liftTracePost_cons, ih, composePost_assoc]
+
+/--
+Trace lifting with a single label appended applies that step last.
+-/
+theorem liftTracePost_snoc_apply
+    {State : Type u}
+    {Label : Type v}
+    (stepPost : Label -> Post State)
+    (labels : List Label)
+    (l : Label)
+    (init : Set State) :
+    liftTracePost stepPost (labels ++ [l]) init =
+      stepPost l (liftTracePost stepPost labels init) := by
+  simp [liftTracePost_append, composePost]
 
 end Trace
 

--- a/AbsInterpLTS/Instances/LTS.lean
+++ b/AbsInterpLTS/Instances/LTS.lean
@@ -1,6 +1,7 @@
 import AbsInterpLTS.Instances.LTS.Semantics.Concrete
 import AbsInterpLTS.Instances.LTS.Semantics.Lemmas
 import AbsInterpLTS.Instances.LTS.Semantics.Collecting
+import AbsInterpLTS.Instances.LTS.Semantics.CollectingTrace
 import AbsInterpLTS.Instances.LTS.Instantiation.Interface
 import AbsInterpLTS.Instances.LTS.Instantiation.Soundness
 import AbsInterpLTS.Instances.LTS.Analyses.Common

--- a/AbsInterpLTS/Instances/LTS/Semantics/Collecting.lean
+++ b/AbsInterpLTS/Instances/LTS/Semantics/Collecting.lean
@@ -65,6 +65,17 @@ theorem tr_mem_postAny
       (μ := label)
       (s' := s')).2 ⟨s, hs, htr⟩
 
+/-- Every labeled post-image is contained in the unlabeled collecting post. -/
+theorem postStep_subset_postAny
+    {State : Type u}
+    {Label : Type v}
+    (lts : Cslib.LTS State Label)
+    (label : Label)
+    (states : Set State) :
+    postStep lts label states ⊆ postAny lts states := by
+  intro s' hs'
+  exact ⟨label, hs'⟩
+
 theorem postAny_monotone
     {State : Type u}
     {Label : Type v}

--- a/AbsInterpLTS/Instances/LTS/Semantics/CollectingTrace.lean
+++ b/AbsInterpLTS/Instances/LTS/Semantics/CollectingTrace.lean
@@ -77,18 +77,19 @@ theorem liftTracePost_subset_kleeneNat
     (n : Nat)
     (hLen : labels.length ≤ n) :
     liftTracePost (postStep lts) labels init ⊆
-      (postAny_collectingStep lts).kleeneNat init (n + 1) := by
-  have h1 : init ⊆ (postAny_collectingStep lts).kleeneNat init 1 :=
-    (postAny_collectingStep lts).init_subset_kleeneNat_succ 0 init
-  have h2 : liftTracePost (postStep lts) labels init ⊆
-      liftTracePost (postStep lts) labels ((postAny_collectingStep lts).kleeneNat init 1) :=
-    liftTracePost_monotone_of_pointwise
-      (hStepMono := fun label => postStep_monotone lts label)
-      labels h1
-  have h3 := liftTracePost_kleeneNat_subset lts labels init 1
-  have h4 : 1 + labels.length ≤ n + 1 := by omega
-  have h5 := (postAny_collectingStep lts).kleeneNat_chain_of_le h4 init
-  exact Set.Subset.trans (Set.Subset.trans h2 h3) h5
+      (postAny_collectingStep lts).kleeneNat init (n + 1) :=
+  calc
+    liftTracePost (postStep lts) labels init
+    _ ⊆ liftTracePost (postStep lts) labels
+          ((postAny_collectingStep lts).kleeneNat init 1) :=
+        liftTracePost_monotone_of_pointwise
+          (hStepMono := fun label => postStep_monotone lts label)
+          labels
+          ((postAny_collectingStep lts).init_subset_kleeneNat_succ 0 init)
+    _ ⊆ (postAny_collectingStep lts).kleeneNat init (1 + labels.length) :=
+        liftTracePost_kleeneNat_subset lts labels init 1
+    _ ⊆ (postAny_collectingStep lts).kleeneNat init (n + 1) :=
+        (postAny_collectingStep lts).kleeneNat_chain_of_le (by omega) init
 
 /--
 **Theorem 2**: Every state in `kleeneNat (n + 1)` has a witnessing labeled trace
@@ -112,10 +113,9 @@ theorem kleeneNat_subset_iUnion_liftTracePost
       simp only [CollectingStep.kleeneNat_succ] at hs
       rcases hs with hInit | hPost
       · exact ⟨[], by simp, hInit⟩
-      · have hPost' : s ∈ postAny lts ((postAny_collectingStep lts).kleeneNat init (n + 1)) :=
-          hPost
-        rw [mem_postAny] at hPost'
-        rcases hPost' with ⟨s', hs'mem, label, htr⟩
+      · change s ∈ postAny lts ((postAny_collectingStep lts).kleeneNat init (n + 1)) at hPost
+        rw [mem_postAny] at hPost
+        rcases hPost with ⟨s', hs'mem, label, htr⟩
         rcases ih s' hs'mem with ⟨labels, hlen, hTrace⟩
         refine ⟨labels ++ [label], ?_, ?_⟩
         · simp; omega

--- a/AbsInterpLTS/Instances/LTS/Semantics/CollectingTrace.lean
+++ b/AbsInterpLTS/Instances/LTS/Semantics/CollectingTrace.lean
@@ -1,0 +1,149 @@
+import Cslib.Init
+import Mathlib.Data.Set.Lattice
+
+import AbsInterpLTS.Framework.Semantics
+import AbsInterpLTS.Framework.Iteration.Collecting
+import AbsInterpLTS.Instances.LTS.Semantics.Collecting
+import AbsInterpLTS.Instances.LTS.Semantics.Lemmas
+
+/-!
+# Collecting–Trace Bridge
+
+This file connects the two concrete semantic paths of the framework:
+
+1. **Trace path** (labeled): `postStep lts label` → `liftTracePost` → traces
+2. **Collecting path** (unlabeled): `postAny lts` → `CollectingStep` → `kleeneNat`
+
+The headline result is that the Kleene chain `kleeneNat (n+1)` equals the union
+of `liftTracePost` over all traces of length `≤ n`.
+-/
+
+namespace AbsInterpLTS
+namespace Instances
+namespace LTS
+
+open Cslib
+open AbsInterpLTS.Framework
+
+universe u v
+
+variable
+    {State : Type u}
+    {Label : Type v}
+    (lts : Cslib.LTS State Label)
+
+/--
+A single labeled step from a Kleene iterate lands in the next iterate.
+-/
+theorem postStep_kleeneNat_subset
+    (label : Label)
+    (init : Set State)
+    (m : Nat) :
+    postStep lts label ((postAny_collectingStep lts).kleeneNat init m) ⊆
+      (postAny_collectingStep lts).kleeneNat init (m + 1) := by
+  intro s' hs'
+  simp [CollectingStep.kleeneNat_succ]
+  right
+  exact postStep_subset_postAny lts label _ hs'
+
+/--
+A lifted trace from Kleene iterate `m` lands in iterate `m + labels.length`.
+-/
+theorem liftTracePost_kleeneNat_subset
+    (labels : List Label)
+    (init : Set State)
+    (m : Nat) :
+    liftTracePost (postStep lts) labels ((postAny_collectingStep lts).kleeneNat init m) ⊆
+      (postAny_collectingStep lts).kleeneNat init (m + labels.length) := by
+  induction labels generalizing m with
+  | nil =>
+      simp
+  | cons label labels ih =>
+      simp only [liftTracePost_cons, composePost, List.length_cons]
+      have hSub := postStep_kleeneNat_subset lts label init m
+      have hMono := liftTracePost_monotone_of_pointwise
+        (hStepMono := fun l => postStep_monotone lts l) labels hSub
+      have hlen : m + (labels.length + 1) = (m + 1) + labels.length := by omega
+      rw [hlen]
+      exact Set.Subset.trans hMono (ih (m + 1))
+
+/--
+**Theorem 1**: Any labeled trace of length `≤ n` from `init` is captured by
+`kleeneNat (n + 1)`.
+-/
+theorem liftTracePost_subset_kleeneNat
+    (labels : List Label)
+    (init : Set State)
+    (n : Nat)
+    (hLen : labels.length ≤ n) :
+    liftTracePost (postStep lts) labels init ⊆
+      (postAny_collectingStep lts).kleeneNat init (n + 1) := by
+  have h1 : init ⊆ (postAny_collectingStep lts).kleeneNat init 1 :=
+    (postAny_collectingStep lts).init_subset_kleeneNat_succ 0 init
+  have h2 : liftTracePost (postStep lts) labels init ⊆
+      liftTracePost (postStep lts) labels ((postAny_collectingStep lts).kleeneNat init 1) :=
+    liftTracePost_monotone_of_pointwise
+      (hStepMono := fun label => postStep_monotone lts label)
+      labels h1
+  have h3 := liftTracePost_kleeneNat_subset lts labels init 1
+  have h4 : 1 + labels.length ≤ n + 1 := by omega
+  have h5 := (postAny_collectingStep lts).kleeneNat_chain_of_le h4 init
+  exact Set.Subset.trans (Set.Subset.trans h2 h3) h5
+
+/--
+**Theorem 2**: Every state in `kleeneNat (n + 1)` has a witnessing labeled trace
+of length `≤ n`.
+-/
+theorem kleeneNat_subset_iUnion_liftTracePost
+    (init : Set State)
+    (n : Nat)
+    (s : State)
+    (hs : s ∈ (postAny_collectingStep lts).kleeneNat init (n + 1)) :
+    ∃ labels : List Label, labels.length ≤ n ∧
+      s ∈ liftTracePost (postStep lts) labels init := by
+  induction n generalizing s with
+  | zero =>
+      simp [CollectingStep.kleeneNat_succ, CollectingStep.kleeneNat_zero] at hs
+      rcases hs with hInit | hPost
+      · exact ⟨[], by simp, hInit⟩
+      · change s ∈ postAny lts ∅ at hPost
+        simp [mem_postAny] at hPost
+  | succ n ih =>
+      simp only [CollectingStep.kleeneNat_succ] at hs
+      rcases hs with hInit | hPost
+      · exact ⟨[], by simp, hInit⟩
+      · have hPost' : s ∈ postAny lts ((postAny_collectingStep lts).kleeneNat init (n + 1)) :=
+          hPost
+        rw [mem_postAny] at hPost'
+        rcases hPost' with ⟨s', hs'mem, label, htr⟩
+        rcases ih s' hs'mem with ⟨labels, hlen, hTrace⟩
+        refine ⟨labels ++ [label], ?_, ?_⟩
+        · simp; omega
+        · rw [liftTracePost_snoc_apply]
+          exact (Cslib.LTS.mem_setImage
+            (lts := lts)
+            (S := liftTracePost (postStep lts) labels init)
+            (μ := label)
+            (s' := s)).2 ⟨s', hTrace, htr⟩
+
+/--
+**Theorem 3**: Exact characterization of the Kleene chain in terms of trace unions.
+-/
+theorem kleeneNat_eq_iUnion_liftTracePost
+    (init : Set State)
+    (n : Nat) :
+    (postAny_collectingStep lts).kleeneNat init (n + 1) =
+      ⋃ (labels : List Label) (_ : labels.length ≤ n),
+        liftTracePost (postStep lts) labels init := by
+  ext s
+  simp only [Set.mem_iUnion]
+  constructor
+  · intro hs
+    rcases kleeneNat_subset_iUnion_liftTracePost lts init n s hs with ⟨labels, hlen, hmem⟩
+    exact ⟨labels, hlen, hmem⟩
+  · intro ⟨labels, hlen, hmem⟩
+    exact liftTracePost_subset_kleeneNat lts labels init n hlen hmem
+
+end LTS
+end Instances
+end AbsInterpLTS

--- a/Tests.lean
+++ b/Tests.lean
@@ -5,6 +5,7 @@ import Tests.Domains.Interval
 import Tests.Domains.Sign
 import Tests.Instances.LTS.Smoke
 import Tests.Instances.LTS.Collecting
+import Tests.Instances.LTS.CollectingTrace
 import Tests.Instances.LTS.IntervalHook
 import Tests.Instances.LTS.SignHook
 import Tests.Framework.Iteration.NatIter

--- a/Tests/Instances/LTS/CollectingTrace.lean
+++ b/Tests/Instances/LTS/CollectingTrace.lean
@@ -1,0 +1,70 @@
+import Cslib.Init
+
+import AbsInterpLTS
+
+namespace Tests
+namespace InstancesLTSCollectingTrace
+
+open AbsInterpLTS
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Instances.LTS
+
+/-- Reuse the toyLTS from Collecting tests: 0 →false→ 1, 0 →true→ 2, 2 →false→ 3. -/
+def toyLTS : Cslib.LTS Nat Bool where
+  Tr s label s' :=
+    (s = 0 ∧ label = false ∧ s' = 1) ∨
+    (s = 0 ∧ label = true ∧ s' = 2) ∨
+    (s = 2 ∧ label = false ∧ s' = 3)
+
+abbrev collectingToy : CollectingStep Nat := postAny_collectingStep toyLTS
+
+def initZero : Set Nat := {0}
+
+abbrev kleeneToy : Nat -> Set Nat := collectingToy.kleeneNat initZero
+
+/-! ## Theorem 1: traces are captured by collecting -/
+
+/-- Trace `[false]` from `{0}` reaches `{1}`, which is in `kleeneToy 2`. -/
+example : liftTracePost (postStep toyLTS) [false] initZero ⊆ kleeneToy 2 :=
+  liftTracePost_subset_kleeneNat toyLTS [false] initZero 1 (by simp)
+
+/-- Trace `[true, false]` from `{0}` is in `kleeneToy 3`. -/
+example : liftTracePost (postStep toyLTS) [true, false] initZero ⊆ kleeneToy 3 :=
+  liftTracePost_subset_kleeneNat toyLTS [true, false] initZero 2 (by simp)
+
+/-! ## Theorem 2: collecting states have witness traces -/
+
+/-- `3 ∈ kleeneToy 3` implies there is a witness trace of length ≤ 2. -/
+example : ∃ labels : List Bool, labels.length ≤ 2 ∧
+    (3 : Nat) ∈ liftTracePost (postStep toyLTS) labels initZero := by
+  have h3 : (3 : Nat) ∈ kleeneToy 3 := by
+    simp [CollectingStep.kleeneNat_succ, CollectingStep.kleeneNat_zero]
+    right
+    exact tr_mem_postAny
+      (lts := toyLTS)
+      (states := kleeneToy 2)
+      (s := 2)
+      (label := false)
+      (by
+        simp [CollectingStep.kleeneNat_succ, CollectingStep.kleeneNat_zero]
+        right
+        exact tr_mem_postAny
+          (lts := toyLTS)
+          (states := kleeneToy 1)
+          (s := 0)
+          (label := true)
+          (by simp [CollectingStep.kleeneNat_succ, CollectingStep.kleeneNat_zero, initZero])
+          (Or.inr (Or.inl ⟨rfl, rfl, rfl⟩)))
+      (Or.inr (Or.inr ⟨rfl, rfl, rfl⟩))
+  exact kleeneNat_subset_iUnion_liftTracePost toyLTS initZero 2 3 h3
+
+/-! ## Theorem 3: equality instantiation -/
+
+/-- Kleene chain at step 2 equals the union of traces of length ≤ 1. -/
+example : kleeneToy 2 =
+    ⋃ (labels : List Bool) (_ : labels.length ≤ 1),
+      liftTracePost (postStep toyLTS) labels initZero :=
+  kleeneNat_eq_iUnion_liftTracePost toyLTS initZero 1
+
+end InstancesLTSCollectingTrace
+end Tests


### PR DESCRIPTION
## Summary

- Add `liftTracePost_append` and `liftTracePost_snoc_apply` framework lemmas for composing trace lifting over list operations
- Add `postStep_subset_postAny` bridge lemma connecting labeled and unlabeled post operators
- Prove three headline theorems establishing that `kleeneNat(n+1)` exactly equals `⋃ {liftTracePost labels init | labels.length ≤ n}`:
  - `liftTracePost_subset_kleeneNat` (traces ⊆ collecting)
  - `kleeneNat_subset_iUnion_liftTracePost` (collecting ⊆ traces)
  - `kleeneNat_eq_iUnion_liftTracePost` (exact equality)
- Add smoke tests exercising all three theorems on `toyLTS`

## Linked issue

Closes #38

## Scope

| File | Action |
|------|--------|
| `Framework/Semantics/Concrete/Lemmas.lean` | Edit — un-private `composePost_assoc`, add append/snoc lemmas |
| `Instances/LTS/Semantics/Collecting.lean` | Edit — add `postStep_subset_postAny` |
| `Instances/LTS/Semantics/CollectingTrace.lean` | New — 5 bridge theorems |
| `Instances/LTS.lean` | Edit — barrel import |
| `Tests/Instances/LTS/CollectingTrace.lean` | New — smoke tests |
| `Tests.lean` | Edit — test barrel import |

## Validation checklist

- [x] `lake build` passes
- [x] `lake build Tests` passes
- [x] `lake test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)