### PR TITLE
feat(examples): label IMP LTS and add abstraction layer

### DIFF
--- a/Examples/IMP.lean
+++ b/Examples/IMP.lean
@@ -1,6 +1,7 @@
 import Examples.IMP.Syntax
 import Examples.IMP.Semantics.Defs
 import Examples.IMP.Semantics.Lemmas
+import Examples.IMP.Abstraction
 import Examples.IMP.LTS
 import Examples.IMP.Programs.Assign
 import Examples.IMP.Programs.Branch

--- a/Examples/IMP/Abstraction.lean
+++ b/Examples/IMP/Abstraction.lean
@@ -1,0 +1,2 @@
+import Examples.IMP.Abstraction.Defs
+import Examples.IMP.Abstraction.Lemmas

--- a/Examples/IMP/Abstraction/Defs.lean
+++ b/Examples/IMP/Abstraction/Defs.lean
@@ -11,21 +11,16 @@ open AbsInterpLTS.Framework.Domains
 
 universe u
 
-/-- Control locations for IMP configurations, forgetting concrete stores. -/
-inductive Control where
-  | running (s : Stmt)
-  | done
-  deriving DecidableEq, Repr
+/-- Control locations for textbook IMP configurations are just statements. -/
+abbrev Control := Stmt
 
 /-- Forget the store component of a concrete configuration. -/
 def controlOfConfig : Config → Control
-  | .running s _ => .running s
-  | .done _ => .done
+  | (s, _) => s
 
 /-- Forget the control component of a concrete configuration. -/
 def storeOfConfig : Config → Store
-  | .running _ σ => σ
-  | .done σ => σ
+  | (_, σ) => σ
 
 /-- Pointwise abstract store over the fixed IMP variable set. -/
 abbrev StoreSharp (Abstract : Type u) := Var → Abstract
@@ -100,7 +95,7 @@ def leConfigSharp
     {Abstract : Type u}
     (cfg : GammaOnlyDomain (StoreSharp Abstract) Store) :
     ConfigSharp Abstract → ConfigSharp Abstract → Prop :=
-  fun κ₁ κ₂ => ∀ pc : Control, cfg.le (κ₁ pc) (κ₂ pc)
+  fun κ₁ κ₂ => ∀ s : Control, cfg.le (κ₁ s) (κ₂ s)
 
 /-- Pointwise top element on abstract IMP configurations. -/
 def topConfigSharp
@@ -134,26 +129,20 @@ def configGammaOnlyDomain
     gamma_monotone := by
       intro κ₁ κ₂ hLe c hc
       cases c with
-      | running s σ =>
-          exact storeCfg.gamma_monotone (hLe (.running s)) hc
-      | done σ =>
-          exact storeCfg.gamma_monotone (hLe .done) hc
+      | mk s σ =>
+          exact storeCfg.gamma_monotone (hLe s) hc
     top := topConfigSharp storeCfg
     gamma_top := by
       intro c
       cases c with
-      | running s σ =>
-          exact storeCfg.gamma_top σ
-      | done σ =>
+      | mk s σ =>
           exact storeCfg.gamma_top σ
     join := joinConfigSharp storeCfg
     join_sound := by
       intro κ₁ κ₂ c hc
       cases c with
-      | running s σ =>
-          exact storeCfg.join_sound (κ₁ (.running s)) (κ₂ (.running s)) hc
-      | done σ =>
-          exact storeCfg.join_sound (κ₁ .done) (κ₂ .done) hc
+      | mk s σ =>
+          exact storeCfg.join_sound (κ₁ s) (κ₂ s) hc
   }
 
 end Examples.IMP

