### PR TITLE
feat(examples): add while and interval widening example for labeled IMP

### DIFF
--- a/AbsInterpLTS/Domains/Interval.lean
+++ b/AbsInterpLTS/Domains/Interval.lean
@@ -1,6 +1,7 @@
 import Cslib.Init
 import Mathlib.Data.Set.Lattice
 import AbsInterpLTS.Framework.Domains
+import AbsInterpLTS.Framework.Iteration
 
 namespace AbsInterpLTS
 namespace Domains
@@ -352,6 +353,47 @@ theorem assumeZeroInterval_sound
       · rename_i hNot
         push_neg at hNot
         omega
+
+/--
+Widening on intervals: if the new interval `b` exceeds `a`'s bounds in
+either direction, jump to `⊤`. This aggressive strategy guarantees
+termination in at most one widening step.
+-/
+def widenInterval (a b : Interval) : Interval :=
+  match normalize a, normalize b with
+  | .bot, b' => b'
+  | a', .bot => a'
+  | .top, _ => .top
+  | _, .top => .top
+  | .range lo1 hi1, .range lo2 hi2 =>
+    if lo2 < lo1 ∨ hi1 < hi2 then .top else .range lo1 hi1
+
+/-- `widenInterval` is an upper bound: `a ≤ widen a b`. -/
+theorem widenInterval_left (a b : Interval) :
+    leInterval a (widenInterval a b) := by
+  intro n hn
+  have hn' : n ∈ gammaInterval (normalize a) := by rwa [gammaInterval_normalize]
+  cases hna : normalize a <;> cases hnb : normalize b <;>
+    simp_all [widenInterval, gammaInterval]
+  case range.range lo1 hi1 lo2 hi2 =>
+    split_ifs <;> simp_all
+
+/-- `widenInterval` is an upper bound: `b ≤ widen a b`. -/
+theorem widenInterval_right (a b : Interval) :
+    leInterval b (widenInterval a b) := by
+  intro n hn
+  have hn' : n ∈ gammaInterval (normalize b) := by rwa [gammaInterval_normalize]
+  cases hna : normalize a <;> cases hnb : normalize b <;>
+    simp_all [widenInterval, gammaInterval]
+  case range.range lo1 hi1 lo2 hi2 =>
+    split_ifs <;> simp_all
+    omega
+
+/-- `widenInterval` satisfies the framework `WidenUpperBound` contract. -/
+theorem widenInterval_upperBound :
+    AbsInterpLTS.Framework.Iteration.WidenUpperBound leInterval widenInterval where
+  left := widenInterval_left
+  right := widenInterval_right
 
 /-- Gamma-only interface instance for the interval domain. -/
 def intervalGammaOnlyDomain :

--- a/Examples/IMP/Abstraction/ActiveIn.lean
+++ b/Examples/IMP/Abstraction/ActiveIn.lean
@@ -35,6 +35,13 @@ inductive ActiveIn : Stmt → Stmt → Prop where
   | iteElse {cond : Expr} {s1 s2 t : Stmt} :
       ActiveIn s2 t →
       ActiveIn (.ite cond s1 s2) t
+  | whileRoot {cond : Expr} {body : Stmt} :
+      ActiveIn (.while cond body) (.while cond body)
+  | whileDone {cond : Expr} {body : Stmt} :
+      ActiveIn (.while cond body) .skip
+  | whileBody {cond : Expr} {body t : Stmt} :
+      ActiveIn body t →
+      ActiveIn (.while cond body) (.seq t (.while cond body))
 
 /-- Every IMP program is active at its own initial control location. -/
 theorem ActiveIn.self (program : Stmt) :
@@ -48,6 +55,8 @@ theorem ActiveIn.self (program : Stmt) :
       exact ActiveIn.seqLeft ih1
   | ite =>
       exact ActiveIn.iteRoot
+  | «while» =>
+      exact ActiveIn.whileRoot
 
 /-- Restrict abstract configurations to control states active in a fixed program. -/
 def gammaProgramConfigOf

--- a/Examples/IMP/Analysis/Interval/Defs.lean
+++ b/Examples/IMP/Analysis/Interval/Defs.lean
@@ -128,6 +128,20 @@ def transferProgramInterval :
       joinConfigInterval
         (transferProgramInterval s1 μ κ)
         (transferProgramInterval s2 μ κ)
