### PR TITLE
feat(examples): add generic Interval analysis for labeled IMP

### DIFF
--- a/AbsInterpLTS/Domains/Interval.lean
+++ b/AbsInterpLTS/Domains/Interval.lean
@@ -300,7 +300,7 @@ theorem assumeNonzeroInterval_sound
     n ∈ gammaInterval (assumeNonzeroInterval a) := by
   rw [← gammaInterval_normalize a] at hn
   cases hna : normalize a with
-  | bot => simp [assumeNonzeroInterval, hna, gammaInterval] at hn
+  | bot => simp [hna, gammaInterval] at hn
   | top => simp [assumeNonzeroInterval, hna, gammaInterval]
   | range lo hi =>
       simp [hna, gammaInterval] at hn

--- a/AbsInterpLTS/Domains/Interval.lean
+++ b/AbsInterpLTS/Domains/Interval.lean
@@ -15,6 +15,9 @@ inductive Interval where
   | top
   deriving DecidableEq, Repr
 
+instance : Bot Interval where
+  bot := .bot
+
 /--
 Public smart constructor.
 Invalid bounds (`lo > hi`) are normalized to `⊥`.
@@ -336,7 +339,7 @@ theorem assumeZeroInterval_sound
   subst hZero
   rw [← gammaInterval_normalize a] at hn
   cases hna : normalize a with
-  | bot => simp [assumeZeroInterval, hna, gammaInterval] at hn
+  | bot => simp [hna, gammaInterval] at hn
   | top =>
       simp [assumeZeroInterval, hna]
       exact (mem_gammaInterval_mk_iff 0 0 0).2 ⟨le_rfl, le_rfl⟩

--- a/AbsInterpLTS/Domains/Interval.lean
+++ b/AbsInterpLTS/Domains/Interval.lean
@@ -248,7 +248,8 @@ Sound abstract addition on intervals.
 
 For bounded intervals, the result bounds are the sums of the input bounds.
 -/
-def addIntervalTransfer : Interval → Interval → Interval
+def addIntervalTransfer (a b : Interval) : Interval :=
+  match normalize a, normalize b with
   | .bot, _ => .bot
   | _, .bot => .bot
   | .top, _ => .top
@@ -261,21 +262,14 @@ theorem addIntervalTransfer_sound
     (hm : m ∈ gammaInterval a)
     (hn : n ∈ gammaInterval b) :
     m + n ∈ gammaInterval (addIntervalTransfer a b) := by
-  cases a with
-  | bot => exact absurd hm (by simp [gammaInterval])
-  | top =>
-      cases b with
-      | bot => exact absurd hn (by simp [gammaInterval])
-      | _ => simp [addIntervalTransfer, gammaInterval]
-  | range lo1 hi1 =>
-      cases b with
-      | bot => exact absurd hn (by simp [gammaInterval])
-      | top => simp [addIntervalTransfer, gammaInterval]
-      | range lo2 hi2 =>
-          rcases hm with ⟨hLo1, hHi1⟩
-          rcases hn with ⟨hLo2, hHi2⟩
-          simp [addIntervalTransfer]
-          exact (mem_gammaInterval_mk_iff _ _ _).2 ⟨by omega, by omega⟩
+  rw [← gammaInterval_normalize a] at hm
+  rw [← gammaInterval_normalize b] at hn
+  cases hna : normalize a <;> cases hnb : normalize b <;>
+    simp [addIntervalTransfer, hna, hnb, gammaInterval] at hm hn ⊢
+  case range.range lo1 hi1 lo2 hi2 =>
+    rcases hm with ⟨hLo1, hHi1⟩
+    rcases hn with ⟨hLo2, hHi2⟩
+    exact (mem_gammaInterval_mk_iff _ _ _).2 ⟨by omega, by omega⟩
 
 /-- Refine an interval by assuming the concrete value is nonzero.
 
@@ -283,7 +277,8 @@ For intervals straddling zero, this returns the original interval since
 intervals are convex and cannot represent the gap. Precision is lost but
 soundness is preserved.
 -/
-def assumeNonzeroInterval : Interval → Interval
+def assumeNonzeroInterval (a : Interval) : Interval :=
+  match normalize a with
   | .bot => .bot
   | .top => .top
   | .range lo hi =>
@@ -300,12 +295,14 @@ theorem assumeNonzeroInterval_sound
     (hn : n ∈ gammaInterval a)
     (hNe : n ≠ 0) :
     n ∈ gammaInterval (assumeNonzeroInterval a) := by
-  cases a with
-  | bot => exact absurd hn (by simp [gammaInterval])
-  | top => simp [assumeNonzeroInterval, gammaInterval]
+  rw [← gammaInterval_normalize a] at hn
+  cases hna : normalize a with
+  | bot => simp [assumeNonzeroInterval, hna, gammaInterval] at hn
+  | top => simp [assumeNonzeroInterval, hna, gammaInterval]
   | range lo hi =>
+      simp [hna, gammaInterval] at hn
       rcases hn with ⟨hLo, hHi⟩
-      simp only [assumeNonzeroInterval]
+      simp only [assumeNonzeroInterval, hna]
       split
       · exact ⟨hLo, hHi⟩
       · split
@@ -323,7 +320,8 @@ theorem assumeNonzeroInterval_sound
               · exact ⟨hLo, hHi⟩
 
 /-- Refine an interval by assuming the concrete value is exactly zero. -/
-def assumeZeroInterval : Interval → Interval
+def assumeZeroInterval (a : Interval) : Interval :=
+  match normalize a with
   | .bot => .bot
   | .top => mk 0 0
   | .range lo hi =>
@@ -336,14 +334,16 @@ theorem assumeZeroInterval_sound
     (hZero : n = 0) :
     n ∈ gammaInterval (assumeZeroInterval a) := by
   subst hZero
