### PR TITLE
feat(examples): add Parity domain as M9 validation

### DIFF
--- a/AbsInterpLTS/Domains.lean
+++ b/AbsInterpLTS/Domains.lean
@@ -2,3 +2,4 @@ import Cslib.Init
 
 import AbsInterpLTS.Domains.Sign
 import AbsInterpLTS.Domains.Interval
+import AbsInterpLTS.Domains.Parity

--- a/AbsInterpLTS/Domains/Parity.lean
+++ b/AbsInterpLTS/Domains/Parity.lean
@@ -1,0 +1,136 @@
+import Cslib.Init
+import Mathlib.Data.Set.Lattice
+import AbsInterpLTS.Framework.Domains
+
+namespace AbsInterpLTS
+namespace Domains
+
+open AbsInterpLTS.Framework.Domains
+
+/-!
+# Parity Domain
+
+A simple 4-element abstract domain tracking integer parity (even/odd).
+Used as a validation target for the generic IMP analysis framework.
+-/
+
+/-- Four-point parity domain: `⊥`, `even`, `odd`, `⊤`. -/
+inductive Parity where
+  | bot
+  | even
+  | odd
+  | top
+  deriving DecidableEq, Repr
+
+instance : Bot Parity where
+  bot := .bot
+
+/-- Concretization map from abstract parity to sets of integers. -/
+def gammaParity : Parity → Set Int
+  | .bot => ∅
+  | .even => { n : Int | n % 2 = 0 }
+  | .odd => { n : Int | n % 2 ≠ 0 }
+  | .top => Set.univ
+
+/-- Order on the parity lattice. -/
+def leParity : Parity → Parity → Prop
+  | .bot, _ => True
+  | _, .top => True
+  | .even, .even => True
+  | .odd, .odd => True
+  | _, _ => False
+
+instance : DecidableRel leParity := by
+  intro a b; cases a <;> cases b <;> simp [leParity] <;> exact inferInstance
+
+theorem leParity_refl : ∀ a : Parity, leParity a a := by
+  intro a; cases a <;> simp [leParity]
+
+theorem leParity_trans : ∀ {a b c : Parity}, leParity a b → leParity b c → leParity a c := by
+  intro a b c hab hbc; cases a <;> cases b <;> cases c <;> simp_all [leParity]
+
+theorem gammaParity_monotone : ∀ {a b : Parity}, leParity a b → gammaParity a ⊆ gammaParity b := by
+  intro a b hab; cases a <;> cases b <;> simp_all [leParity, gammaParity, Set.subset_univ]
+
+/-- Join on the parity lattice. -/
+def joinParity : Parity → Parity → Parity
+  | .bot, a => a
+  | a, .bot => a
+  | .even, .even => .even
+  | .odd, .odd => .odd
+  | _, _ => .top
+
+theorem joinParity_sound : ∀ a b : Parity, gammaParity a ∪ gammaParity b ⊆ gammaParity (joinParity a b) := by
+  intro a b n hn
+  cases a <;> cases b <;> simp_all [joinParity, gammaParity, Set.mem_union, Set.mem_empty_iff_false]
+
+/-- The complete gamma-only domain instance for Parity. -/
+def parityGammaOnlyDomain : GammaOnlyDomain Parity Int where
+  gamma := gammaParity
+  le := leParity
+  le_refl := leParity_refl
+  le_trans := leParity_trans
+  gamma_monotone := gammaParity_monotone
+  top := .top
+  gamma_top := fun _ => Set.mem_univ _
+  join := joinParity
+  join_sound := joinParity_sound
+
+/-- Abstract a concrete integer constant by its parity. -/
+def constParity (n : Int) : Parity :=
+  if n % 2 = 0 then .even else .odd
+
+theorem constParity_sound (n : Int) : n ∈ gammaParity (constParity n) := by
+  unfold constParity
+  by_cases h : n % 2 = 0 <;> simp_all [gammaParity]
+
+/-- Abstract addition transfer for the parity domain. -/
+def addParityTransfer : Parity → Parity → Parity
+  | .bot, _ => .bot
+  | _, .bot => .bot
+  | .top, _ => .top
+  | _, .top => .top
+  | .even, .even => .even
+  | .even, .odd => .odd
+  | .odd, .even => .odd
+  | .odd, .odd => .even
+
+theorem addParityTransfer_sound
+    {a b : Parity} {m n : Int}
+    (hm : m ∈ gammaParity a)
+    (hn : n ∈ gammaParity b) :
+    m + n ∈ gammaParity (addParityTransfer a b) := by
+  cases a <;> cases b <;> simp_all [addParityTransfer, gammaParity]
+  all_goals omega
+
+/-- Refine a parity value under a nonzero assumption. -/
+def assumeNonzeroParity : Parity → Parity
+  | .bot => .bot
+  | .even => .even
+  | .odd => .odd
+  | .top => .top
+
+theorem assumeNonzeroParity_sound
+    {a : Parity} {n : Int}
+    (hn : n ∈ gammaParity a)
+    (_ : n ≠ 0) :
+    n ∈ gammaParity (assumeNonzeroParity a) := by
+  cases a <;> simp_all [assumeNonzeroParity, gammaParity]
+
+/-- Refine a parity value under a zero assumption. -/
+def assumeZeroParity : Parity → Parity
+  | .bot => .bot
+  | .even => .even
+  | .odd => .bot
+  | .top => .even
+
+theorem assumeZeroParity_sound
+    {a : Parity} {n : Int}
+    (hn : n ∈ gammaParity a)
+    (hZero : n = 0) :
+    n ∈ gammaParity (assumeZeroParity a) := by
+  subst hZero
+  cases a <;> simp_all [assumeZeroParity, gammaParity]
+
+end Domains
+end AbsInterpLTS

