### PR TITLE
feat(examples): IMP language with end-to-end Sign analysis

### DIFF
--- a/Examples.lean
+++ b/Examples.lean
@@ -1,0 +1,1 @@
+import Examples.IMP

--- a/Examples/IMP.lean
+++ b/Examples/IMP.lean
@@ -2,3 +2,5 @@ import Examples.IMP.Syntax
 import Examples.IMP.Semantics.Defs
 import Examples.IMP.Semantics.Lemmas
 import Examples.IMP.LTS
+import Examples.IMP.Programs.Assign
+import Examples.IMP.Programs.Branch

--- a/Examples/IMP.lean
+++ b/Examples/IMP.lean
@@ -1,0 +1,4 @@
+import Examples.IMP.Syntax
+import Examples.IMP.Semantics.Defs
+import Examples.IMP.Semantics.Lemmas
+import Examples.IMP.LTS

--- a/Examples/IMP/LTS.lean
+++ b/Examples/IMP/LTS.lean
@@ -1,0 +1,18 @@
+import Cslib.Init
+import Cslib.Foundations.Semantics.LTS.Basic
+
+import Examples.IMP.Semantics.Defs
+
+namespace Examples.IMP
+
+/--
+The IMP language packaged as an unlabeled (`Unit`) LTS.
+
+This general LTS covers all IMP programs and is provided for reference.
+For abstract analyses with non-trivial precision, use program-specific LTS
+instances (see `Examples.IMP.Programs`).
+-/
+def impLTS : Cslib.LTS Config Unit where
+  Tr c _ c' := Step c c'
+
+end Examples.IMP

--- a/Examples/IMP/Programs/Assign.lean
+++ b/Examples/IMP/Programs/Assign.lean
@@ -1,0 +1,65 @@
+import Cslib.Init
+import Cslib.Foundations.Semantics.LTS.Basic
+
+import AbsInterpLTS
+
+import Examples.IMP.Syntax
+import Examples.IMP.Semantics.Defs
+
+/-!
+# Sign Analysis of `x0 := 5`
+
+End-to-end demonstration of the abstract interpretation framework:
+1. Define a program-specific LTS encoding `x0 := 5`
+2. Connect the Sign domain via `ReadGamma`
+3. Prove one-step soundness (`SignStepSound`)
+4. Obtain trace soundness automatically (`soundTraceLifted`)
+-/
+
+namespace Examples.IMP.Programs
+
+open AbsInterpLTS
+open AbsInterpLTS.Domains
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Instances.LTS
+open AbsInterpLTS.Instances.LTS.Analyses
+
+/-! ## Program-specific LTS for `x0 := 5`
+
+State: `(Bool, Int)` — `(before/after, value of x0)`.
+A single transition sets x0 to 5.
+-/
+
+/-- LTS encoding `x0 := 5`. State = `(pending?, x0 value)`. -/
+def assignLTS : Cslib.LTS (Bool × Int) Unit where
+  Tr s _ s' := s.1 = true ∧ s'.1 = false ∧ s'.2 = 5
+
+/-- Observe x0 from the state. -/
+def readX0Assign : Bool × Int → Int := Prod.snd
+
+/-- Abstract transfer: after `x0 := 5`, the sign is positive. -/
+def transferAssign : Unit → Sign → Sign
+  | (), _ => .pos
+
+/-! ## Soundness -/
+
+/-- One-step sign soundness for the assignment LTS. -/
+theorem stepSoundAssign :
+    SignStepSound assignLTS readX0Assign transferAssign := by
+  intro _ _ _ s' _ htr
+  rcases htr with ⟨_, _, hVal⟩
+  simp [gammaStateOfRead, readX0Assign, transferAssign, gammaSign, hVal]
+
+/-- LTS abstraction for `x0 := 5` with the Sign domain. -/
+def assignSignAbstraction : LTSAbstraction (Bool × Int) Unit Sign :=
+  signAbstractionOfStepSound assignLTS readX0Assign transferAssign stepSoundAssign
+
+/-- Trace soundness obtained for free from one-step soundness. -/
+example :
+    SoundTrace
+      (liftTracePost (postStep assignLTS))
+      (gammaSignState readX0Assign)
+      (liftTracePostSharp transferAssign) :=
+  assignSignAbstraction.soundTraceLifted
+
+end Examples.IMP.Programs