--- a/Examples/IMP/Abstraction/Defs.lean
+++ b/Examples/IMP/Abstraction/Defs.lean
@@ -1,0 +1,159 @@
+import Cslib.Init
+import Mathlib.Data.Set.Lattice
+
+import AbsInterpLTS.Framework.Domains
+import Examples.IMP.Semantics.Defs
+
+namespace Examples.IMP
+
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Framework.Domains
+
+universe u
+
+/-- Control locations for IMP configurations, forgetting concrete stores. -/
+inductive Control where
+  | running (s : Stmt)
+  | done
+  deriving DecidableEq, Repr
+
+/-- Forget the store component of a concrete configuration. -/
+def controlOfConfig : Config → Control
+  | .running s _ => .running s
+  | .done _ => .done
+
+/-- Forget the control component of a concrete configuration. -/
+def storeOfConfig : Config → Store
+  | .running _ σ => σ
+  | .done σ => σ
+
+/-- Pointwise abstract store over the fixed IMP variable set. -/
+abbrev StoreSharp (Abstract : Type u) := Var → Abstract
+
+/-- Pointwise abstract configurations indexed by IMP control locations. -/
+abbrev ConfigSharp (Abstract : Type u) := Control → StoreSharp Abstract
+
+/-- Lift a scalar concretization to IMP stores pointwise. -/
+def gammaStoreOf
+    {Abstract : Type u}
+    (gamma : Abstract → Set Int) :
+    Gamma (StoreSharp Abstract) Store :=
+  fun ρ => { σ : Store | ∀ x : Var, σ x ∈ gamma (ρ x) }
+
+/-- Lift a scalar concretization to IMP configurations via control-indexed stores. -/
+def gammaConfigOf
+    {Abstract : Type u}
+    (gamma : Abstract → Set Int) :
+    Gamma (ConfigSharp Abstract) Config :=
+  fun κ => { c : Config | storeOfConfig c ∈ gammaStoreOf gamma (κ (controlOfConfig c)) }
+
+/-- Pointwise order on abstract IMP stores. -/
+def leStoreSharp
+    {Abstract : Type u}
+    (cfg : GammaOnlyDomain Abstract Int) :
+    StoreSharp Abstract → StoreSharp Abstract → Prop :=
+  fun ρ₁ ρ₂ => ∀ x : Var, cfg.le (ρ₁ x) (ρ₂ x)
+
+/-- Pointwise top element on abstract IMP stores. -/
+def topStoreSharp
+    {Abstract : Type u}
+    (cfg : GammaOnlyDomain Abstract Int) :
+    StoreSharp Abstract :=
+  fun _ => cfg.top
+
+/-- Pointwise join on abstract IMP stores. -/
+def joinStoreSharp
+    {Abstract : Type u}
+    (cfg : GammaOnlyDomain Abstract Int) :
+    StoreSharp Abstract → StoreSharp Abstract → StoreSharp Abstract :=
+  fun ρ₁ ρ₂ x => cfg.join (ρ₁ x) (ρ₂ x)
+
+/-- Pointwise IMP-store domain lifted from a scalar integer domain. -/
+def storeGammaOnlyDomain
+    {Abstract : Type u}
+    (cfg : GammaOnlyDomain Abstract Int) :
+    GammaOnlyDomain (StoreSharp Abstract) Store where
+  gamma := gammaStoreOf cfg.gamma
+  le := leStoreSharp cfg
+  le_refl := by
+    intro ρ x
+    exact cfg.le_refl (ρ x)
+  le_trans := by
+    intro ρ₁ ρ₂ ρ₃ h12 h23 x
+    exact cfg.le_trans (h12 x) (h23 x)
+  gamma_monotone := by
+    intro ρ₁ ρ₂ hLe σ hσ x
+    exact cfg.gamma_monotone (hLe x) (hσ x)
+  top := topStoreSharp cfg
+  gamma_top := by
+    intro σ x
+    exact cfg.gamma_top (σ x)
+  join := joinStoreSharp cfg
+  join_sound := by
+    intro ρ₁ ρ₂ σ hσ x
+    rcases hσ with hσ | hσ
+    · exact cfg.join_sound (ρ₁ x) (ρ₂ x) (Or.inl (hσ x))
+    · exact cfg.join_sound (ρ₁ x) (ρ₂ x) (Or.inr (hσ x))
+
+/-- Pointwise order on abstract IMP configurations. -/
+def leConfigSharp
+    {Abstract : Type u}
+    (cfg : GammaOnlyDomain (StoreSharp Abstract) Store) :
+    ConfigSharp Abstract → ConfigSharp Abstract → Prop :=
+  fun κ₁ κ₂ => ∀ pc : Control, cfg.le (κ₁ pc) (κ₂ pc)
+
+/-- Pointwise top element on abstract IMP configurations. -/
+def topConfigSharp
+    {Abstract : Type u}
+    (cfg : GammaOnlyDomain (StoreSharp Abstract) Store) :
+    ConfigSharp Abstract :=
+  fun _ => cfg.top
+
+/-- Pointwise join on abstract IMP configurations. -/
+def joinConfigSharp
+    {Abstract : Type u}
+    (cfg : GammaOnlyDomain (StoreSharp Abstract) Store) :
+    ConfigSharp Abstract → ConfigSharp Abstract → ConfigSharp Abstract :=
+  fun κ₁ κ₂ pc => cfg.join (κ₁ pc) (κ₂ pc)
+
+/-- Pointwise IMP-configuration domain lifted from a scalar integer domain. -/
+def configGammaOnlyDomain
+    {Abstract : Type u}
+    (cfg : GammaOnlyDomain Abstract Int) :
+    GammaOnlyDomain (ConfigSharp Abstract) Config :=
+  let storeCfg := storeGammaOnlyDomain cfg
+  {
+    gamma := gammaConfigOf cfg.gamma
+    le := leConfigSharp storeCfg
+    le_refl := by
+      intro κ pc
+      exact storeCfg.le_refl (κ pc)
+    le_trans := by
+      intro κ₁ κ₂ κ₃ h12 h23 pc
+      exact storeCfg.le_trans (h12 pc) (h23 pc)
+    gamma_monotone := by
+      intro κ₁ κ₂ hLe c hc
+      cases c with
+      | running s σ =>
+          exact storeCfg.gamma_monotone (hLe (.running s)) hc
+      | done σ =>
+          exact storeCfg.gamma_monotone (hLe .done) hc
+    top := topConfigSharp storeCfg
+    gamma_top := by
+      intro c
+      cases c with
+      | running s σ =>
+          exact storeCfg.gamma_top σ
+      | done σ =>
+          exact storeCfg.gamma_top σ
+    join := joinConfigSharp storeCfg
+    join_sound := by
+      intro κ₁ κ₂ c hc
+      cases c with
+      | running s σ =>
+          exact storeCfg.join_sound (κ₁ (.running s)) (κ₂ (.running s)) hc
+      | done σ =>
+          exact storeCfg.join_sound (κ₁ .done) (κ₂ .done) hc
+  }
+
+end Examples.IMP