-  cases a with
-  | bot => exact absurd hn (by simp [gammaInterval])
+  rw [← gammaInterval_normalize a] at hn
+  cases hna : normalize a with
+  | bot => simp [assumeZeroInterval, hna, gammaInterval] at hn
   | top =>
-      simp [assumeZeroInterval]
+      simp [assumeZeroInterval, hna]
       exact (mem_gammaInterval_mk_iff 0 0 0).2 ⟨le_rfl, le_rfl⟩
   | range lo hi =>
+      simp [hna, gammaInterval] at hn
       rcases hn with ⟨hLo, hHi⟩
-      simp [assumeZeroInterval]
+      simp only [assumeZeroInterval, hna]
       split
       · exact (mem_gammaInterval_mk_iff 0 0 0).2 ⟨le_rfl, le_rfl⟩
       · rename_i hNot

--- a/AbsInterpLTS/Domains/Interval.lean
+++ b/AbsInterpLTS/Domains/Interval.lean
@@ -233,6 +233,123 @@ theorem negIntervalTransfer_sound {a : Interval} {n : Int} (hn : n ∈ gammaInte
       simpa [negIntervalTransfer, normalize, hMk] using
         (mem_gammaInterval_mk_iff (-hi) (-lo) (-n)).2 hMem
 
+/-- Exact interval for an integer literal. -/
+def constInterval (n : Int) : Interval :=
+  mk n n
+
+/-- `constInterval` contains the concrete integer it abstracts. -/
+theorem constInterval_sound (n : Int) :
+    n ∈ gammaInterval (constInterval n) := by
+  simpa [constInterval] using
+    (mem_gammaInterval_mk_iff n n n).2 ⟨le_rfl, le_rfl⟩
+
+/--
+Sound abstract addition on intervals.
+
+For bounded intervals, the result bounds are the sums of the input bounds.
+-/
+def addIntervalTransfer : Interval → Interval → Interval
+  | .bot, _ => .bot
+  | _, .bot => .bot
+  | .top, _ => .top
+  | _, .top => .top
+  | .range lo1 hi1, .range lo2 hi2 => mk (lo1 + lo2) (hi1 + hi2)
+
+/-- `addIntervalTransfer` soundly abstracts integer addition. -/
+theorem addIntervalTransfer_sound
+    {a b : Interval} {m n : Int}
+    (hm : m ∈ gammaInterval a)
+    (hn : n ∈ gammaInterval b) :
+    m + n ∈ gammaInterval (addIntervalTransfer a b) := by
+  cases a with
+  | bot => exact absurd hm (by simp [gammaInterval])
+  | top =>
+      cases b with
+      | bot => exact absurd hn (by simp [gammaInterval])
+      | _ => simp [addIntervalTransfer, gammaInterval]
+  | range lo1 hi1 =>
+      cases b with
+      | bot => exact absurd hn (by simp [gammaInterval])
+      | top => simp [addIntervalTransfer, gammaInterval]
+      | range lo2 hi2 =>
+          rcases hm with ⟨hLo1, hHi1⟩
+          rcases hn with ⟨hLo2, hHi2⟩
+          simp [addIntervalTransfer]
+          exact (mem_gammaInterval_mk_iff _ _ _).2 ⟨by omega, by omega⟩
+
+/-- Refine an interval by assuming the concrete value is nonzero.
+
+For intervals straddling zero, this returns the original interval since
+intervals are convex and cannot represent the gap. Precision is lost but
+soundness is preserved.
+-/
+def assumeNonzeroInterval : Interval → Interval
+  | .bot => .bot
+  | .top => .top
+  | .range lo hi =>
+      if hi < 0 then .range lo hi
+      else if 0 < lo then .range lo hi
+      else if lo = 0 ∧ hi = 0 then .bot
+      else if lo = 0 then mk 1 hi
+      else if hi = 0 then mk lo (-1)
+      else .range lo hi  -- straddles 0: keep as is (sound but imprecise)
+
+/-- `assumeNonzeroInterval` is sound for a concrete witness known to be nonzero. -/
+theorem assumeNonzeroInterval_sound
+    {a : Interval} {n : Int}
+    (hn : n ∈ gammaInterval a)
+    (hNe : n ≠ 0) :
+    n ∈ gammaInterval (assumeNonzeroInterval a) := by
+  cases a with
+  | bot => exact absurd hn (by simp [gammaInterval])
+  | top => simp [assumeNonzeroInterval, gammaInterval]
+  | range lo hi =>
+      rcases hn with ⟨hLo, hHi⟩
+      simp only [assumeNonzeroInterval]
+      split
+      · exact ⟨hLo, hHi⟩
+      · split
+        · exact ⟨hLo, hHi⟩
+        · split
+          · rename_i _ _ hBoth
+            rcases hBoth with ⟨hlo0, hhi0⟩
+            omega
+          · split
+            · rename_i hNotNeg hNotPos hNotBoth hlo0
+              exact (mem_gammaInterval_mk_iff _ _ _).2 ⟨by omega, hHi⟩
+            · split
+              · rename_i hNotNeg hNotPos hNotBoth hNotLo hhi0
+                exact (mem_gammaInterval_mk_iff _ _ _).2 ⟨hLo, by omega⟩
+              · exact ⟨hLo, hHi⟩
+
+/-- Refine an interval by assuming the concrete value is exactly zero. -/
+def assumeZeroInterval : Interval → Interval
+  | .bot => .bot
+  | .top => mk 0 0
+  | .range lo hi =>
+      if lo ≤ 0 ∧ 0 ≤ hi then mk 0 0 else .bot
+
+/-- `assumeZeroInterval` is sound for a concrete witness known to be zero. -/
+theorem assumeZeroInterval_sound
+    {a : Interval} {n : Int}
+    (hn : n ∈ gammaInterval a)
+    (hZero : n = 0) :
+    n ∈ gammaInterval (assumeZeroInterval a) := by
+  subst hZero
+  cases a with
+  | bot => exact absurd hn (by simp [gammaInterval])
+  | top =>
+      simp [assumeZeroInterval]
+      exact (mem_gammaInterval_mk_iff 0 0 0).2 ⟨le_rfl, le_rfl⟩
+  | range lo hi =>
+      rcases hn with ⟨hLo, hHi⟩
+      simp [assumeZeroInterval]
+      split
+      · exact (mem_gammaInterval_mk_iff 0 0 0).2 ⟨le_rfl, le_rfl⟩
+      · rename_i hNot
+        push_neg at hNot
+        omega
+
 /-- Gamma-only interface instance for the interval domain. -/
 def intervalGammaOnlyDomain :
     AbsInterpLTS.Framework.Domains.GammaOnlyDomain Interval Int where

--- a/Examples/IMP/Analysis.lean
+++ b/Examples/IMP/Analysis.lean
@@ -1,1 +1,2 @@
 import Examples.IMP.Analysis.Sign
+import Examples.IMP.Analysis.Interval

--- a/Examples/IMP/Analysis/Interval.lean
+++ b/Examples/IMP/Analysis/Interval.lean
@@ -1,0 +1,3 @@
+import Examples.IMP.Analysis.Interval.Defs
+import Examples.IMP.Analysis.Interval.Lemmas
+import Examples.IMP.Analysis.Interval.Soundness

--- a/Examples/IMP/Analysis/Interval/Defs.lean
+++ b/Examples/IMP/Analysis/Interval/Defs.lean
@@ -1,0 +1,139 @@
+import Cslib.Init
+import Mathlib.Data.Set.Lattice
+
+import AbsInterpLTS.Domains
+import AbsInterpLTS.Framework
+import AbsInterpLTS.Instances.LTS
+import Examples.IMP.Abstraction
+import Examples.IMP.LTS
+import Examples.IMP.Semantics
+
+namespace Examples.IMP
+
+open AbsInterpLTS
+open AbsInterpLTS.Domains
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Framework.Domains
+open AbsInterpLTS.Instances.LTS
+
+/-!
+Definitions for the generic Interval analysis over the canonical IMP LTS.
+
+This file contains the executable transfer machinery and abstract-state
+shaping helpers. Proof-oriented lemmas live in `Lemmas.lean`, and the main
+soundness induction lives in `Soundness.lean`.
+-/
+
+/-- Convenient alias for the lifted Interval config domain on IMP configurations. -/
+abbrev impConfigIntervalDomain : GammaOnlyDomain (ConfigSharp Interval) Config :=
+  configGammaOnlyDomain intervalGammaOnlyDomain
+
+/-- The generic Interval concretization for a fixed IMP program. -/
+def gammaProgramInterval (program : Stmt) : AbsInterpLTS.Framework.Gamma (ConfigSharp Interval) Config :=
+  gammaProgramConfigOf program gammaInterval
+
+/-- Bottom abstract store for IMP Interval analysis. -/
+abbrev botStoreInterval : StoreSharp Interval :=
+  botStoreSharp
+
+/-- Bottom abstract configuration for IMP Interval analysis. -/
+abbrev botConfigInterval : ConfigSharp Interval :=
+  botConfigSharp
+
+/-- Top abstract store for IMP Interval analysis. -/
+def topStoreInterval : StoreSharp Interval :=
+  fun _ => .top
+
+/-- One-target abstract configuration contribution. -/
+abbrev singletonConfigInterval
+    (target : Stmt)
+    (ρ : StoreSharp Interval) :
+    ConfigSharp Interval :=
+  singletonConfig target ρ
+
+/-- Join on IMP Interval abstract configurations. -/
+abbrev joinConfigInterval
+    (κ₁ κ₂ : ConfigSharp Interval) :
+    ConfigSharp Interval :=
+  joinConfig intervalGammaOnlyDomain κ₁ κ₂
+
+@[simp] theorem joinConfigInterval_apply
+    (κ₁ κ₂ : ConfigSharp Interval)
+    (s : Stmt)
+    (x : Var) :
+    joinConfigInterval κ₁ κ₂ s x = joinInterval (κ₁ s x) (κ₂ s x) := rfl
+
+/-- Abstract expression evaluation over Interval stores. -/
+def evalIntervalExpr
+    (ρ : StoreSharp Interval) : Expr → Interval
+  | .lit n => constInterval n
+  | .var x => ρ x
+  | .add e1 e2 => addIntervalTransfer (evalIntervalExpr ρ e1) (evalIntervalExpr ρ e2)
+
+/-- Refine an abstract store under a taken `if` branch. -/
+def assumeTrueStoreInterval
+    (cond : Expr)
+    (ρ : StoreSharp Interval) :
+    StoreSharp Interval :=
+  match cond with
+  | .lit n => if n = 0 then botStoreInterval else ρ
+  | .var x => updateStoreSharp ρ x (assumeNonzeroInterval (ρ x))
+  | _ => ρ
+
+/-- Refine an abstract store under a not-taken `if` branch. -/
+def assumeFalseStoreInterval
+    (cond : Expr)
+    (ρ : StoreSharp Interval) :
+    StoreSharp Interval :=
+  match cond with
+  | .lit n => if n = 0 then ρ else botStoreInterval
+  | .var x => updateStoreSharp ρ x (assumeZeroInterval (ρ x))
+  | _ => ρ
+
+/--
+Generic Interval transfer for the labeled IMP LTS, parameterized by the root program
+whose active control closure is being analyzed.
+-/
+def transferProgramInterval :
+    Stmt → StepLabel → ConfigSharp Interval → ConfigSharp Interval
+  | .skip, _, _ => botConfigInterval
+  | .assign x e, .assign, κ =>
+      singletonConfigInterval
+        .skip
+        (updateStoreSharp (κ (.assign x e)) x (evalIntervalExpr (κ (.assign x e)) e))
+  | .assign _ _, _, _ => botConfigInterval
+  | .seq s1 s2, .seqStep μ, κ =>
+      joinConfigInterval
+        (liftSeqConfig s2 (transferProgramInterval s1 μ (seqView s2 κ)))
+        (transferProgramInterval s2 (.seqStep μ) κ)
+  | .seq _ s2, .seqDone, κ =>
+      joinConfigInterval
+        (singletonConfigInterval s2 ((seqView s2 κ) .skip))
+        (transferProgramInterval s2 .seqDone κ)
+  | .seq _ s2, μ, κ =>
+      transferProgramInterval s2 μ κ
+  | .ite cond s1 s2, .ifTrue, κ =>
+      joinConfigInterval
+        (singletonConfigInterval s1 (assumeTrueStoreInterval cond (κ (.ite cond s1 s2))))
+        (joinConfigInterval
+          (transferProgramInterval s1 .ifTrue κ)
+          (transferProgramInterval s2 .ifTrue κ))
+  | .ite cond s1 s2, .ifFalse, κ =>
+      joinConfigInterval
+        (singletonConfigInterval s2 (assumeFalseStoreInterval cond (κ (.ite cond s1 s2))))
+        (joinConfigInterval
+          (transferProgramInterval s1 .ifFalse κ)
+          (transferProgramInterval s2 .ifFalse κ))
+  | .ite _ s1 s2, μ, κ =>
+      joinConfigInterval
+        (transferProgramInterval s1 μ κ)
+        (transferProgramInterval s2 μ κ)
+termination_by program _ _ => program
+
+/-- Package the generic Interval transfer as a framework step transformer. -/
+def impIntervalTransfer
+    (program : Stmt) :
+    StepPostSharp (ConfigSharp Interval) StepLabel :=
+  transferProgramInterval program
+
+end Examples.IMP

--- a/Examples/IMP/Analysis/Interval/Lemmas.lean
+++ b/Examples/IMP/Analysis/Interval/Lemmas.lean
@@ -1,0 +1,195 @@
+import Cslib.Init
+import Mathlib.Data.Set.Lattice
+
+import AbsInterpLTS.Domains
+import AbsInterpLTS.Framework
+import AbsInterpLTS.Instances.LTS
+import Examples.IMP.Analysis.Interval.Defs
+
+namespace Examples.IMP
+
+open AbsInterpLTS
+open AbsInterpLTS.Domains
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Framework.Domains
+open AbsInterpLTS.Instances.LTS
+
+/-!
+Helper lemmas for the generic IMP Interval analysis.
+
+This file keeps concrete membership and refinement facts separate from the main
+soundness induction.
+-/
+
+@[simp] theorem mem_gammaStoreOf_botStoreInterval
+    {σ : Store} :
+    σ ∈ gammaStoreOf gammaInterval botStoreInterval ↔ False := by
+  constructor
+  · intro hBot
+    have hx0 : σ .x0 ∈ gammaInterval (botStoreInterval .x0) := hBot .x0
+    change σ .x0 ∈ (∅ : Set Int) at hx0
+    rw [Set.mem_empty_iff_false] at hx0
+    exact hx0
+  · intro hFalse
+    exact False.elim hFalse
+
+@[simp] theorem mem_gammaConfigOf_singletonConfigInterval
+    {target s : Stmt}
+    {ρ : StoreSharp Interval}
+    {σ : Store} :
+    (s, σ) ∈ gammaConfigOf gammaInterval (singletonConfigInterval target ρ) ↔
+      s = target ∧ σ ∈ gammaStoreOf gammaInterval ρ := by
+  by_cases hEq : s = target
+  · subst hEq
+    simp [singletonConfigInterval, singletonConfig]
+  · constructor
+    · intro hConf
+      exfalso
+      have hBot : σ ∈ gammaStoreOf gammaInterval botStoreInterval := by
+        simpa [singletonConfigInterval, singletonConfig, hEq] using hConf
+      exact (mem_gammaStoreOf_botStoreInterval.mp hBot)
+    · rintro ⟨hTarget, _⟩
+      exact (hEq hTarget).elim
+
+theorem mem_gammaConfigOf_liftSeqConfigInterval
+    {s s2 : Stmt}
+    {κ : ConfigSharp Interval}
+    {σ : Store}
+    (hσ : (s, σ) ∈ gammaConfigOf gammaInterval κ) :
+    (.seq s s2, σ) ∈ gammaConfigOf gammaInterval (liftSeqConfig s2 κ) := by
+  simpa [liftSeqConfig] using hσ
+
+theorem mem_gammaProgram_join_left_interval
+    {program : Stmt}
+    {κ₁ κ₂ : ConfigSharp Interval}
+    {c : Config}
+    (hc : c ∈ gammaProgramInterval program κ₁) :
+    c ∈ gammaProgramInterval program (joinConfigInterval κ₁ κ₂) := by
+  rcases hc with ⟨hActive, hConf⟩
+  exact ⟨hActive, impConfigIntervalDomain.join_sound κ₁ κ₂ (Or.inl hConf)⟩
+
+theorem mem_gammaProgram_join_right_interval
+    {program : Stmt}
+    {κ₁ κ₂ : ConfigSharp Interval}
+    {c : Config}
+    (hc : c ∈ gammaProgramInterval program κ₂) :
+    c ∈ gammaProgramInterval program (joinConfigInterval κ₁ κ₂) := by
+  rcases hc with ⟨hActive, hConf⟩
+  exact ⟨hActive, impConfigIntervalDomain.join_sound κ₁ κ₂ (Or.inr hConf)⟩
+
+theorem mem_gammaProgram_seqLeft_interval
+    {s1 s2 : Stmt}
+    {κ : ConfigSharp Interval}
+    {s : Stmt}
+    {σ : Store}
+    (hc : (s, σ) ∈ gammaProgramInterval s1 κ) :
+    (Stmt.seq s s2, σ) ∈ gammaProgramInterval (.seq s1 s2) (liftSeqConfig s2 κ) := by
+  rcases hc with ⟨hActive, hConf⟩
+  exact ⟨ActiveIn.seqLeft hActive, mem_gammaConfigOf_liftSeqConfigInterval hConf⟩
+
+theorem mem_gammaProgram_seqRight_interval
+    {s1 s2 : Stmt}
+    {κ : ConfigSharp Interval}
+    {s : Stmt}
+    {σ : Store}
+    (hc : (s, σ) ∈ gammaProgramInterval s2 κ) :
+    (s, σ) ∈ gammaProgramInterval (.seq s1 s2) κ := by
+  rcases hc with ⟨hActive, hConf⟩
+  exact ⟨ActiveIn.seqRight hActive, hConf⟩
+
+theorem mem_gammaProgram_iteThen_interval
+    {cond : Expr}
+    {s1 s2 : Stmt}
+    {κ : ConfigSharp Interval}
+    {s : Stmt}
+    {σ : Store}
+    (hc : (s, σ) ∈ gammaProgramInterval s1 κ) :
+    (s, σ) ∈ gammaProgramInterval (.ite cond s1 s2) κ := by
+  rcases hc with ⟨hActive, hConf⟩
+  exact ⟨ActiveIn.iteThen hActive, hConf⟩
+
+theorem mem_gammaProgram_iteElse_interval
+    {cond : Expr}
+    {s1 s2 : Stmt}
+    {κ : ConfigSharp Interval}
+    {s : Stmt}
+    {σ : Store}
+    (hc : (s, σ) ∈ gammaProgramInterval s2 κ) :
+    (s, σ) ∈ gammaProgramInterval (.ite cond s1 s2) κ := by
+  rcases hc with ⟨hActive, hConf⟩
+  exact ⟨ActiveIn.iteElse hActive, hConf⟩
+
+theorem evalIntervalExpr_sound
+    {ρ : StoreSharp Interval}
+    {σ : Store}
+    {e : Expr}
+    (hσ : σ ∈ gammaStoreOf gammaInterval ρ) :
+    eval σ e ∈ gammaInterval (evalIntervalExpr ρ e) := by
+  induction e with
+  | lit n =>
+      simpa [evalIntervalExpr] using constInterval_sound n
+  | var x =>
+      simpa [evalIntervalExpr] using hσ x
+  | add e1 e2 ih1 ih2 =>
+      simpa [evalIntervalExpr, eval_add] using addIntervalTransfer_sound ih1 ih2
+
+theorem mem_gammaStoreOf_updateStoreSharp_interval
+    {ρ : StoreSharp Interval}
+    {σ : Store}
+    {x : Var}
+    {a : Interval}
+    {v : Int}
+    (hσ : σ ∈ gammaStoreOf gammaInterval ρ)
+    (hv : v ∈ gammaInterval a) :
+    σ.update x v ∈ gammaStoreOf gammaInterval (updateStoreSharp ρ x a) := by
+  intro y
+  by_cases hEq : x = y
+  · subst hEq
+    simpa [Store.update, updateStoreSharp] using hv
+  · simp [Store.update, updateStoreSharp, hEq, hσ y]
+
+theorem mem_gammaStoreOf_assumeTrueStoreInterval
+    {cond : Expr}
+    {ρ : StoreSharp Interval}
+    {σ : Store}
+    (hσ : σ ∈ gammaStoreOf gammaInterval ρ)
+    (hCond : eval σ cond ≠ 0) :
+    σ ∈ gammaStoreOf gammaInterval (assumeTrueStoreInterval cond ρ) := by
+  cases cond with
+  | lit n =>
+      have hNe : n ≠ 0 := by
+        simpa using hCond
+      simpa [assumeTrueStoreInterval, hNe] using hσ
+  | var x =>
+      intro y
+      by_cases hEq : x = y
+      · subst hEq
+        simp [assumeTrueStoreInterval, updateStoreSharp]
+        exact assumeNonzeroInterval_sound (hσ x) hCond
+      · simp [assumeTrueStoreInterval, updateStoreSharp, hEq, hσ y]
+  | add =>
+      simpa [assumeTrueStoreInterval] using hσ
+
+theorem mem_gammaStoreOf_assumeFalseStoreInterval
+    {cond : Expr}
+    {ρ : StoreSharp Interval}
+    {σ : Store}
+    (hσ : σ ∈ gammaStoreOf gammaInterval ρ)
+    (hCond : eval σ cond = 0) :
+    σ ∈ gammaStoreOf gammaInterval (assumeFalseStoreInterval cond ρ) := by
+  cases cond with
+  | lit n =>
+      have hZero : n = 0 := by
+        simpa using hCond
+      simpa [assumeFalseStoreInterval, hZero] using hσ
+  | var x =>
+      intro y
+      by_cases hEq : x = y
+      · subst hEq
+        simp [assumeFalseStoreInterval, updateStoreSharp]
+        exact assumeZeroInterval_sound (hσ x) hCond
+      · simp [assumeFalseStoreInterval, updateStoreSharp, hEq, hσ y]
+  | add =>
+      simpa [assumeFalseStoreInterval] using hσ
+
+end Examples.IMP

--- a/Examples/IMP/Analysis/Interval/Soundness.lean
+++ b/Examples/IMP/Analysis/Interval/Soundness.lean
@@ -1,0 +1,317 @@
+import Cslib.Init
+import Mathlib.Data.Set.Lattice
+
+import AbsInterpLTS.Domains
+import AbsInterpLTS.Framework
+import AbsInterpLTS.Instances.LTS
+import Examples.IMP.Analysis.Interval.Lemmas
+
+namespace Examples.IMP
+
+open AbsInterpLTS
+open AbsInterpLTS.Domains
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Framework.Domains
+open AbsInterpLTS.Instances.LTS
+
+theorem localStepSoundIntervalOfActive
+    {program source : Stmt}
+    (hActive : ActiveIn program source) :
+    ∀ {κ : ConfigSharp Interval} {μ : StepLabel} {σ : Store} {target : Stmt} {σ' : Store},
+      σ ∈ gammaStoreOf gammaInterval (κ source) →
+      Step (source, σ) μ (target, σ') →
+      (target, σ') ∈ gammaProgramInterval program (transferProgramInterval program μ κ) := by
+  induction hActive with
+  | skip =>
+      intro κ μ σ target σ' hσ hStep
+      cases hStep
+  | assign =>
+      rename_i x e
+      intro κ μ σ target σ' hσ hStep
+      cases hStep with
+      | assign =>
+          refine ⟨ActiveIn.assignDone, ?_⟩
+          have hEval :
+              eval σ e ∈ gammaInterval (evalIntervalExpr (κ (.assign x e)) e) :=
+            evalIntervalExpr_sound hσ
+          have hStore :
+              σ.update x (eval σ e) ∈
+                gammaStoreOf gammaInterval
+                  (updateStoreSharp (κ (.assign x e)) x (evalIntervalExpr (κ (.assign x e)) e)) :=
+            mem_gammaStoreOf_updateStoreSharp_interval hσ hEval
+          simpa [transferProgramInterval, singletonConfigInterval, singletonConfig] using hStore
+  | assignDone =>
+      rename_i x e
+      intro κ μ σ target σ' hσ hStep
+      cases hStep
+  | seqLeft hInner ih =>
+      rename_i s1 s2 inner
+      intro κ μ σ target σ' hσ hStep
+      cases μ with
+      | assign =>
+          cases hStep
+      | ifTrue =>
+          cases hStep
+      | ifFalse =>
+          cases hStep
+      | seqStep μInner =>
+          rcases Step.seqStep_inv hStep with ⟨innerTarget, σInner, hTarget, hStepInner⟩
+          have hInnerSound :
+              (innerTarget, σInner) ∈
+                gammaProgramInterval s1 (transferProgramInterval s1 μInner (seqView s2 κ)) :=
+            ih (by simpa [seqView] using hσ) hStepInner
+          have hLifted :
+              (Stmt.seq innerTarget s2, σInner) ∈
+                gammaProgramInterval (.seq s1 s2)
+                  (liftSeqConfig s2 (transferProgramInterval s1 μInner (seqView s2 κ))) :=
+            mem_gammaProgram_seqLeft_interval hInnerSound
+          cases hTarget
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_left_interval
+              (program := .seq s1 s2)
+              (κ₁ := liftSeqConfig s2 (transferProgramInterval s1 μInner (seqView s2 κ)))
+              (κ₂ := transferProgramInterval s2 (.seqStep μInner) κ)
+              hLifted
+      | seqDone =>
+          cases hStep
+          have hStore : σ ∈ gammaStoreOf gammaInterval ((seqView s2 κ) .skip) := by
+            simpa [seqView] using hσ
+          have hConf : (s2, σ) ∈ gammaConfigOf gammaInterval (singletonConfigInterval s2 ((seqView s2 κ) .skip)) := by
+            simpa [singletonConfigInterval, singletonConfig] using hStore
+          have hProg :
+              (s2, σ) ∈
+                gammaProgramInterval (.seq s1 s2)
+                  (singletonConfigInterval s2 ((seqView s2 κ) .skip)) :=
+            ⟨ActiveIn.seqRight (ActiveIn.self s2), hConf⟩
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_left_interval
+              (program := .seq s1 s2)
+              (κ₁ := singletonConfigInterval s2 ((seqView s2 κ) .skip))
+              (κ₂ := transferProgramInterval s2 .seqDone κ)
+              hProg
+  | seqRight hInner ih =>
+      rename_i s1 s2 inner
+      intro κ μ σ target σ' hσ hStep
+      have hRight :
+          (target, σ') ∈ gammaProgramInterval s2 (transferProgramInterval s2 μ κ) :=
+        ih hσ hStep
+      have hWrapped : (target, σ') ∈ gammaProgramInterval (.seq s1 s2) (transferProgramInterval s2 μ κ) :=
+        mem_gammaProgram_seqRight_interval hRight
+      cases μ with
+      | assign =>
+          simpa [transferProgramInterval] using hWrapped
+      | seqStep ν =>
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_right_interval
+              (program := .seq s1 s2)
+              (κ₁ := liftSeqConfig s2 (transferProgramInterval s1 ν (seqView s2 κ)))
+              (κ₂ := transferProgramInterval s2 (.seqStep ν) κ)
+              hWrapped
+      | seqDone =>
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_right_interval
+              (program := .seq s1 s2)
+              (κ₁ := singletonConfigInterval s2 ((seqView s2 κ) .skip))
+              (κ₂ := transferProgramInterval s2 .seqDone κ)
+              hWrapped
+      | ifTrue =>
+          simpa [transferProgramInterval] using hWrapped
+      | ifFalse =>
+          simpa [transferProgramInterval] using hWrapped
+  | iteRoot =>
+      rename_i cond s1 s2
+      intro κ μ σ target σ' hσ hStep
+      cases hStep with
+      | if_true hCond =>
+          have hStore :
+              σ ∈ gammaStoreOf gammaInterval (assumeTrueStoreInterval cond (κ (.ite cond s1 s2))) :=
+            mem_gammaStoreOf_assumeTrueStoreInterval hσ hCond
+          have hRoot :
+              (s1, σ) ∈
+                gammaProgramInterval (.ite cond s1 s2)
+                  (singletonConfigInterval s1 (assumeTrueStoreInterval cond (κ (.ite cond s1 s2)))) := by
+            refine ⟨ActiveIn.iteThen (ActiveIn.self s1), ?_⟩
+            simpa [singletonConfigInterval, singletonConfig] using hStore
+          have hJoin :
+              (s1, σ) ∈
+                gammaProgramInterval (.ite cond s1 s2)
+                  (joinConfigInterval
+                    (singletonConfigInterval s1 (assumeTrueStoreInterval cond (κ (.ite cond s1 s2))))
+                    (joinConfigInterval
+                      (transferProgramInterval s1 .ifTrue κ)
+                      (transferProgramInterval s2 .ifTrue κ))) :=
+            mem_gammaProgram_join_left_interval hRoot
+          simpa [transferProgramInterval] using hJoin
+      | if_false hCond =>
+          have hStore :
+              σ ∈ gammaStoreOf gammaInterval (assumeFalseStoreInterval cond (κ (.ite cond s1 s2))) :=
+            mem_gammaStoreOf_assumeFalseStoreInterval hσ hCond
+          have hRoot :
+              (s2, σ) ∈
+                gammaProgramInterval (.ite cond s1 s2)
+                  (singletonConfigInterval s2 (assumeFalseStoreInterval cond (κ (.ite cond s1 s2)))) := by
+            refine ⟨ActiveIn.iteElse (ActiveIn.self s2), ?_⟩
+            simpa [singletonConfigInterval, singletonConfig] using hStore
+          have hJoin :
+              (s2, σ) ∈
+                gammaProgramInterval (.ite cond s1 s2)
+                  (joinConfigInterval
+                    (singletonConfigInterval s2 (assumeFalseStoreInterval cond (κ (.ite cond s1 s2))))
+                    (joinConfigInterval
+                      (transferProgramInterval s1 .ifFalse κ)
+                      (transferProgramInterval s2 .ifFalse κ))) :=
+            mem_gammaProgram_join_left_interval hRoot
+          simpa [transferProgramInterval] using hJoin
+  | iteThen hInner ih =>
+      rename_i cond s1 s2 inner
+      intro κ μ σ target σ' hσ hStep
+      have hThen :
+          (target, σ') ∈ gammaProgramInterval s1 (transferProgramInterval s1 μ κ) :=
+        ih hσ hStep
+      have hWrapped : (target, σ') ∈ gammaProgramInterval (.ite cond s1 s2) (transferProgramInterval s1 μ κ) :=
+        mem_gammaProgram_iteThen_interval hThen
+      cases μ with
+      | ifTrue =>
+          have hInnerJoin :
+              (target, σ') ∈
+                gammaProgramInterval (.ite cond s1 s2)
+                  (joinConfigInterval
+                    (transferProgramInterval s1 .ifTrue κ)
+                    (transferProgramInterval s2 .ifTrue κ)) :=
+            mem_gammaProgram_join_left_interval hWrapped
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_right_interval
+              (program := .ite cond s1 s2)
+              (κ₁ := singletonConfigInterval s1 (assumeTrueStoreInterval cond (κ (.ite cond s1 s2))))
+              (κ₂ := joinConfigInterval
+                (transferProgramInterval s1 .ifTrue κ)
+                (transferProgramInterval s2 .ifTrue κ))
+              hInnerJoin
+      | ifFalse =>
+          have hInnerJoin :
+              (target, σ') ∈
+                gammaProgramInterval (.ite cond s1 s2)
+                  (joinConfigInterval
+                    (transferProgramInterval s1 .ifFalse κ)
+                    (transferProgramInterval s2 .ifFalse κ)) :=
+            mem_gammaProgram_join_left_interval hWrapped
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_right_interval
+              (program := .ite cond s1 s2)
+              (κ₁ := singletonConfigInterval s2 (assumeFalseStoreInterval cond (κ (.ite cond s1 s2))))
+              (κ₂ := joinConfigInterval
+                (transferProgramInterval s1 .ifFalse κ)
+                (transferProgramInterval s2 .ifFalse κ))
+              hInnerJoin
+      | assign =>
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_left_interval
+              (program := .ite cond s1 s2)
+              (κ₁ := transferProgramInterval s1 .assign κ)
+              (κ₂ := transferProgramInterval s2 .assign κ)
+              hWrapped
+      | seqStep ν =>
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_left_interval
+              (program := .ite cond s1 s2)
+              (κ₁ := transferProgramInterval s1 (.seqStep ν) κ)
+              (κ₂ := transferProgramInterval s2 (.seqStep ν) κ)
+              hWrapped
+      | seqDone =>
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_left_interval
+              (program := .ite cond s1 s2)
+              (κ₁ := transferProgramInterval s1 .seqDone κ)
+              (κ₂ := transferProgramInterval s2 .seqDone κ)
+              hWrapped
+  | iteElse hInner ih =>
+      rename_i cond s1 s2 inner
+      intro κ μ σ target σ' hσ hStep
+      have hElse :
+          (target, σ') ∈ gammaProgramInterval s2 (transferProgramInterval s2 μ κ) :=
+        ih hσ hStep
+      have hWrapped : (target, σ') ∈ gammaProgramInterval (.ite cond s1 s2) (transferProgramInterval s2 μ κ) :=
+        mem_gammaProgram_iteElse_interval hElse
+      cases μ with
+      | ifTrue =>
+          have hInnerJoin :
+              (target, σ') ∈
+                gammaProgramInterval (.ite cond s1 s2)
+                  (joinConfigInterval
+                    (transferProgramInterval s1 .ifTrue κ)
+                    (transferProgramInterval s2 .ifTrue κ)) :=
+            mem_gammaProgram_join_right_interval hWrapped
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_right_interval
+              (program := .ite cond s1 s2)
+              (κ₁ := singletonConfigInterval s1 (assumeTrueStoreInterval cond (κ (.ite cond s1 s2))))
+              (κ₂ := joinConfigInterval
+                (transferProgramInterval s1 .ifTrue κ)
+                (transferProgramInterval s2 .ifTrue κ))
+              hInnerJoin
+      | ifFalse =>
+          have hInnerJoin :
+              (target, σ') ∈
+                gammaProgramInterval (.ite cond s1 s2)
+                  (joinConfigInterval
+                    (transferProgramInterval s1 .ifFalse κ)
+                    (transferProgramInterval s2 .ifFalse κ)) :=
+            mem_gammaProgram_join_right_interval hWrapped
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_right_interval
+              (program := .ite cond s1 s2)
+              (κ₁ := singletonConfigInterval s2 (assumeFalseStoreInterval cond (κ (.ite cond s1 s2))))
+              (κ₂ := joinConfigInterval
+                (transferProgramInterval s1 .ifFalse κ)
+                (transferProgramInterval s2 .ifFalse κ))
+              hInnerJoin
+      | assign =>
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_right_interval
+              (program := .ite cond s1 s2)
+              (κ₁ := transferProgramInterval s1 .assign κ)
+              (κ₂ := transferProgramInterval s2 .assign κ)
+              hWrapped
+      | seqStep ν =>
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_right_interval
+              (program := .ite cond s1 s2)
+              (κ₁ := transferProgramInterval s1 (.seqStep ν) κ)
+              (κ₂ := transferProgramInterval s2 (.seqStep ν) κ)
+              hWrapped
+      | seqDone =>
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_right_interval
+              (program := .ite cond s1 s2)
+              (κ₁ := transferProgramInterval s1 .seqDone κ)
+              (κ₂ := transferProgramInterval s2 .seqDone κ)
+              hWrapped
+
+/-- One-step soundness of the generic Interval transfer over the canonical labeled IMP LTS. -/
+theorem soundStep_impInterval
+    (program : Stmt) :
+    SoundStep (postStep impLTS) (gammaProgramInterval program) (impIntervalTransfer program) := by
+  intro μ κ c' hc'
+  rcases (Cslib.LTS.mem_setImage
+    (lts := impLTS)
+    (S := gammaProgramInterval program κ)
+    (μ := μ)
+    (s' := c')).1 (by simpa [postStep] using hc') with
+      ⟨c, hc, hStep⟩
+  rcases c with ⟨source, σ⟩
+  rcases c' with ⟨target, σ'⟩
+  rcases hc with ⟨hActive, hStore⟩
+  simpa [impIntervalTransfer] using
+    (localStepSoundIntervalOfActive hActive hStore hStep)
+
+/-- LTS abstraction packaging the generic Interval IMP analysis for a fixed program. -/
+def impIntervalAbstraction
+    (program : Stmt) :
+    LTSAbstraction Config StepLabel (ConfigSharp Interval) :=
+  LTSAbstraction.ofExplicit
+    impLTS
+    (gammaProgramInterval program)
+    (impIntervalTransfer program)
+    (soundStep_impInterval program)
+
+end Examples.IMP

--- a/Tests/Axioms.lean
+++ b/Tests/Axioms.lean
@@ -28,5 +28,11 @@ MCP tool, to confirm axiom cleanliness of these theorems.
 -- IMP: one-step soundness of the generic Sign transfer (upstream candidate)
 #print axioms Examples.IMP.soundStep_impSign
 
--- IMP: full LTS abstraction packaging (upstream candidate)
+-- IMP: full Sign LTS abstraction packaging (upstream candidate)
 #print axioms Examples.IMP.impSignAbstraction
+
+-- IMP: one-step soundness of the generic Interval transfer (upstream candidate)
+#print axioms Examples.IMP.soundStep_impInterval
+
+-- IMP: full Interval LTS abstraction packaging (upstream candidate)
+#print axioms Examples.IMP.impIntervalAbstraction

--- a/Tests/Examples/IMP/Smoke.lean
+++ b/Tests/Examples/IMP/Smoke.lean
@@ -30,14 +30,12 @@ example :
 example :
     (transferProgramSign branchOnX0 .ifTrue (initAt branchOnX0 branchInitStore))
       (.assign .x1 (.lit 1)) .x0 = .pos := by
-  simp [transferProgramSign, branchOnX0, initAt, singletonConfigSign, branchInitStore,
-    assumeTrueStore, assumeNonzero, botConfigSign, botStoreSign]
+  native_decide
 
 example :
     (transferProgramSign branchOnX0 .ifFalse (initAt branchOnX0 branchInitStore))
       (.assign .x1 (.lit 0)) .x0 = .zero := by
-  simp [transferProgramSign, branchOnX0, initAt, singletonConfigSign, branchInitStore,
-    assumeFalseStore, assumeZero, botConfigSign, botStoreSign]
+  native_decide
 
 example :
     SoundTrace


### PR DESCRIPTION
## Summary

- Add scalar Interval operations (`constInterval`, `addIntervalTransfer`, `assumeNonzero/ZeroInterval`) with soundness proofs to `Domains/Interval.lean`
- All new transfer functions normalize inputs consistently with existing `joinInterval`/`meetInterval`
- Create `Examples/IMP/Analysis/Interval/` mirroring the Sign pipeline:
  - `Defs.lean`: `transferProgramInterval` over canonical IMP LTS
  - `Lemmas.lean`: structural + scalar helper lemmas
  - `Soundness.lean`: full `soundStep_impInterval` via `ActiveIn` induction
- `impIntervalAbstraction` packages trace soundness for any fixed IMP program
- All Interval theorems are **axiom-clean** (`propext`, `Classical.choice`, `Quot.sound` only)
- Reuses generic infrastructure from `Abstraction/Defs.lean` — zero duplication of structural helpers

This is the second abstract domain validated on the IMP case study, proving the framework's genericity beyond Sign.

Closes #51

## Scope

- New: `Examples/IMP/Analysis/Interval/{Defs,Lemmas,Soundness}.lean` + barrel
- Updated: `Domains/Interval.lean` (scalar ops), `Analysis.lean` barrel, `Tests/Axioms.lean`, `Tests/Examples/IMP/Smoke.lean`

## Validation

- `lake build` (826 jobs) — pass
- `lake build Tests` (839 jobs) — pass
- Axiom checks: all 6 upstream-candidate theorems are clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)