### PR TITLE
chore(framework): remove compatibility re-export files under Semantics/Collecting

### DIFF
--- a/AbsInterpLTS/Framework/Semantics.lean
+++ b/AbsInterpLTS/Framework/Semantics.lean
@@ -1,4 +1,3 @@
 import AbsInterpLTS.Framework.Semantics.TraceLift
 import AbsInterpLTS.Framework.Semantics.Concrete
-import AbsInterpLTS.Framework.Semantics.Collecting
 import AbsInterpLTS.Framework.Semantics.Abstract

--- a/AbsInterpLTS/Framework/Semantics/Collecting.lean
+++ b/AbsInterpLTS/Framework/Semantics/Collecting.lean
@@ -1,3 +1,0 @@
-import AbsInterpLTS.Framework.Semantics.Concrete.Collecting
-/-! Compatibility re-export. Canonical location:
-`AbsInterpLTS.Framework.Semantics.Concrete.Collecting` -/

--- a/AbsInterpLTS/Framework/Semantics/Collecting/Defs.lean
+++ b/AbsInterpLTS/Framework/Semantics/Collecting/Defs.lean
@@ -1,3 +1,0 @@
-import AbsInterpLTS.Framework.Semantics.Concrete.Collecting.Defs
-/-! Compatibility re-export. Canonical location:
-`AbsInterpLTS.Framework.Semantics.Concrete.Collecting.Defs` -/

--- a/AbsInterpLTS/Framework/Semantics/Collecting/Lemmas.lean
+++ b/AbsInterpLTS/Framework/Semantics/Collecting/Lemmas.lean
@@ -1,3 +1,0 @@
-import AbsInterpLTS.Framework.Semantics.Concrete.Collecting.Lemmas
-/-! Compatibility re-export. Canonical location:
-`AbsInterpLTS.Framework.Semantics.Concrete.Collecting.Lemmas` -/


### PR DESCRIPTION
## Summary

- Delete three compatibility re-export shim files under `Framework/Semantics/Collecting/` left over from #32
- Remove redundant `Semantics.Collecting` import from the `Semantics.lean` barrel (already covered by `Semantics.Concrete`)

Closes #61

## Scope

Pure deletion — no logic or API changes.

## Validation

- `lake build` (821 jobs) — pass
- `lake build Tests` (833 jobs) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)