+  | .while cond body, .whileTrue, κ =>
+      singletonConfigInterval
+        (.seq body (.while cond body))
+        (assumeTrueStoreInterval cond (κ (.while cond body)))
+  | .while cond body, .whileFalse, κ =>
+      singletonConfigInterval .skip
+        (assumeFalseStoreInterval cond (κ (.while cond body)))
+  | .while cond body, .seqStep μ, κ =>
+      liftSeqConfig (.while cond body)
+        (transferProgramInterval body μ (seqView (.while cond body) κ))
+  | .while cond body, .seqDone, κ =>
+      singletonConfigInterval (.while cond body)
+        ((seqView (.while cond body) κ) .skip)
+  | .while _ _, _, _ => botConfigInterval
 termination_by program _ _ => program
 
 /-- Package the generic Interval transfer as a framework step transformer. -/

--- a/Examples/IMP/Analysis/Interval/Soundness.lean
+++ b/Examples/IMP/Analysis/Interval/Soundness.lean
@@ -54,6 +54,10 @@ theorem localStepSoundIntervalOfActive
           cases hStep
       | ifFalse =>
           cases hStep
+      | whileTrue =>
+          cases hStep
+      | whileFalse =>
+          cases hStep
       | seqStep μInner =>
           rcases Step.seqStep_inv hStep with ⟨innerTarget, σInner, hTarget, hStepInner⟩
           have hInnerSound :
@@ -117,6 +121,10 @@ theorem localStepSoundIntervalOfActive
       | ifTrue =>
           simpa [transferProgramInterval] using hWrapped
       | ifFalse =>
+          simpa [transferProgramInterval] using hWrapped
+      | whileTrue =>
+          simpa [transferProgramInterval] using hWrapped
+      | whileFalse =>
           simpa [transferProgramInterval] using hWrapped
   | iteRoot =>
       rename_i cond s1 s2
@@ -224,6 +232,20 @@ theorem localStepSoundIntervalOfActive
               (κ₁ := transferProgramInterval s1 .seqDone κ)
               (κ₂ := transferProgramInterval s2 .seqDone κ)
               hWrapped
+      | whileTrue =>
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_left_interval
+              (program := .ite cond s1 s2)
+              (κ₁ := transferProgramInterval s1 .whileTrue κ)
+              (κ₂ := transferProgramInterval s2 .whileTrue κ)
+              hWrapped
+      | whileFalse =>
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_left_interval
+              (program := .ite cond s1 s2)
+              (κ₁ := transferProgramInterval s1 .whileFalse κ)
+              (κ₂ := transferProgramInterval s2 .whileFalse κ)
+              hWrapped
   | iteElse hInner ih =>
       rename_i cond s1 s2 inner
       intro κ μ σ target σ' hσ hStep
@@ -286,6 +308,91 @@ theorem localStepSoundIntervalOfActive
               (κ₁ := transferProgramInterval s1 .seqDone κ)
               (κ₂ := transferProgramInterval s2 .seqDone κ)
               hWrapped
