### PR TITLE
chore(examples): document native_decide axiom boundary and add axiom checks

### DIFF
--- a/Examples/IMP/Programs/Showcase.lean
+++ b/Examples/IMP/Programs/Showcase.lean
@@ -6,6 +6,22 @@ Flagship end-to-end IMP case study for the repository.
 
 This file exercises the generic Sign analysis over the canonical labeled IMP
 LTS, rather than introducing a separate program-specific toy LTS.
+
+## Axiom note
+
+The `analyzeShowcase_*` theorems use `native_decide` to compute abstract
+results along fixed traces. This pulls in `Lean.ofReduceBool` and
+`Lean.trustCompiler`. The kernel-only `decide` tactic cannot reduce the
+recursive `transferProgramSign` computation within its limits.
+
+The semantic corollaries (`signShowcase_trueTrace_concrete_x0_nonneg`,
+`signShowcase_falseTrace_unreachable`) therefore inherit the same
+non-standard axioms.
+
+This is acceptable for validation code: the upstream-candidate soundness
+path (`soundStep_impSign`, `LTSAbstraction.soundTraceLifted`,
+`soundTrace_of_soundStep`) is axiom-clean (`propext`, `Quot.sound`,
+`Classical.choice` only).
 -/
 
 namespace Examples.IMP.Programs

--- a/Tests.lean
+++ b/Tests.lean
@@ -13,3 +13,4 @@ import Tests.Instances.LTS.SignHook
 import Tests.Framework.Iteration.NatIter
 import Tests.Framework.Iteration.Widening
 import Tests.Framework.Semantics.AbstractOrder
+import Tests.Axioms

--- a/Tests/Axioms.lean
+++ b/Tests/Axioms.lean
@@ -8,7 +8,12 @@ Axiom-cleanliness reference for upstream-candidate theorems.
 
 The reusable soundness path (Framework → Instances/LTS → IMP step
 soundness) must use only standard axioms: `propext`, `Quot.sound`,
-`Classical.choice`. No `Lean.ofReduceBool` or `Lean.trustCompiler`.
+`Classical.choice`. The non-standard compiler-trusting axioms
+`Lean.ofReduceBool` and `Lean.trustCompiler` (introduced by
+`native_decide`) must not appear.
+
+`Classical.choice` is expected and acceptable — it arises from
+classical reasoning in set-membership proofs, not from unsafe reduction.
 
 Run `lake build Tests` and inspect the output, or use the `lean_verify`
 MCP tool, to confirm axiom cleanliness of these theorems.

--- a/Tests/Axioms.lean
+++ b/Tests/Axioms.lean
@@ -1,0 +1,27 @@
+import Cslib.Init
+
+import AbsInterpLTS
+import Examples
+
+/-!
+Axiom-cleanliness reference for upstream-candidate theorems.
+
+The reusable soundness path (Framework → Instances/LTS → IMP step
+soundness) must use only standard axioms: `propext`, `Quot.sound`,
+`Classical.choice`. No `Lean.ofReduceBool` or `Lean.trustCompiler`.
+
+Run `lake build Tests` and inspect the output, or use the `lean_verify`
+MCP tool, to confirm axiom cleanliness of these theorems.
+-/
+
+-- Framework: step soundness lifts to trace soundness (upstream candidate)
+#print axioms AbsInterpLTS.Framework.soundTrace_of_soundStep
+
+-- Instances/LTS: LTSAbstraction packages the lifting (upstream candidate)
+#print axioms AbsInterpLTS.Instances.LTS.LTSAbstraction.soundTraceLifted
+
+-- IMP: one-step soundness of the generic Sign transfer (upstream candidate)
+#print axioms Examples.IMP.soundStep_impSign
+
+-- IMP: full LTS abstraction packaging (upstream candidate)
+#print axioms Examples.IMP.impSignAbstraction


### PR DESCRIPTION
## Summary

- Document the axiom boundary in `Showcase.lean`: `native_decide` is used for computed equalities (validation code), while the upstream-candidate soundness path is axiom-clean
- Add `Tests/Axioms.lean` with `#print axioms` for the four upstream-candidate theorems, making axiom cleanliness visible in every `lake build Tests` run

The upstream soundness path uses only standard axioms:
- `soundTrace_of_soundStep`: `propext`, `Quot.sound`
- `soundTraceLifted`: + `Classical.choice`
- `soundStep_impSign`: + `Classical.choice`
- `impSignAbstraction`: + `Classical.choice`

Closes #63

## Scope

- Updated: `Examples/IMP/Programs/Showcase.lean` (docstring)
- New: `Tests/Axioms.lean`
- Updated: `Tests.lean` barrel

## Validation

- `lake build` (821 jobs) — pass
- `lake build Tests` — pass, axiom output confirmed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)