### PR TITLE
refactor(examples): move ActiveIn/gammaProgramConfigOf to Abstraction layer

### DIFF
--- a/Examples/IMP/Abstraction.lean
+++ b/Examples/IMP/Abstraction.lean
@@ -1,2 +1,3 @@
 import Examples.IMP.Abstraction.Defs
 import Examples.IMP.Abstraction.Lemmas
+import Examples.IMP.Abstraction.ActiveIn

--- a/Examples/IMP/Abstraction/ActiveIn.lean
+++ b/Examples/IMP/Abstraction/ActiveIn.lean
@@ -1,7 +1,7 @@
 import Cslib.Init
 
 import AbsInterpLTS.Framework.Soundness
-import Examples.IMP.Abstraction
+import Examples.IMP.Abstraction.Defs
 
 namespace Examples.IMP
 

--- a/Examples/IMP/Analysis.lean
+++ b/Examples/IMP/Analysis.lean
@@ -1,2 +1,1 @@
-import Examples.IMP.Analysis.Common
 import Examples.IMP.Analysis.Sign

--- a/Examples/IMP/Analysis/Sign/Defs.lean
+++ b/Examples/IMP/Analysis/Sign/Defs.lean
@@ -4,7 +4,7 @@ import Mathlib.Data.Set.Lattice
 import AbsInterpLTS.Domains
 import AbsInterpLTS.Framework
 import AbsInterpLTS.Instances.LTS
-import Examples.IMP.Analysis.Common
+import Examples.IMP.Abstraction
 import Examples.IMP.LTS
 import Examples.IMP.Semantics
 


### PR DESCRIPTION
## Summary

- Move `ActiveIn`, `ActiveIn.self`, `gammaProgramConfigOf`, and `mem_gammaProgramConfigOf_mk` from `Analysis/Common.lean` to `Abstraction/ActiveIn.lean`
- These are analysis-agnostic IMP infrastructure — future analyses (Interval, etc.) depend on them without needing analysis-specific imports

Closes #64

## Scope

- New: `Examples/IMP/Abstraction/ActiveIn.lean`
- Updated: `Abstraction.lean` barrel, `Analysis.lean` barrel, `Analysis/Sign/Defs.lean` import
- Deleted: `Examples/IMP/Analysis/Common.lean`

## Validation

- `lake build` (821 jobs) — pass
- `lake build Tests` (833 jobs) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)