--- a/Examples/IMP/Abstraction/Defs.lean
+++ b/Examples/IMP/Abstraction/Defs.lean
@@ -85,10 +85,11 @@ def storeGammaOnlyDomain
     exact cfg.gamma_top (σ x)
   join := joinStoreSharp cfg
   join_sound := by
-    intro ρ₁ ρ₂ σ hσ x
-    rcases hσ with hσ | hσ
-    · exact cfg.join_sound (ρ₁ x) (ρ₂ x) (Or.inl (hσ x))
-    · exact cfg.join_sound (ρ₁ x) (ρ₂ x) (Or.inr (hσ x))
+    intro ρ₁ ρ₂ σ hUnion x
+    apply cfg.join_sound
+    rcases hUnion with hLeft | hRight
+    · exact Or.inl (hLeft x)
+    · exact Or.inr (hRight x)
 
 /-- Pointwise order on abstract IMP configurations. -/
 def leConfigSharp
@@ -128,21 +129,18 @@ def configGammaOnlyDomain
       exact storeCfg.le_trans (h12 pc) (h23 pc)
     gamma_monotone := by
       intro κ₁ κ₂ hLe c hc
-      cases c with
-      | mk s σ =>
-          exact storeCfg.gamma_monotone (hLe s) hc
+      exact storeCfg.gamma_monotone (hLe (controlOfConfig c)) hc
     top := topConfigSharp storeCfg
     gamma_top := by
       intro c
-      cases c with
-      | mk s σ =>
-          exact storeCfg.gamma_top σ
+      exact storeCfg.gamma_top (storeOfConfig c)
     join := joinConfigSharp storeCfg
     join_sound := by
       intro κ₁ κ₂ c hc