+      | whileTrue =>
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_right_interval
+              (program := .ite cond s1 s2)
+              (κ₁ := transferProgramInterval s1 .whileTrue κ)
+              (κ₂ := transferProgramInterval s2 .whileTrue κ)
+              hWrapped
+      | whileFalse =>
+          simpa [transferProgramInterval] using
+            mem_gammaProgram_join_right_interval
+              (program := .ite cond s1 s2)
+              (κ₁ := transferProgramInterval s1 .whileFalse κ)
+              (κ₂ := transferProgramInterval s2 .whileFalse κ)
+              hWrapped
+  | whileRoot =>
+      rename_i cond body
+      intro κ μ σ target σ' hσ hStep
+      cases hStep with
+      | while_true hCond =>
+          have hStore :
+              σ ∈ gammaStoreOf gammaInterval (assumeTrueStoreInterval cond (κ (.while cond body))) :=
+            mem_gammaStoreOf_assumeTrueStoreInterval hσ hCond
+          have hRoot :
+              (.seq body (.while cond body), σ) ∈
+                gammaProgramInterval (.while cond body)
+                  (singletonConfigInterval (.seq body (.while cond body))
+                    (assumeTrueStoreInterval cond (κ (.while cond body)))) := by
+            refine ⟨ActiveIn.whileBody (ActiveIn.self body), ?_⟩
+            simpa [singletonConfigInterval, singletonConfig] using hStore
+          simpa [transferProgramInterval] using hRoot
+      | while_false hCond =>
+          have hStore :
+              σ ∈ gammaStoreOf gammaInterval (assumeFalseStoreInterval cond (κ (.while cond body))) :=
+            mem_gammaStoreOf_assumeFalseStoreInterval hσ hCond
+          have hRoot :
+              (.skip, σ) ∈
+                gammaProgramInterval (.while cond body)
+                  (singletonConfigInterval .skip
+                    (assumeFalseStoreInterval cond (κ (.while cond body)))) := by
+            refine ⟨ActiveIn.whileDone, ?_⟩
+            simpa [singletonConfigInterval, singletonConfig] using hStore
+          simpa [transferProgramInterval] using hRoot
+  | whileDone =>
+      rename_i cond body
+      intro κ μ σ target σ' hσ hStep
+      cases hStep
+  | whileBody hInner ih =>
+      rename_i cond body inner
+      intro κ μ σ target σ' hσ hStep
+      cases μ with
+      | assign =>
+          cases hStep
+      | ifTrue =>
+          cases hStep
+      | ifFalse =>
+          cases hStep
+      | whileTrue =>
+          cases hStep
+      | whileFalse =>
+          cases hStep
+      | seqStep μInner =>
+          rcases Step.seqStep_inv hStep with ⟨innerTarget, σInner, hTarget, hStepInner⟩
+          have hInnerSound :
+              (innerTarget, σInner) ∈
+                gammaProgramInterval body (transferProgramInterval body μInner (seqView (.while cond body) κ)) :=
+            ih (by simpa [seqView] using hσ) hStepInner
+          have hLifted :
+              (Stmt.seq innerTarget (.while cond body), σInner) ∈
+                gammaProgramInterval (.while cond body)
+                  (liftSeqConfig (.while cond body) (transferProgramInterval body μInner (seqView (.while cond body) κ))) := by
+            rcases hInnerSound with ⟨hActiveInner, hConfInner⟩
+            exact ⟨ActiveIn.whileBody hActiveInner, mem_gammaConfigOf_liftSeqConfigInterval hConfInner⟩
+          cases hTarget
+          simpa [transferProgramInterval] using hLifted
+      | seqDone =>
+          cases hStep
+          have hStore : σ ∈ gammaStoreOf gammaInterval ((seqView (.while cond body) κ) .skip) := by
+            simpa [seqView] using hσ
+          have hProg :
+              (.while cond body, σ) ∈
+                gammaProgramInterval (.while cond body)
+                  (singletonConfigInterval (.while cond body) ((seqView (.while cond body) κ) .skip)) := by
+            refine ⟨ActiveIn.whileRoot, ?_⟩
+            simpa [singletonConfigInterval, singletonConfig] using hStore
+          simpa [transferProgramInterval] using hProg
 
 /-- One-step soundness of the generic Interval transfer over the canonical labeled IMP LTS. -/
 theorem soundStep_impInterval

--- a/Examples/IMP/Analysis/Sign/Defs.lean
+++ b/Examples/IMP/Analysis/Sign/Defs.lean
@@ -134,6 +134,20 @@ def transferProgramSign :
       joinConfigSign
         (transferProgramSign s1 μ κ)
         (transferProgramSign s2 μ κ)
+  | .while cond body, .whileTrue, κ =>
+      singletonConfigSign
+        (.seq body (.while cond body))
+        (assumeTrueStore cond (κ (.while cond body)))
+  | .while cond body, .whileFalse, κ =>
+      singletonConfigSign .skip
+        (assumeFalseStore cond (κ (.while cond body)))
+  | .while cond body, .seqStep μ, κ =>
+      liftSeqConfig (.while cond body)
+        (transferProgramSign body μ (seqView (.while cond body) κ))
+  | .while cond body, .seqDone, κ =>
+      singletonConfigSign (.while cond body)
+        ((seqView (.while cond body) κ) .skip)
+  | .while _ _, _, _ => botConfigSign
 termination_by program _ _ => program
 
 /-- Package the generic Sign transfer as a framework step transformer. -/

--- a/Examples/IMP/Analysis/Sign/Soundness.lean
+++ b/Examples/IMP/Analysis/Sign/Soundness.lean
@@ -54,6 +54,10 @@ theorem localStepSoundSignOfActive
           cases hStep
       | ifFalse =>
           cases hStep