--- a/Examples/IMP/Programs/Branch.lean
+++ b/Examples/IMP/Programs/Branch.lean
@@ -88,8 +88,7 @@ theorem stepSoundBranch :
     simp [gammaStateOfRead, readX0Branch, transferBranch, gammaSign, hVal]
   | takeThen =>
     rcases htr with ⟨_, hNe, _, hVal⟩
-    simp [gammaStateOfRead, readX0Branch] at hs ⊢
-    simp [transferBranch, hVal]
+    simp [gammaStateOfRead, readX0Branch, transferBranch, hVal] at hs ⊢
     cases a with
     | bot => exact absurd hs (by simp [gammaSign])
     | neg => simp [gammaSign] at hs ⊢; omega

--- a/Examples/IMP/Programs/Branch.lean
+++ b/Examples/IMP/Programs/Branch.lean
@@ -1,0 +1,117 @@
+import Cslib.Init
+import Cslib.Foundations.Semantics.LTS.Basic
+
+import AbsInterpLTS
+
+import Examples.IMP.Syntax
+import Examples.IMP.Semantics.Defs
+
+/-!
+# Sign Analysis of `x0 := 5; if x0 then x0 := x0 + 1 else x0 := 0`
+
+Demonstrates multi-label Sign analysis on a branching IMP program.
+The transfer function exploits branch conditions for precision:
+- `takeThen` guard (`x0 ≠ 0`) eliminates `zero` from the abstract state
+- `takeElse` guard (`x0 = 0`) pins the result to `.zero`
+-/
+
+namespace Examples.IMP.Programs
+
+open AbsInterpLTS
+open AbsInterpLTS.Domains
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Instances.LTS
+open AbsInterpLTS.Instances.LTS.Analyses
+
+/-! ## Program-specific LTS
+
+```
+init -[assignFive]-> test -[takeThen]-> doneTrue
+                          -[takeElse]-> doneFalse
+```
+-/
+
+/-- Program counter for the branch program. -/
+inductive BranchPC where
+  | init
+  | test
+  | doneTrue
+  | doneFalse
+  deriving DecidableEq, Repr
+
+/-- Transition labels for the branch program. -/
+inductive BranchLabel where
+  | assignFive
+  | takeThen
+  | takeElse
+  deriving DecidableEq, Repr
+
+/-- LTS for `x0 := 5; if x0 then x0 := x0 + 1 else x0 := 0`.
+    State = `(PC, x0 value)`. -/
+def branchLTS : Cslib.LTS (BranchPC × Int) BranchLabel where
+  Tr s label s' := match label with
+    | .assignFive => s.1 = .init ∧ s'.1 = .test ∧ s'.2 = 5
+    | .takeThen   => s.1 = .test ∧ s.2 ≠ 0 ∧ s'.1 = .doneTrue ∧ s'.2 = s.2 + 1
+    | .takeElse   => s.1 = .test ∧ s.2 = 0 ∧ s'.1 = .doneFalse ∧ s'.2 = 0
+
+/-- Observe x0 from the state. -/
+def readX0Branch : BranchPC × Int → Int := Prod.snd
+
+/--
+Abstract transfer for the branch program.
+
+Key precision gains from branch conditions:
+- `.takeThen, .zero => .bot`: x0 = 0 cannot take the true branch (vacuously sound)
+- `.takeThen, .pos => .pos`: positive + 1 is positive
+- `.takeThen, .nonneg => .pos`: nonneg ∧ ≠ 0 means positive, +1 stays positive
+-/
+def transferBranch : BranchLabel → Sign → Sign
+  | .assignFive, _ => .pos
+  | .takeThen, .bot => .bot
+  | .takeThen, .neg => .nonpos
+  | .takeThen, .zero => .bot
+  | .takeThen, .pos => .pos
+  | .takeThen, .nonpos => .nonpos
+  | .takeThen, .nonneg => .pos
+  | .takeThen, .top => .top
+  | .takeElse, _ => .zero
+
+/-! ## Soundness -/
+
+/-- One-step sign soundness for the branch LTS. -/
+theorem stepSoundBranch :
+    SignStepSound branchLTS readX0Branch transferBranch := by
+  intro label a s s' hs htr
+  cases label with
+  | assignFive =>
+    rcases htr with ⟨_, _, hVal⟩
+    simp [gammaStateOfRead, readX0Branch, transferBranch, gammaSign, hVal]
+  | takeThen =>
+    rcases htr with ⟨_, hNe, _, hVal⟩
+    simp [gammaStateOfRead, readX0Branch] at hs ⊢
+    simp [transferBranch, hVal]
+    cases a with
+    | bot => exact absurd hs (by simp [gammaSign])
+    | neg => simp [gammaSign] at hs ⊢; omega
+    | zero => simp [gammaSign] at hs; omega
+    | pos => simp [gammaSign] at hs ⊢; omega
+    | nonpos => simp [gammaSign] at hs ⊢; omega
+    | nonneg => simp [gammaSign] at hs ⊢; omega
+    | top => simp [gammaSign]
+  | takeElse =>
+    rcases htr with ⟨_, _, _, hVal⟩
+    simp [gammaStateOfRead, readX0Branch, transferBranch, gammaSign, hVal]
+
+/-- LTS abstraction for the branch program with the Sign domain. -/
+def branchSignAbstraction : LTSAbstraction (BranchPC × Int) BranchLabel Sign :=
+  signAbstractionOfStepSound branchLTS readX0Branch transferBranch stepSoundBranch
+
+/-- Trace soundness obtained for free from one-step soundness. -/
+example :
+    SoundTrace
+      (liftTracePost (postStep branchLTS))
+      (gammaSignState readX0Branch)
+      (liftTracePostSharp transferBranch) :=
+  branchSignAbstraction.soundTraceLifted
+
+end Examples.IMP.Programs