-      cases c with
-      | mk s σ =>
-          exact storeCfg.join_sound (κ₁ s) (κ₂ s) hc
+      change
+        storeOfConfig c ∈ gammaStoreOf cfg.gamma (κ₁ (controlOfConfig c)) ∪
+          gammaStoreOf cfg.gamma (κ₂ (controlOfConfig c)) at hc
+      exact storeCfg.join_sound (κ₁ (controlOfConfig c)) (κ₂ (controlOfConfig c)) hc
   }
 
 end Examples.IMP

--- a/Examples/IMP/Abstraction/Lemmas.lean
+++ b/Examples/IMP/Abstraction/Lemmas.lean
@@ -4,20 +4,12 @@ import Examples.IMP.Abstraction.Defs
 
 namespace Examples.IMP
 
-@[simp] theorem controlOfConfig_running (s : Stmt) (σ : Store) :
-    controlOfConfig (.running s σ) = .running s :=
+@[simp] theorem controlOfConfig_mk (s : Stmt) (σ : Store) :
+    controlOfConfig (s, σ) = s :=
   rfl
 
-@[simp] theorem controlOfConfig_done (σ : Store) :
-    controlOfConfig (.done σ) = .done :=
-  rfl
-
-@[simp] theorem storeOfConfig_running (s : Stmt) (σ : Store) :
-    storeOfConfig (.running s σ) = σ :=
-  rfl
-
-@[simp] theorem storeOfConfig_done (σ : Store) :
-    storeOfConfig (.done σ) = σ :=
+@[simp] theorem storeOfConfig_mk (s : Stmt) (σ : Store) :
+    storeOfConfig (s, σ) = σ :=
   rfl
 
 @[simp] theorem mem_gammaStoreOf
@@ -28,23 +20,14 @@ namespace Examples.IMP
     σ ∈ gammaStoreOf gamma ρ ↔ ∀ x : Var, σ x ∈ gamma (ρ x) :=
   Iff.rfl
 
-@[simp] theorem mem_gammaConfigOf_running
+@[simp] theorem mem_gammaConfigOf_mk
     {Abstract : Type _}
     {gamma : Abstract → Set Int}
     {κ : ConfigSharp Abstract}
     {s : Stmt}
     {σ : Store} :
-    (.running s σ) ∈ gammaConfigOf gamma κ ↔
-      σ ∈ gammaStoreOf gamma (κ (.running s)) :=
-  Iff.rfl
-
-@[simp] theorem mem_gammaConfigOf_done
-    {Abstract : Type _}
-    {gamma : Abstract → Set Int}
-    {κ : ConfigSharp Abstract}
-    {σ : Store} :
-    (.done σ) ∈ gammaConfigOf gamma κ ↔
-      σ ∈ gammaStoreOf gamma (κ .done) :=
+    (s, σ) ∈ gammaConfigOf gamma κ ↔
+      σ ∈ gammaStoreOf gamma (κ s) :=
   Iff.rfl
 
 end Examples.IMP

--- a/Examples/IMP/Abstraction/Lemmas.lean
+++ b/Examples/IMP/Abstraction/Lemmas.lean
@@ -1,0 +1,50 @@
+import Cslib.Init
+
+import Examples.IMP.Abstraction.Defs
+
+namespace Examples.IMP
+
+@[simp] theorem controlOfConfig_running (s : Stmt) (σ : Store) :
+    controlOfConfig (.running s σ) = .running s :=
+  rfl
+
+@[simp] theorem controlOfConfig_done (σ : Store) :
+    controlOfConfig (.done σ) = .done :=
+  rfl
+
+@[simp] theorem storeOfConfig_running (s : Stmt) (σ : Store) :
+    storeOfConfig (.running s σ) = σ :=
+  rfl
+
+@[simp] theorem storeOfConfig_done (σ : Store) :
+    storeOfConfig (.done σ) = σ :=
+  rfl
+
+@[simp] theorem mem_gammaStoreOf
+    {Abstract : Type _}
+    {gamma : Abstract → Set Int}
+    {ρ : StoreSharp Abstract}
+    {σ : Store} :
+    σ ∈ gammaStoreOf gamma ρ ↔ ∀ x : Var, σ x ∈ gamma (ρ x) :=
+  Iff.rfl
+
+@[simp] theorem mem_gammaConfigOf_running
+    {Abstract : Type _}
+    {gamma : Abstract → Set Int}
+    {κ : ConfigSharp Abstract}
+    {s : Stmt}
+    {σ : Store} :
+    (.running s σ) ∈ gammaConfigOf gamma κ ↔
+      σ ∈ gammaStoreOf gamma (κ (.running s)) :=
+  Iff.rfl
+
+@[simp] theorem mem_gammaConfigOf_done
+    {Abstract : Type _}
+    {gamma : Abstract → Set Int}
+    {κ : ConfigSharp Abstract}
+    {σ : Store} :
+    (.done σ) ∈ gammaConfigOf gamma κ ↔
+      σ ∈ gammaStoreOf gamma (κ .done) :=
+  Iff.rfl
+
+end Examples.IMP