--- a/AbsInterpLTS/Domains/Parity.lean
+++ b/AbsInterpLTS/Domains/Parity.lean
@@ -103,19 +103,14 @@ theorem addParityTransfer_sound
   cases a <;> cases b <;> simp_all [addParityTransfer, gammaParity]
   all_goals omega
 
-/-- Refine a parity value under a nonzero assumption. -/
-def assumeNonzeroParity : Parity → Parity
-  | .bot => .bot
-  | .even => .even
-  | .odd => .odd
-  | .top => .top
+/-- Refine a parity value under a nonzero assumption (identity — parity cannot refine). -/
+def assumeNonzeroParity : Parity → Parity := id
 
 theorem assumeNonzeroParity_sound
     {a : Parity} {n : Int}
     (hn : n ∈ gammaParity a)
     (_ : n ≠ 0) :
-    n ∈ gammaParity (assumeNonzeroParity a) := by
-  cases a <;> simp_all [assumeNonzeroParity, gammaParity]
+    n ∈ gammaParity (assumeNonzeroParity a) := hn
 
 /-- Refine a parity value under a zero assumption. -/
 def assumeZeroParity : Parity → Parity

--- a/Examples/IMP/Analysis.lean
+++ b/Examples/IMP/Analysis.lean
@@ -1,3 +1,4 @@
 import Examples.IMP.Analysis.Generic
 import Examples.IMP.Analysis.Sign
 import Examples.IMP.Analysis.Interval
+import Examples.IMP.Analysis.Parity

--- a/Examples/IMP/Analysis/Parity.lean
+++ b/Examples/IMP/Analysis/Parity.lean
@@ -1,0 +1,1 @@
+import Examples.IMP.Analysis.Parity.Defs

--- a/Examples/IMP/Analysis/Parity/Defs.lean
+++ b/Examples/IMP/Analysis/Parity/Defs.lean
@@ -1,0 +1,58 @@
+import AbsInterpLTS.Domains.Parity
+import AbsInterpLTS.Framework
+import AbsInterpLTS.Instances.LTS
+import Examples.IMP.Analysis.Generic
+
+namespace Examples.IMP
+
+open AbsInterpLTS
+open AbsInterpLTS.Domains
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Framework.Domains
+open AbsInterpLTS.Instances.LTS
+
+/-!
+# Parity Analysis — Domain Instance
+
+Thin wrapper that instantiates the generic IMP analysis for the Parity domain.
+Validates that adding a new domain to the generic framework requires minimal code.
+-/
+
+/-- IMP analysis domain instance for Parity. -/
+def parityAnalysisDomain : IMPAnalysisDomain Parity where
+  scalarDomain := parityGammaOnlyDomain
+  gamma_bot := rfl
+  const := constParity
+  const_sound := constParity_sound
+  addTransfer := addParityTransfer
+  addTransfer_sound := addParityTransfer_sound
+  assumeNonzero := assumeNonzeroParity
+  assumeNonzero_sound := assumeNonzeroParity_sound
+  assumeZero := assumeZeroParity
+  assumeZero_sound := assumeZeroParity_sound
+
+/-- The generic Parity concretization for a fixed IMP program. -/
+def gammaProgramParity (program : Stmt) : Framework.Gamma (ConfigSharp Parity) Config :=
+  gammaProgram parityAnalysisDomain program
+
+/-- Top abstract store for IMP Parity analysis. -/
+def topStoreParity : StoreSharp Parity := fun _ => .top
+
+/-- Generic Parity transfer for the labeled IMP LTS. -/
+def transferProgramParity := transferProgram parityAnalysisDomain
+
+/-- Package the generic Parity transfer as a framework step transformer. -/
+def impParityTransfer (program : Stmt) : StepPostSharp (ConfigSharp Parity) StepLabel :=
+  impTransfer parityAnalysisDomain program
+
+/-- One-step soundness of the generic Parity transfer over the canonical labeled IMP LTS. -/
+theorem soundStep_impParity (program : Stmt) :
+    SoundStep (postStep impLTS) (gammaProgramParity program) (impParityTransfer program) :=
+  soundStep_imp parityAnalysisDomain program
+
+/-- LTS abstraction packaging the generic Parity IMP analysis for a fixed program. -/
+def impParityAbstraction (program : Stmt) :
+    LTSAbstraction Config StepLabel (ConfigSharp Parity) :=
+  impAbstraction parityAnalysisDomain program
+
+end Examples.IMP

