### PR TITLE
refactor(examples): define IMPAnalysisDomain interface

### DIFF
--- a/Examples/IMP/Analysis.lean
+++ b/Examples/IMP/Analysis.lean
@@ -1,2 +1,3 @@
+import Examples.IMP.Analysis.Generic
 import Examples.IMP.Analysis.Sign
 import Examples.IMP.Analysis.Interval

--- a/Examples/IMP/Analysis/Generic.lean
+++ b/Examples/IMP/Analysis/Generic.lean
@@ -1,0 +1,1 @@
+import Examples.IMP.Analysis.Generic.Domain

--- a/Examples/IMP/Analysis/Generic/Domain.lean
+++ b/Examples/IMP/Analysis/Generic/Domain.lean
@@ -1,0 +1,77 @@
+import Cslib.Init
+import Mathlib.Data.Set.Lattice
+
+import AbsInterpLTS.Framework.Domains
+import Examples.IMP.Semantics
+
+namespace Examples.IMP
+
+open AbsInterpLTS.Framework.Domains
+
+universe u
+
+/-!
+# IMP Analysis Domain Interface
+
+`IMPAnalysisDomain` captures the domain-specific obligations for an IMP
+abstract analysis, so that transfer functions and soundness proofs can be
+written once generically.
+
+The interface sits between the scalar abstract domain (`GammaOnlyDomain A Int`)
+and the IMP-specific analysis machinery. A concrete instance must supply:
+
+- scalar expression evaluation primitives (`const`, `addTransfer`) with
+  soundness,
+- branch refinement operators (`assumeNonzero`, `assumeZero`) with soundness,
+- a proof that the bottom element has empty concretization.
+-/
+
+/--
+Domain-specific obligations for a generic IMP abstract analysis.
+
+An instance packages a scalar `GammaOnlyDomain` together with the transfer
+primitives and soundness contracts needed by the generic IMP transfer function
+and its soundness proof.
+-/
+structure IMPAnalysisDomain (A : Type u) [Bot A] where
+  /-- The underlying scalar gamma-only domain over integers. -/
+  scalarDomain : GammaOnlyDomain A Int
+  /-- The bottom element has empty concretization. -/
+  gamma_bot : scalarDomain.gamma ⊥ = ∅
+  /-- Abstract a concrete integer constant. -/
+  const : Int → A
+  /-- Constant abstraction is sound. -/
+  const_sound : ∀ n : Int, n ∈ scalarDomain.gamma (const n)
+  /-- Abstract addition transfer. -/
+  addTransfer : A → A → A
+  /-- Addition transfer is sound. -/
+  addTransfer_sound : ∀ {a₁ a₂ : A} {v₁ v₂ : Int},
+    v₁ ∈ scalarDomain.gamma a₁ → v₂ ∈ scalarDomain.gamma a₂ →
+    v₁ + v₂ ∈ scalarDomain.gamma (addTransfer a₁ a₂)
+  /-- Refine an abstract value under a nonzero assumption. -/
+  assumeNonzero : A → A
+  /-- Nonzero refinement is sound. -/
+  assumeNonzero_sound : ∀ {a : A} {v : Int},
+    v ∈ scalarDomain.gamma a → v ≠ 0 → v ∈ scalarDomain.gamma (assumeNonzero a)
+  /-- Refine an abstract value under a zero assumption. -/
+  assumeZero : A → A
+  /-- Zero refinement is sound. -/
+  assumeZero_sound : ∀ {a : A} {v : Int},
+    v ∈ scalarDomain.gamma a → v = 0 → v ∈ scalarDomain.gamma (assumeZero a)
+
+namespace IMPAnalysisDomain
+
+variable {A : Type u} [Bot A] (d : IMPAnalysisDomain A)
+
+/-- Convenience accessor for the scalar concretization function. -/
+abbrev gamma : A → Set Int := d.scalarDomain.gamma
+
+/-- Convenience accessor for the scalar join. -/
+abbrev join : A → A → A := d.scalarDomain.join
+
+/-- Convenience accessor for the scalar top element. -/
+abbrev top : A := d.scalarDomain.top
+
+end IMPAnalysisDomain
+
+end Examples.IMP


### PR DESCRIPTION
## Summary
- Define `IMPAnalysisDomain` structure in `Examples/IMP/Analysis/Generic/Domain.lean` that captures domain-specific obligations for a generic IMP abstract analysis
- Interface bundles scalar `GammaOnlyDomain`, expression evaluation primitives (`const`, `addTransfer`), branch refinement operators (`assumeNonzero`, `assumeZero`), and soundness contracts for each
- Add barrel file and import wiring through `Examples/IMP/Analysis.lean`

## Linked issue
Closes #73

## Scope
- New file: `Examples/IMP/Analysis/Generic/Domain.lean`
- New barrel: `Examples/IMP/Analysis/Generic.lean`
- Updated import: `Examples/IMP/Analysis.lean`
- No changes to existing Sign or Interval analyses

## Validation
- `lake build` passes (829 jobs)
- `lake build Tests` passes (842 jobs)
- Interface signatures verified to be instantiable by both Sign and Interval domains (matching `constSign_sound`/`constInterval_sound`, `addTransfer_sound`/`addIntervalTransfer_sound`, `assumeNonzero_sound`/`assumeNonzeroInterval_sound`, `assumeZero_sound`/`assumeZeroInterval_sound`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)