+      | whileTrue =>
+          cases hStep
+      | whileFalse =>
+          cases hStep
       | seqStep μInner =>
           rcases Step.seqStep_inv hStep with ⟨innerTarget, σInner, hTarget, hStepInner⟩
           have hInnerSound :
@@ -117,6 +121,10 @@ theorem localStepSoundSignOfActive
       | ifTrue =>
           simpa [transferProgramSign] using hWrapped
       | ifFalse =>
+          simpa [transferProgramSign] using hWrapped
+      | whileTrue =>
+          simpa [transferProgramSign] using hWrapped
+      | whileFalse =>
           simpa [transferProgramSign] using hWrapped
   | iteRoot =>
       rename_i cond s1 s2
@@ -224,6 +232,20 @@ theorem localStepSoundSignOfActive
               (κ₁ := transferProgramSign s1 .seqDone κ)
               (κ₂ := transferProgramSign s2 .seqDone κ)
               hWrapped
+      | whileTrue =>
+          simpa [transferProgramSign] using
+            mem_gammaProgram_join_left
+              (program := .ite cond s1 s2)
+              (κ₁ := transferProgramSign s1 .whileTrue κ)
+              (κ₂ := transferProgramSign s2 .whileTrue κ)
+              hWrapped
+      | whileFalse =>
+          simpa [transferProgramSign] using
+            mem_gammaProgram_join_left
+              (program := .ite cond s1 s2)
+              (κ₁ := transferProgramSign s1 .whileFalse κ)
+              (κ₂ := transferProgramSign s2 .whileFalse κ)
+              hWrapped
   | iteElse hInner ih =>
       rename_i cond s1 s2 inner
       intro κ μ σ target σ' hσ hStep
@@ -286,6 +308,91 @@ theorem localStepSoundSignOfActive
               (κ₁ := transferProgramSign s1 .seqDone κ)
               (κ₂ := transferProgramSign s2 .seqDone κ)
               hWrapped
+      | whileTrue =>
+          simpa [transferProgramSign] using
+            mem_gammaProgram_join_right
+              (program := .ite cond s1 s2)
+              (κ₁ := transferProgramSign s1 .whileTrue κ)
+              (κ₂ := transferProgramSign s2 .whileTrue κ)
+              hWrapped
+      | whileFalse =>
+          simpa [transferProgramSign] using
+            mem_gammaProgram_join_right
+              (program := .ite cond s1 s2)
+              (κ₁ := transferProgramSign s1 .whileFalse κ)
+              (κ₂ := transferProgramSign s2 .whileFalse κ)
+              hWrapped
+  | whileRoot =>
+      rename_i cond body
+      intro κ μ σ target σ' hσ hStep
+      cases hStep with
+      | while_true hCond =>
+          have hStore :
+              σ ∈ gammaStoreOf gammaSign (assumeTrueStore cond (κ (.while cond body))) :=
+            mem_gammaStoreOf_assumeTrueStore hσ hCond
+          have hRoot :
+              (.seq body (.while cond body), σ) ∈
+                gammaProgramSign (.while cond body)
+                  (singletonConfigSign (.seq body (.while cond body))
+                    (assumeTrueStore cond (κ (.while cond body)))) := by
+            refine ⟨ActiveIn.whileBody (ActiveIn.self body), ?_⟩
+            simpa [singletonConfigSign] using hStore
+          simpa [transferProgramSign] using hRoot
+      | while_false hCond =>
+          have hStore :
+              σ ∈ gammaStoreOf gammaSign (assumeFalseStore cond (κ (.while cond body))) :=
+            mem_gammaStoreOf_assumeFalseStore hσ hCond
+          have hRoot :
+              (.skip, σ) ∈
+                gammaProgramSign (.while cond body)
+                  (singletonConfigSign .skip
+                    (assumeFalseStore cond (κ (.while cond body)))) := by
+            refine ⟨ActiveIn.whileDone, ?_⟩
+            simpa [singletonConfigSign] using hStore
+          simpa [transferProgramSign] using hRoot
+  | whileDone =>
+      rename_i cond body
+      intro κ μ σ target σ' hσ hStep
+      cases hStep
+  | whileBody hInner ih =>
+      rename_i cond body inner
+      intro κ μ σ target σ' hσ hStep
+      cases μ with
+      | assign =>
+          cases hStep
+      | ifTrue =>
+          cases hStep
+      | ifFalse =>
+          cases hStep
+      | whileTrue =>
+          cases hStep
+      | whileFalse =>
+          cases hStep
+      | seqStep μInner =>
+          rcases Step.seqStep_inv hStep with ⟨innerTarget, σInner, hTarget, hStepInner⟩
+          have hInnerSound :
+              (innerTarget, σInner) ∈
+                gammaProgramSign body (transferProgramSign body μInner (seqView (.while cond body) κ)) :=
+            ih (by simpa [seqView] using hσ) hStepInner
+          have hLifted :
+              (Stmt.seq innerTarget (.while cond body), σInner) ∈
+                gammaProgramSign (.while cond body)
+                  (liftSeqConfig (.while cond body) (transferProgramSign body μInner (seqView (.while cond body) κ))) := by
+            rcases hInnerSound with ⟨hActiveInner, hConfInner⟩
+            exact ⟨ActiveIn.whileBody hActiveInner, mem_gammaConfigOf_liftSeqConfig hConfInner⟩
+          cases hTarget
+          simpa [transferProgramSign] using hLifted
+      | seqDone =>
+          cases hStep
+          have hStore : σ ∈ gammaStoreOf gammaSign ((seqView (.while cond body) κ) .skip) := by
+            simpa [seqView] using hσ
+          have hProg :
+              (.while cond body, σ) ∈
+                gammaProgramSign (.while cond body)
+                  (singletonConfigSign (.while cond body) ((seqView (.while cond body) κ) .skip)) := by
+            refine ⟨ActiveIn.whileRoot, ?_⟩
+            simpa [singletonConfigSign] using hStore
+          simpa [transferProgramSign] using hProg
 
 /-- One-step soundness of the generic Sign transfer over the canonical labeled IMP LTS. -/
 theorem soundStep_impSign

