### PR TITLE
refactor(instances): split LTS barrel into core and domain-analysis imports

### DIFF
--- a/AbsInterpLTS/Instances/LTS.lean
+++ b/AbsInterpLTS/Instances/LTS.lean
@@ -1,9 +1,4 @@
-import AbsInterpLTS.Instances.LTS.Semantics.Concrete
-import AbsInterpLTS.Instances.LTS.Semantics.Lemmas
-import AbsInterpLTS.Instances.LTS.Semantics.Collecting
-import AbsInterpLTS.Instances.LTS.Semantics.CollectingTrace
-import AbsInterpLTS.Instances.LTS.Instantiation.Interface
-import AbsInterpLTS.Instances.LTS.Instantiation.Soundness
+import AbsInterpLTS.Instances.LTS.Core
 import AbsInterpLTS.Instances.LTS.Analyses.Common
 import AbsInterpLTS.Instances.LTS.Analyses.Sign
 import AbsInterpLTS.Instances.LTS.Analyses.Interval

--- a/AbsInterpLTS/Instances/LTS/Core.lean
+++ b/AbsInterpLTS/Instances/LTS/Core.lean
@@ -1,0 +1,6 @@
+import AbsInterpLTS.Instances.LTS.Semantics.Concrete
+import AbsInterpLTS.Instances.LTS.Semantics.Lemmas
+import AbsInterpLTS.Instances.LTS.Semantics.Collecting
+import AbsInterpLTS.Instances.LTS.Semantics.CollectingTrace
+import AbsInterpLTS.Instances.LTS.Instantiation.Interface
+import AbsInterpLTS.Instances.LTS.Instantiation.Soundness


### PR DESCRIPTION
## Summary

- Introduce `Instances/LTS/Core.lean` as the upstream-candidate barrel: imports only Semantics + Instantiation (reusable LTS abstraction layer)
- `Instances/LTS.lean` now re-exports Core + domain-specific Analyses, preserving backward compatibility

This way `Instances.LTS.Core` gives the full step-to-trace soundness pipeline without pulling in Sign/Interval APIs.

Closes #62

## Scope

- New: `AbsInterpLTS/Instances/LTS/Core.lean`
- Updated: `AbsInterpLTS/Instances/LTS.lean`

## Validation

- `lake build` (822 jobs) — pass
- `lake build Tests` (834 jobs) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)