--- a/Examples/IMP/LTS.lean
+++ b/Examples/IMP/LTS.lean
@@ -6,13 +6,13 @@ import Examples.IMP.Semantics.Defs
 namespace Examples.IMP
 
 /--
-The IMP language packaged as an unlabeled (`Unit`) LTS.
+The canonical labeled small-step LTS for IMP.
 
-This general LTS covers all IMP programs and is provided for reference.
-For abstract analyses with non-trivial precision, use program-specific LTS
-instances (see `Examples.IMP.Programs`).
+This general LTS covers all IMP programs and is the intended surface for
+generic abstract analyses. Program-specific examples remain under
+`Examples.IMP.Programs` temporarily, but are no longer the preferred path.
 -/
-def impLTS : Cslib.LTS Config Unit where
-  Tr c _ c' := Step c c'
+def impLTS : Cslib.LTS Config StepLabel where
+  Tr c μ c' := Step c μ c'
 
 end Examples.IMP

--- a/Examples/IMP/Semantics/Defs.lean
+++ b/Examples/IMP/Semantics/Defs.lean
@@ -17,38 +17,32 @@ def eval (σ : Store) : Expr → Int
   | .var x => σ x
   | .add e1 e2 => eval σ e1 + eval σ e2
 
-/-- A configuration is either a running statement with a store, or a terminated store. -/
-inductive Config where
-  | running (s : Stmt) (σ : Store)
-  | done (σ : Store)
+/-- IMP configurations pair the current statement with the current store. -/
+abbrev Config := Stmt × Store
 
 /-- Labels for the canonical small-step IMP LTS. -/
 inductive StepLabel where
-  | skip
   | assign
   | seqStep (μ : StepLabel)
-  | seqDone (μ : StepLabel)
+  | seqDone
   | ifTrue
   | ifFalse
   deriving DecidableEq, Repr
 
 /-- Labeled small-step transition relation for IMP. -/
 inductive Step : Config → StepLabel → Config → Prop where
-  | skip {σ : Store} :
-      Step (.running .skip σ) .skip (.done σ)
   | assign {x : Var} {e : Expr} {σ : Store} :
-      Step (.running (.assign x e) σ) .assign (.done (σ.update x (eval σ e)))
+      Step (.assign x e, σ) .assign (.skip, σ.update x (eval σ e))
   | seq_step {s1 s1' s2 : Stmt} {σ σ' : Store} {μ : StepLabel} :