--- a/Examples/IMP/Pretty.lean
+++ b/Examples/IMP/Pretty.lean
@@ -18,6 +18,7 @@ scoped syntax "(" imp_stmt ")" : imp_stmt
 scoped syntax ident " := " imp_expr : imp_stmt
 scoped syntax:60 imp_stmt:61 " ;; " imp_stmt:60 : imp_stmt
 scoped syntax "if " imp_expr " then " imp_stmt " else " imp_stmt : imp_stmt
+scoped syntax "while " imp_expr " do " imp_stmt : imp_stmt
 
 syntax "[imp_expr| " imp_expr "]" : term
 syntax "[imp| " imp_stmt "]" : term
@@ -48,5 +49,7 @@ macro_rules
       `(Stmt.seq [imp| $s1] [imp| $s2])
   | `([imp| if $cond:imp_expr then $s1:imp_stmt else $s2:imp_stmt]) =>
       `(Stmt.ite [imp_expr| $cond] [imp| $s1] [imp| $s2])
+  | `([imp| while $cond:imp_expr do $body:imp_stmt]) =>
+      `(Stmt.while [imp_expr| $cond] [imp| $body])
 
 end Examples.IMP

--- a/Examples/IMP/Programs.lean
+++ b/Examples/IMP/Programs.lean
@@ -1,9 +1,11 @@
 import Examples.IMP.Programs.Tutorial
 import Examples.IMP.Programs.Showcase
+import Examples.IMP.Programs.WidenShowcase
 
 /-!
 Program-level demonstrations for the IMP example suite.
 
 - `Tutorial`: small standalone LTSs that introduce the framework API
 - `Showcase`: the main generic IMP case study over the canonical IMP LTS
+- `WidenShowcase`: widening-based Interval analysis over a while loop
 -/

--- a/Examples/IMP/Programs/WidenShowcase.lean
+++ b/Examples/IMP/Programs/WidenShowcase.lean
@@ -1,0 +1,152 @@
+import Examples.IMP.Analysis.Interval
+import Examples.IMP.Pretty
+
+/-!
+# Widening-based Interval analysis for a looping IMP program
+
+Demonstrates the framework widening interfaces (`pfp`, `WAcc`,
+`WidenUpperBound`) on a simple while-loop IMP program analyzed with
+the Interval domain.
+
+## Program
+
+```
+x0 := 0;
+while x1 do
+  x0 := x0 + 1
+```
+
+## Approach
+
+A finite 4-element domain tracks the Interval progression of `x0` at the
+loop head: `⊥ → [0,0] → [0,1] → ⊤`. Each element maps to a concrete
+`Interval` via `toInterval`, connecting to the Interval domain's
+concretization. Widening jumps to `⊤` when bounds change, exactly
+matching the aggressive `widenInterval` strategy.
+
+The framework `pfp` computes a post-fixpoint in two widening steps,
+and `isPostFixpoint_pfp` certifies the result.
+-/
+
+namespace Examples.IMP.Programs
+
+open AbsInterpLTS.Domains
+open AbsInterpLTS.Framework.Iteration
+
+/-! ## The IMP program -/
+
+/-- The IMP program analyzed with widening. -/
+def widenShowcase : Stmt := [imp|
+  x0 := 0 ;;
+  while x1 do
+    x0 := x0 + 1
+]
+
+/-! ## Finite loop domain
+
+A 4-element domain tracking the Interval progression of `x0` during
+widened iteration. Follows the `Flat3` test pattern. -/
+
+/-- Finite abstraction of `x0` at the while-loop head. -/
+inductive LoopAbs where
+  | bot
+  | zero     -- represents [0, 0]
+  | zeroOne  -- represents [0, 1]
+  | top
+  deriving DecidableEq, Repr
+
+namespace LoopAbs
+
+/-- Map to the Interval domain. -/
+def toInterval : LoopAbs → Interval
+  | .bot => .bot
+  | .zero => AbsInterpLTS.Domains.mk 0 0
+  | .zeroOne => AbsInterpLTS.Domains.mk 0 1
+  | .top => .top
+
+/-- Concretization via Interval. -/
+def gamma (a : LoopAbs) : Set Int :=
+  gammaInterval (toInterval a)
+
+/-- Flat order. -/
+def le : LoopAbs → LoopAbs → Prop
+  | .bot, _ => True
+  | .zero, .zero => True
+  | .zero, .top => True
+  | .zeroOne, .zeroOne => True
+  | .zeroOne, .top => True
+  | .top, .top => True
+  | _, _ => False
+
+instance : DecidableRel le := by
+  intro a b; cases a <;> cases b <;> simp [le] <;> exact inferInstance
+
+theorem le_refl : ∀ a : LoopAbs, le a a := by
+  intro a; cases a <;> simp [le]
+
+/-- Gamma monotonicity. -/
+theorem gamma_mono : ∀ {a b : LoopAbs}, le a b → gamma a ⊆ gamma b := by
+  intro a b hab
+  cases a <;> cases b <;> simp_all [le, gamma, toInterval, gammaInterval, AbsInterpLTS.Domains.mk]
+
+/--
+Abstract loop body transfer: models `x0 := x0 + 1`.
+
+- `f(bot) = zero`: initial entry sets x0 = 0, joined with body(bot) = bot
+- `f(zero) = zeroOne`: join([0,0], [0,0]+1) = join([0,0], [1,1]) = [0,1]
+- `f(zeroOne) = top`: join([0,0], [0,1]+1) = join([0,0], [1,2]) = [0,2], but
+  [0,2] is not in our finite domain, so we over-approximate as ⊤
+- `f(top) = top`: join([0,0], ⊤+1) = ⊤
+-/
+def f : LoopAbs → LoopAbs
+  | .bot => .zero
+  | .zero => .zeroOne
+  | .zeroOne => .top
+  | .top => .top
+
+/-- `f` is sound: concrete computation stays within `gamma (f a)`. -/
+theorem f_sound (a : LoopAbs) :
+    ∀ n ∈ gamma a, (n + 1) ∈ gamma (f a) ∧ (0 : Int) ∈ gamma (f a) := by
+  intro n hn
+  cases a <;> simp_all [f, gamma, toInterval, gammaInterval, AbsInterpLTS.Domains.mk]
+  all_goals omega
+
+/-- Widening: jump to ⊤ unless equal. -/
+def w : Widen LoopAbs
+  | a, b => if a == b then a else .top
+
+theorem w_upper_bound : WidenUpperBound le w where
+  left := by
+    intro a b; by_cases h : a == b
+    · simp [w, h]; cases a <;> simp [le, BEq.beq, decide_eq_true_eq] at h ⊢
+    · simp [w, h]; cases a <;> simp [le]
+  right := by
+    intro a b; by_cases h : a == b
+    · simp [w, h]; cases a <;> cases b <;> simp_all [le, BEq.beq]
+    · simp [w, h]; cases b <;> simp [le]
+
+/-- WAcc witness: 2 widening steps suffice. -/
+def wacc : WAcc le f w .bot .bot := by
+  apply WAcc.intro; intro _ _
+  apply WAcc.intro; intro _ _
+  apply WAcc.intro; intro _ h
+  exact absurd (le_refl (f .top)) h
+
+theorem hBot : ∀ a : LoopAbs, le .bot a := by
+  intro a; cases a <;> simp [le]
+
+/-- Compute post-fixpoint via framework `pfp`. -/
+def loopPfp : LoopAbs :=
+  pfp (inferInstance) w_upper_bound .bot hBot wacc
+
+/-- The computed result is ⊤. -/
+theorem loopPfp_eq_top : loopPfp = .top := by native_decide
+
+/-- The result is a genuine post-fixpoint: `f(result) ≤ result`. -/
+theorem loopPfp_isPostFixpoint :
+    IsPostFixpoint le f loopPfp :=
+  isPostFixpoint_pfp (inferInstance) w_upper_bound .bot hBot wacc
+
+end LoopAbs
+
+end Examples.IMP.Programs

--- a/Examples/IMP/Semantics/Defs.lean
+++ b/Examples/IMP/Semantics/Defs.lean
@@ -27,6 +27,8 @@ inductive StepLabel where
   | seqDone
   | ifTrue
   | ifFalse
+  | whileTrue
+  | whileFalse
   deriving DecidableEq, Repr
 
 /-- Labeled small-step transition relation for IMP. -/
@@ -44,5 +46,11 @@ inductive Step : Config → StepLabel → Config → Prop where
   | if_false {cond : Expr} {s1 s2 : Stmt} {σ : Store} :
       eval σ cond = 0 →
       Step (.ite cond s1 s2, σ) .ifFalse (s2, σ)
+  | while_true {cond : Expr} {body : Stmt} {σ : Store} :
+      eval σ cond ≠ 0 →
+      Step (.while cond body, σ) .whileTrue (.seq body (.while cond body), σ)
+  | while_false {cond : Expr} {body : Stmt} {σ : Store} :
+      eval σ cond = 0 →
+      Step (.while cond body, σ) .whileFalse (.skip, σ)
 
 end Examples.IMP

--- a/Examples/IMP/Syntax.lean
+++ b/Examples/IMP/Syntax.lean
@@ -19,12 +19,13 @@ inductive Expr where
   | add (e1 e2 : Expr)
   deriving DecidableEq, Repr
 
-/-- Statements: the core IMP constructs (no loops in this subset). -/
+/-- Statements: the core IMP constructs including while loops. -/
 inductive Stmt where
   | skip
   | assign (x : Var) (e : Expr)
   | seq (s1 s2 : Stmt)
   | ite (cond : Expr) (s1 s2 : Stmt)
+  | while (cond : Expr) (body : Stmt)
   deriving DecidableEq, Repr
 
 end Examples.IMP


### PR DESCRIPTION
## Summary
- Add `while` loops to IMP syntax with `whileTrue`/`whileFalse` labeled small-step rules
- Extend both Sign and Interval transfer functions with full soundness proofs for while
- Add `widenInterval` with `WidenUpperBound` proof to the Interval domain
- Create `WidenShowcase.lean`: a widening-based post-fixpoint example using framework `pfp`

## Linked Issue
Closes #54

## Scope
- `Examples/IMP/` — syntax, semantics, abstraction, analyses, programs
- `AbsInterpLTS/Domains/Interval.lean` — widening operation
- Framework and Instances layers untouched

## Validation
- `lake build` ✅ (811 jobs)
- `lake build Tests` ✅ (840 jobs, axiom profile unchanged)
- `lake test` ✅ ("all build checks passed")
- All while soundness proofs are complete (no `sorry`)

## Test plan
- [x] Sign and Interval analyses build with while transfer cases
- [x] Full local step soundness proven for while in both analyses
- [x] `widenInterval` upper-bound contract proven
- [x] `WidenShowcase`: `pfp` computes ⊤ post-fixpoint via `native_decide`
- [x] Existing Showcase, Tutorial, and Smoke tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)