--- a/Tests.lean
+++ b/Tests.lean
@@ -4,6 +4,7 @@ import AbsInterpLTS
 import Tests.Domains.Interval
 import Tests.Domains.Sign
 import Tests.Examples.IMP.Smoke
+import Tests.Examples.IMP.ParitySmoke
 import Tests.Framework.Domains.GammaOnly
 import Tests.Instances.LTS.Smoke
 import Tests.Instances.LTS.Collecting

--- a/Tests/Examples/IMP/ParitySmoke.lean
+++ b/Tests/Examples/IMP/ParitySmoke.lean
@@ -1,0 +1,59 @@
+import Cslib.Init
+
+import Examples
+
+namespace Tests
+namespace ExamplesIMPParitySmoke
+
+open AbsInterpLTS
+open AbsInterpLTS.Domains
+open AbsInterpLTS.Framework
+open AbsInterpLTS.Instances.LTS
+open Examples.IMP
+
+/-!
+# Parity Analysis Smoke Tests
+
+Validates the Parity domain instantiation of the generic IMP analysis framework.
+-/
+
+/-- `x0 := 5` assigns an odd value. -/
+def assignOdd : Stmt :=
+  .assign Var.x0 (.lit 5)
+
+/-- `x0 := 4` assigns an even value. -/
+def assignEven : Stmt :=
+  .assign Var.x0 (.lit 4)
+
+/-- `x0 := 5; x1 := x0 + x0` — odd + odd = even. -/
+def addOddOdd : Stmt :=
+  .seq (.assign Var.x0 (.lit 5)) (.assign Var.x1 (.add (.var Var.x0) (.var Var.x0)))
+
+example :
+    (transferProgramParity assignOdd .assign (initAt assignOdd topStoreParity))
+      .skip Var.x0 = .odd := by
+  native_decide
+
+example :
+    (transferProgramParity assignEven .assign (initAt assignEven topStoreParity))
+      .skip Var.x0 = .even := by
+  native_decide
+
+/-- odd + odd = even, validated along a two-step trace. -/
+example :
+    (liftTracePostSharp (impParityTransfer addOddOdd)
+      [.seqStep .assign, .seqDone, .assign]
+      (initAt addOddOdd topStoreParity))
+      .skip Var.x1 = .even := by
+  native_decide
+
+/-- Soundness: the Parity analysis is trace-sound over the canonical IMP LTS. -/
+example :
+    SoundTrace
+      (liftTracePost (postStep impLTS))
+      (gammaProgramParity assignOdd)
+      (liftTracePostSharp (impParityTransfer assignOdd)) :=
+  (impParityAbstraction assignOdd).soundTraceLifted
+
+end ExamplesIMPParitySmoke
+end Tests


### PR DESCRIPTION
## Summary
- Add 4-element Parity domain (`bot`/`even`/`odd`/`top`) in `AbsInterpLTS/Domains/Parity.lean`
- Instantiate `IMPAnalysisDomain` for Parity in 58 lines (target: < 100)
- Add smoke tests: assignment parity tracking, odd+odd=even composition, trace soundness

## Linked issue
Closes #75

## Scope
- New: `AbsInterpLTS/Domains/Parity.lean`, `Examples/IMP/Analysis/Parity/Defs.lean`, `Tests/Examples/IMP/ParitySmoke.lean`
- Updated: barrel imports (`Domains.lean`, `Analysis.lean`, `Tests.lean`)

## Validation
- `lake build` passes (831 jobs)
- `lake build Tests` passes (845 jobs)
- `lake test` passes
- Axiom profile unchanged
- Instantiation < 100 lines (58 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)