### PR TITLE
chore(repo): align build, test, and docs with Examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@ A reusable abstract interpretation framework built on [cslib](https://github.com
 ## Build & Test
 
 ```bash
-lake build              # Build main library (AbsInterpLTS)
+lake build              # Build default libraries (AbsInterpLTS, Examples)
+lake build Examples     # Build example library explicitly
 lake build Tests        # Build test suite
 lake test               # Run test driver (includes build)
 ```
@@ -38,6 +39,11 @@ Instances/LTS/          cslib LTS-specific instantiation
 Domains/                Concrete abstract domains
   Sign.lean             7-point sign lattice
   Interval.lean         bot/range(lo,hi)/top interval domain
+
+Examples/IMP/           Loop-free IMP case study
+  Semantics/            Syntax, small-step semantics, and labeled IMP LTS
+  Analysis/             Generic Sign analysis over IMP configurations
+  Programs/             Small case studies and end-to-end showcase traces
 ```
 
 **Core theorem chain**: `SoundStep` -> `soundTrace_of_soundStep` -> `SoundTrace`

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # absinterp-lts
 
-`absinterp-lts` is an independent Lean 4 staging repository for reusable abstract interpretation constructions over CSLib semantics.
+`absinterp-lts` is an independent Lean 4 repository for reusable abstract interpretation constructions over CSLib semantics.
 
 ## Project status
 
-This repository is intentionally in a staged bootstrap phase.
+The project now has a usable core:
 
-- Repository workflow, CI, and issue tracking are set up first.
-- Framework modules expose stable interfaces with minimal implementation.
-- Detailed formalization is added incrementally through issue-scoped PRs.
+- a reusable `gamma`-only abstract interpretation framework over LTS-style semantics
+- a CSLib-LTS instantiation with soundness lifting from one-step to traces
+- collecting-semantics infrastructure and a collecting/trace bridge
+- concrete Sign and Interval domains
+- a loop-free IMP case study showing how to build a generic abstract interpreter on top of the framework
+
+The remaining staged work is mostly about broadening coverage: more domains,
+more iteration/fixpoint case studies, and richer language examples.
 
 ## Initial architecture
 
@@ -21,14 +26,20 @@ This repository is intentionally in a staged bootstrap phase.
   - `Instantiation`: framework-to-LTS abstraction/soundness instantiation layer.
   - `Analyses`: domain-specific analysis instances over LTS (staged).
 - `AbsInterpLTS/Domains`: sign and interval domain interfaces.
+- `Examples/IMP`: a loop-free IMP case study with a generic Sign analysis over
+  the canonical IMP LTS.
 
 ## Build and test
 
 ```bash
 lake build
+lake build Examples
 lake build Tests
 lake test
 ```
+
+`lake build` builds the main library and the example library. `lake test`
+checks that the default libraries and the test suite both compile.
 
 ## Development workflow
 

--- a/Tests.lean
+++ b/Tests.lean
@@ -11,4 +11,5 @@ import Tests.Instances.LTS.CollectingTrace
 import Tests.Instances.LTS.IntervalHook
 import Tests.Instances.LTS.SignHook
 import Tests.Framework.Iteration.NatIter
+import Tests.Framework.Iteration.Widening
 import Tests.Framework.Semantics.AbstractOrder

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,6 +1,6 @@
 name = "absinterp-lts"
 version = "0.1.0"
-defaultTargets = ["AbsInterpLTS"]
+defaultTargets = ["AbsInterpLTS", "Examples"]
 testDriver = "runTests"
 
 [leanOptions]

--- a/scripts/RunTests.lean
+++ b/scripts/RunTests.lean
@@ -4,10 +4,10 @@ def runLake (args : Array String) : IO UInt32 := do
   IO.Process.spawn { cmd := "lake", args := args } >>= (·.wait)
 
 def main (_ : List String) : IO UInt32 := do
-  IO.println "building AbsInterpLTS..."
+  IO.println "building default libraries..."
   let buildResult <- runLake #["build"]
   if buildResult != 0 then
-    IO.eprintln "build failed"
+    IO.eprintln "default library build failed"
     return buildResult
 
   IO.println "building Tests..."
@@ -16,5 +16,5 @@ def main (_ : List String) : IO UInt32 := do
     IO.eprintln "test build failed"
     return testsBuildResult
 
-  IO.println "bootstrap checks passed"
+  IO.println "all build checks passed"
   return 0


### PR DESCRIPTION
## Summary
- include `Examples` in the default build targets so `lake build` validates the flagship IMP case study
- update the test driver and top-level `Tests` wiring so the documented validation path matches intended coverage
- refresh `README.md` and `CLAUDE.md` so the repository architecture and build flow reflect the current post-IMP state

## Linked Issue
Closes #57

## Scope
- Repo hygiene and validation-flow alignment only
- No semantic changes to the framework, domains, or IMP analyses

## Validation
- `lake build`
- `lake build Tests`
- `lake test`