-      Step (.running s1 σ) μ (.running s1' σ') →
-      Step (.running (.seq s1 s2) σ) (.seqStep μ) (.running (.seq s1' s2) σ')
-  | seq_done {s1 s2 : Stmt} {σ σ' : Store} {μ : StepLabel} :
-      Step (.running s1 σ) μ (.done σ') →
-      Step (.running (.seq s1 s2) σ) (.seqDone μ) (.running s2 σ')
+      Step (s1, σ) μ (s1', σ') →
+      Step (.seq s1 s2, σ) (.seqStep μ) (.seq s1' s2, σ')
+  | seq_done {s2 : Stmt} {σ : Store} :
+      Step (.seq .skip s2, σ) .seqDone (s2, σ)
   | if_true {cond : Expr} {s1 s2 : Stmt} {σ : Store} :
       eval σ cond ≠ 0 →
-      Step (.running (.ite cond s1 s2) σ) .ifTrue (.running s1 σ)
+      Step (.ite cond s1 s2, σ) .ifTrue (s1, σ)
   | if_false {cond : Expr} {s1 s2 : Stmt} {σ : Store} :
       eval σ cond = 0 →
-      Step (.running (.ite cond s1 s2) σ) .ifFalse (.running s2 σ)
+      Step (.ite cond s1 s2, σ) .ifFalse (s2, σ)
 
 end Examples.IMP

--- a/Examples/IMP/Semantics/Defs.lean
+++ b/Examples/IMP/Semantics/Defs.lean
@@ -22,23 +22,33 @@ inductive Config where
   | running (s : Stmt) (σ : Store)
   | done (σ : Store)
 
-/-- Small-step transition relation for IMP. -/
-inductive Step : Config → Config → Prop where
+/-- Labels for the canonical small-step IMP LTS. -/
+inductive StepLabel where
+  | skip
+  | assign
+  | seqStep (μ : StepLabel)
+  | seqDone (μ : StepLabel)
+  | ifTrue
+  | ifFalse
+  deriving DecidableEq, Repr
+
+/-- Labeled small-step transition relation for IMP. -/
+inductive Step : Config → StepLabel → Config → Prop where
   | skip {σ : Store} :
-      Step (.running .skip σ) (.done σ)
+      Step (.running .skip σ) .skip (.done σ)
   | assign {x : Var} {e : Expr} {σ : Store} :
-      Step (.running (.assign x e) σ) (.done (σ.update x (eval σ e)))
-  | seq_step {s1 s1' s2 : Stmt} {σ σ' : Store} :
-      Step (.running s1 σ) (.running s1' σ') →
-      Step (.running (.seq s1 s2) σ) (.running (.seq s1' s2) σ')
-  | seq_done {s1 s2 : Stmt} {σ σ' : Store} :
-      Step (.running s1 σ) (.done σ') →
-      Step (.running (.seq s1 s2) σ) (.running s2 σ')
+      Step (.running (.assign x e) σ) .assign (.done (σ.update x (eval σ e)))
+  | seq_step {s1 s1' s2 : Stmt} {σ σ' : Store} {μ : StepLabel} :
+      Step (.running s1 σ) μ (.running s1' σ') →
+      Step (.running (.seq s1 s2) σ) (.seqStep μ) (.running (.seq s1' s2) σ')
+  | seq_done {s1 s2 : Stmt} {σ σ' : Store} {μ : StepLabel} :
+      Step (.running s1 σ) μ (.done σ') →
+      Step (.running (.seq s1 s2) σ) (.seqDone μ) (.running s2 σ')
   | if_true {cond : Expr} {s1 s2 : Stmt} {σ : Store} :
       eval σ cond ≠ 0 →
-      Step (.running (.ite cond s1 s2) σ) (.running s1 σ)
+      Step (.running (.ite cond s1 s2) σ) .ifTrue (.running s1 σ)
   | if_false {cond : Expr} {s1 s2 : Stmt} {σ : Store} :
       eval σ cond = 0 →
-      Step (.running (.ite cond s1 s2) σ) (.running s2 σ)
+      Step (.running (.ite cond s1 s2) σ) .ifFalse (.running s2 σ)
 
 end Examples.IMP

--- a/Examples/IMP/Semantics/Lemmas.lean
+++ b/Examples/IMP/Semantics/Lemmas.lean
@@ -22,18 +22,17 @@ namespace Examples.IMP
     eval σ (.add e1 e2) = eval σ e1 + eval σ e2 := rfl
 
 @[simp] theorem step_skip_iff {σ : Store} {μ : StepLabel} {c' : Config} :
-    Step (.running .skip σ) μ c' ↔ μ = .skip ∧ c' = .done σ := by
+    Step (.skip, σ) μ c' ↔ False := by
   constructor
   · intro hStep
     cases hStep
-    simp
-  · rintro ⟨rfl, rfl⟩
-    exact Step.skip
+  · intro hFalse
+    exact False.elim hFalse
 
 @[simp] theorem step_assign_iff
     {x : Var} {e : Expr} {σ : Store} {μ : StepLabel} {c' : Config} :
-    Step (.running (.assign x e) σ) μ c' ↔
-      μ = .assign ∧ c' = .done (σ.update x (eval σ e)) := by
+    Step (.assign x e, σ) μ c' ↔
+      μ = .assign ∧ c' = (.skip, σ.update x (eval σ e)) := by
   constructor
   · intro hStep
     cases hStep
@@ -41,10 +40,20 @@ namespace Examples.IMP
   · rintro ⟨rfl, rfl⟩
     exact Step.assign
 
+@[simp] theorem step_seqDone_iff
+    {s2 : Stmt} {σ : Store} {c' : Config} :
+    Step (.seq .skip s2, σ) .seqDone c' ↔ c' = (s2, σ) := by
+  constructor
+  · intro hStep
+    cases hStep
+    simp
+  · rintro rfl
+    exact Step.seq_done
+
 @[simp] theorem step_ifTrue_iff
     {cond : Expr} {s1 s2 : Stmt} {σ : Store} {c' : Config} :
-    Step (.running (.ite cond s1 s2) σ) .ifTrue c' ↔
-      eval σ cond ≠ 0 ∧ c' = .running s1 σ := by
+    Step (.ite cond s1 s2, σ) .ifTrue c' ↔
+      eval σ cond ≠ 0 ∧ c' = (s1, σ) := by
   constructor
   · intro hStep
     cases hStep with
@@ -55,8 +64,8 @@ namespace Examples.IMP
 
 @[simp] theorem step_ifFalse_iff
     {cond : Expr} {s1 s2 : Stmt} {σ : Store} {c' : Config} :
-    Step (.running (.ite cond s1 s2) σ) .ifFalse c' ↔
-      eval σ cond = 0 ∧ c' = .running s2 σ := by
+    Step (.ite cond s1 s2, σ) .ifFalse c' ↔
+      eval σ cond = 0 ∧ c' = (s2, σ) := by
   constructor
   · intro hStep
     cases hStep with
@@ -67,22 +76,20 @@ namespace Examples.IMP
 
 theorem Step.seqStep_inv
     {s1 s2 : Stmt} {σ : Store} {μ : StepLabel} {c' : Config}
-    (hStep : Step (.running (.seq s1 s2) σ) (.seqStep μ) c') :
+    (hStep : Step (.seq s1 s2, σ) (.seqStep μ) c') :
     ∃ s1' σ',
-      c' = .running (.seq s1' s2) σ' ∧
-      Step (.running s1 σ) μ (.running s1' σ') := by
+      c' = (.seq s1' s2, σ') ∧
+      Step (s1, σ) μ (s1', σ') := by
   cases hStep with
   | seq_step hInner =>
       exact ⟨_, _, rfl, hInner⟩
 
 theorem Step.seqDone_inv
-    {s1 s2 : Stmt} {σ : Store} {μ : StepLabel} {c' : Config}
-    (hStep : Step (.running (.seq s1 s2) σ) (.seqDone μ) c') :
-    ∃ σ',
-      c' = .running s2 σ' ∧
-      Step (.running s1 σ) μ (.done σ') := by
+    {s2 : Stmt} {σ : Store} {c' : Config}
+    (hStep : Step (.seq .skip s2, σ) .seqDone c') :
+    c' = (s2, σ) := by
   cases hStep with
-  | seq_done hInner =>
-      exact ⟨_, rfl, hInner⟩
+  | seq_done =>
+      rfl
 
 end Examples.IMP

--- a/Examples/IMP/Semantics/Lemmas.lean
+++ b/Examples/IMP/Semantics/Lemmas.lean
@@ -21,4 +21,68 @@ namespace Examples.IMP
 @[simp] theorem eval_add (σ : Store) (e1 e2 : Expr) :
     eval σ (.add e1 e2) = eval σ e1 + eval σ e2 := rfl
 
+@[simp] theorem step_skip_iff {σ : Store} {μ : StepLabel} {c' : Config} :
+    Step (.running .skip σ) μ c' ↔ μ = .skip ∧ c' = .done σ := by
+  constructor
+  · intro hStep
+    cases hStep
+    simp
+  · rintro ⟨rfl, rfl⟩
+    exact Step.skip
+
+@[simp] theorem step_assign_iff
+    {x : Var} {e : Expr} {σ : Store} {μ : StepLabel} {c' : Config} :
+    Step (.running (.assign x e) σ) μ c' ↔
+      μ = .assign ∧ c' = .done (σ.update x (eval σ e)) := by
+  constructor
+  · intro hStep
+    cases hStep
+    simp
+  · rintro ⟨rfl, rfl⟩
+    exact Step.assign
+
+@[simp] theorem step_ifTrue_iff
+    {cond : Expr} {s1 s2 : Stmt} {σ : Store} {c' : Config} :
+    Step (.running (.ite cond s1 s2) σ) .ifTrue c' ↔
+      eval σ cond ≠ 0 ∧ c' = .running s1 σ := by
+  constructor
+  · intro hStep
+    cases hStep with
+    | if_true hCond =>
+        simp [hCond]
+  · rintro ⟨hCond, rfl⟩
+    exact Step.if_true hCond
+
+@[simp] theorem step_ifFalse_iff
+    {cond : Expr} {s1 s2 : Stmt} {σ : Store} {c' : Config} :
+    Step (.running (.ite cond s1 s2) σ) .ifFalse c' ↔
+      eval σ cond = 0 ∧ c' = .running s2 σ := by
+  constructor
+  · intro hStep
+    cases hStep with
+    | if_false hCond =>
+        simp [hCond]
+  · rintro ⟨hCond, rfl⟩
+    exact Step.if_false hCond
+
+theorem Step.seqStep_inv
+    {s1 s2 : Stmt} {σ : Store} {μ : StepLabel} {c' : Config}
+    (hStep : Step (.running (.seq s1 s2) σ) (.seqStep μ) c') :
+    ∃ s1' σ',
+      c' = .running (.seq s1' s2) σ' ∧
+      Step (.running s1 σ) μ (.running s1' σ') := by
+  cases hStep with
+  | seq_step hInner =>
+      exact ⟨_, _, rfl, hInner⟩
+
+theorem Step.seqDone_inv
+    {s1 s2 : Stmt} {σ : Store} {μ : StepLabel} {c' : Config}
+    (hStep : Step (.running (.seq s1 s2) σ) (.seqDone μ) c') :
+    ∃ σ',
+      c' = .running s2 σ' ∧
+      Step (.running s1 σ) μ (.done σ') := by
+  cases hStep with
+  | seq_done hInner =>
+      exact ⟨_, rfl, hInner⟩
+
 end Examples.IMP

--- a/Examples/IMP/Syntax.lean
+++ b/Examples/IMP/Syntax.lean
@@ -13,7 +13,7 @@ inductive Expr where
   | lit (n : Int)
   | var (x : Var)
   | add (e1 e2 : Expr)
-  deriving Repr
+  deriving DecidableEq, Repr
 
 /-- Statements: the core IMP constructs (no loops in this subset). -/
 inductive Stmt where
@@ -21,6 +21,6 @@ inductive Stmt where
   | assign (x : Var) (e : Expr)
   | seq (s1 s2 : Stmt)
   | ite (cond : Expr) (s1 s2 : Stmt)
-  deriving Repr
+  deriving DecidableEq, Repr
 
 end Examples.IMP


### PR DESCRIPTION
## Summary

- label the canonical IMP small-step semantics and expose `impLTS` as `Cslib.LTS Config StepLabel`
- switch IMP configurations to the textbook shape `Stmt × Store`, using `skip` as the final-form command instead of a separate `done` constructor
- add IMP-side abstraction modules for statement-indexed abstract stores/configurations and lifted gamma-only domains
- add helper lemmas for labeled stepping while keeping the current program-specific examples building

## Linked issue

- Closes #49

## Scope

- In scope:
  - labeled IMP step relation and labeled `impLTS`
  - textbook-style IMP configurations and final-form handling
  - IMP abstraction layer for statement-indexed abstract stores/configurations
  - helper lemmas and barrel exports needed by later generic analyses
- Out of scope:
  - generic Sign and Interval transfers over `impLTS`
  - `while` and widening examples
  - variable generalization beyond `x0` and `x1`

## Validation

- [x] `lake build`
- [x] `lake build Tests`
- [x] `lake test`

## Checklist

- [x] Branch name follows `issue-<n>-<short-slug>`
- [x] PR title uses Conventional format
- [x] Changes are limited to this issue scope
- [x] Tests/docs updated for behavior changes