--- a/Examples/IMP/Semantics/Defs.lean
+++ b/Examples/IMP/Semantics/Defs.lean
@@ -1,0 +1,44 @@
+import Cslib.Init
+
+import Examples.IMP.Syntax
+
+namespace Examples.IMP
+
+/-- A store maps each variable to an integer value. -/
+abbrev Store := Var → Int
+
+/-- Update a store at variable `x` with value `v`. -/
+def Store.update (σ : Store) (x : Var) (v : Int) : Store :=
+  fun y => if x = y then v else σ y
+
+/-- Evaluate an arithmetic expression in a store. -/
+def eval (σ : Store) : Expr → Int
+  | .lit n => n
+  | .var x => σ x
+  | .add e1 e2 => eval σ e1 + eval σ e2
+
+/-- A configuration is either a running statement with a store, or a terminated store. -/
+inductive Config where
+  | running (s : Stmt) (σ : Store)
+  | done (σ : Store)
+
+/-- Small-step transition relation for IMP. -/
+inductive Step : Config → Config → Prop where
+  | skip {σ : Store} :
+      Step (.running .skip σ) (.done σ)
+  | assign {x : Var} {e : Expr} {σ : Store} :
+      Step (.running (.assign x e) σ) (.done (σ.update x (eval σ e)))
+  | seq_step {s1 s1' s2 : Stmt} {σ σ' : Store} :
+      Step (.running s1 σ) (.running s1' σ') →
+      Step (.running (.seq s1 s2) σ) (.running (.seq s1' s2) σ')
+  | seq_done {s1 s2 : Stmt} {σ σ' : Store} :
+      Step (.running s1 σ) (.done σ') →
+      Step (.running (.seq s1 s2) σ) (.running s2 σ')
+  | if_true {cond : Expr} {s1 s2 : Stmt} {σ : Store} :
+      eval σ cond ≠ 0 →
+      Step (.running (.ite cond s1 s2) σ) (.running s1 σ)
+  | if_false {cond : Expr} {s1 s2 : Stmt} {σ : Store} :
+      eval σ cond = 0 →
+      Step (.running (.ite cond s1 s2) σ) (.running s2 σ)
+
+end Examples.IMP

--- a/Examples/IMP/Semantics/Lemmas.lean
+++ b/Examples/IMP/Semantics/Lemmas.lean
@@ -1,0 +1,24 @@
+import Cslib.Init
+
+import Examples.IMP.Semantics.Defs
+
+namespace Examples.IMP
+
+@[simp] theorem Store.update_same (σ : Store) (x : Var) (v : Int) :
+    (σ.update x v) x = v := by
+  simp [Store.update]
+
+@[simp] theorem Store.update_other (σ : Store) (x y : Var) (v : Int) (hne : x ≠ y) :
+    (σ.update x v) y = σ y := by
+  simp [Store.update, hne]
+
+@[simp] theorem eval_lit (σ : Store) (n : Int) :
+    eval σ (.lit n) = n := rfl
+
+@[simp] theorem eval_var (σ : Store) (x : Var) :
+    eval σ (.var x) = σ x := rfl
+
+@[simp] theorem eval_add (σ : Store) (e1 e2 : Expr) :
+    eval σ (.add e1 e2) = eval σ e1 + eval σ e2 := rfl
+
+end Examples.IMP

--- a/Examples/IMP/Syntax.lean
+++ b/Examples/IMP/Syntax.lean
@@ -1,0 +1,26 @@
+import Cslib.Init
+
+namespace Examples.IMP
+
+/-- Program variables for the IMP language. Two variables suffice for examples. -/
+inductive Var where
+  | x0
+  | x1
+  deriving DecidableEq, Repr
+
+/-- Arithmetic expressions: integer literals, variable reads, and addition. -/
+inductive Expr where
+  | lit (n : Int)
+  | var (x : Var)
+  | add (e1 e2 : Expr)
+  deriving Repr
+
+/-- Statements: the core IMP constructs (no loops in this subset). -/
+inductive Stmt where
+  | skip
+  | assign (x : Var) (e : Expr)
+  | seq (s1 s2 : Stmt)
+  | ite (cond : Expr) (s1 s2 : Stmt)
+  deriving Repr
+
+end Examples.IMP

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -20,6 +20,9 @@ rev = "v4.28.0-rc1"
 name = "AbsInterpLTS"
 
 [[lean_lib]]
+name = "Examples"
+
+[[lean_lib]]
 name = "Tests"
 
 [[lean_exe]]


### PR DESCRIPTION
## Summary

- Define IMP language: `Var`, `Expr` (lit/var/add), `Stmt` (skip/assign/seq/ite), `Store`, `Config`, `Step` small-step relation
- Add end-to-end Sign analysis for two programs:
  - **Assign** (`x0 := 5`): single-transition LTS, proves x0 becomes `.pos`
  - **Branch** (`x0 := 5; if x0 then x0 := x0 + 1 else x0 := 0`): multi-label LTS with non-trivial transfer exploiting branch conditions (`.takeThen/.zero => .bot` since zero cannot take true branch)
- Both examples follow the full framework pipeline: define LTS → prove `SignStepSound` → build `LTSAbstraction` → obtain `SoundTrace` via `soundTraceLifted`

Closes #45, Closes #46, Closes #47

## Scope

| File | Purpose |
|------|---------|
| `Examples/IMP/Syntax.lean` | `Var`, `Expr`, `Stmt` types |
| `Examples/IMP/Semantics/Defs.lean` | `Store`, `eval`, `Config`, `Step` |
| `Examples/IMP/Semantics/Lemmas.lean` | `Store.update` and `eval` simp lemmas |
| `Examples/IMP/LTS.lean` | General `impLTS` (reference) |
| `Examples/IMP/Programs/Assign.lean` | Assignment Sign analysis end-to-end |
| `Examples/IMP/Programs/Branch.lean` | Branch Sign analysis end-to-end |
| `lakefile.toml` | Add `Examples` lean_lib |

## Test plan

- [x] `lake build` passes
- [x] `lake build Examples` passes (no warnings)
- [x] `lake build Tests` passes
- [x] `lake test` passes
- [x] No `sorry` in any file

🤖 Generated with [Claude Code](https://claude.com/claude-code)