### PR TITLE
feat(framework): backward abstract operators interface

### DIFF
--- a/AbsInterp/Domains/Sign.lean
+++ b/AbsInterp/Domains/Sign.lean
@@ -221,6 +221,70 @@ theorem assumeZero_sound
     simp [gammaSign, assumeZero] at hn ⊢ <;>
     omega
 
+/-- Meet (greatest lower bound) on signs. -/
+def meetSign (a b : Sign) : Sign :=
+  signOfFlags
+    (hasNeg a && hasNeg b)
+    (hasZero a && hasZero b)
+    (hasPos a && hasPos b)
+
+/-- `meetSign` is sound: intersection of concretizations is contained in the meet. -/
+theorem meetSign_sound
+    {a b : Sign}
+    {n : Int}
+    (ha : n ∈ gammaSign a)
+    (hb : n ∈ gammaSign b) :
+    n ∈ gammaSign (meetSign a b) := by
+  cases a <;> cases b <;>
+    simp [gammaSign, meetSign, signOfFlags, hasNeg, hasZero, hasPos] at ha hb ⊢ <;>
+    omega
+
+/-- Backward refinement for addition under nonzero constraint. -/
+def assumeNonzeroAddSign (a₁ a₂ : Sign) : Sign × Sign :=
+  match a₂ with
+  | .zero => (assumeNonzero a₁, a₂)
+  | _ => match a₁ with
+    | .zero => (a₁, assumeNonzero a₂)
+    | _ => (a₁, a₂)
+
+/-- `assumeNonzeroAddSign` is sound. -/
+theorem assumeNonzeroAddSign_sound
+    {a₁ a₂ : Sign}
+    {v₁ v₂ : Int}
+    (h₁ : v₁ ∈ gammaSign a₁)
+    (h₂ : v₂ ∈ gammaSign a₂)
+    (hNe : v₁ + v₂ ≠ 0) :
+    v₁ ∈ gammaSign (assumeNonzeroAddSign a₁ a₂).1 ∧
+    v₂ ∈ gammaSign (assumeNonzeroAddSign a₁ a₂).2 := by
+  cases a₁ <;> cases a₂ <;>
+    simp [gammaSign, assumeNonzeroAddSign, assumeNonzero] at h₁ h₂ ⊢ <;>
+    omega
+
+/-- Backward refinement for addition under zero constraint. -/
+def assumeZeroAddSign (a₁ a₂ : Sign) : Sign × Sign :=
+  ( match a₂ with
+    | .bot => a₁ | .zero => assumeZero a₁ | .pos => meetSign a₁ .neg
+    | .neg => meetSign a₁ .pos | .nonneg => meetSign a₁ .nonpos
+    | .nonpos => meetSign a₁ .nonneg | .top => a₁
+  , match a₁ with
+    | .bot => a₂ | .zero => assumeZero a₂ | .pos => meetSign a₂ .neg
+    | .neg => meetSign a₂ .pos | .nonneg => meetSign a₂ .nonpos
+    | .nonpos => meetSign a₂ .nonneg | .top => a₂ )
+
+/-- `assumeZeroAddSign` is sound. -/
+theorem assumeZeroAddSign_sound
+    {a₁ a₂ : Sign}
+    {v₁ v₂ : Int}
+    (h₁ : v₁ ∈ gammaSign a₁)
+    (h₂ : v₂ ∈ gammaSign a₂)
+    (hZero : v₁ + v₂ = 0) :
+    v₁ ∈ gammaSign (assumeZeroAddSign a₁ a₂).1 ∧
+    v₂ ∈ gammaSign (assumeZeroAddSign a₁ a₂).2 := by
+  cases a₁ <;> cases a₂ <;>
+    simp [gammaSign, assumeZeroAddSign, assumeZero, meetSign,
+          signOfFlags, hasNeg, hasZero, hasPos] at h₁ h₂ ⊢ <;>
+    omega
+
 /-- Baseline unary transfer shape: abstract negation. -/
 def negTransfer : Sign -> Sign
   | .bot => .bot

--- a/AbsInterp/Domains/Sign.lean
+++ b/AbsInterp/Domains/Sign.lean
@@ -241,7 +241,8 @@ theorem meetSign_sound
 
 /-- Backward refinement for addition under nonzero constraint. -/
 def assumeNonzeroAddSign (a₁ a₂ : Sign) : Sign × Sign :=
-  match a₂ with
+  if a₁ = .bot ∨ a₂ = .bot then (.bot, .bot)
+  else match a₂ with
   | .zero => (assumeNonzero a₁, a₂)
   | _ => match a₁ with
     | .zero => (a₁, assumeNonzero a₂)
@@ -263,11 +264,11 @@ theorem assumeNonzeroAddSign_sound
 /-- Backward refinement for addition under zero constraint. -/
 def assumeZeroAddSign (a₁ a₂ : Sign) : Sign × Sign :=
   ( match a₂ with
-    | .bot => a₁ | .zero => assumeZero a₁ | .pos => meetSign a₁ .neg
+    | .bot => .bot | .zero => assumeZero a₁ | .pos => meetSign a₁ .neg
     | .neg => meetSign a₁ .pos | .nonneg => meetSign a₁ .nonpos
     | .nonpos => meetSign a₁ .nonneg | .top => a₁
   , match a₁ with
-    | .bot => a₂ | .zero => assumeZero a₂ | .pos => meetSign a₂ .neg
+    | .bot => .bot | .zero => assumeZero a₂ | .pos => meetSign a₂ .neg
     | .neg => meetSign a₂ .pos | .nonneg => meetSign a₂ .nonpos
     | .nonpos => meetSign a₂ .nonneg | .top => a₂ )
 

--- a/AbsInterp/Framework/Domains.lean
+++ b/AbsInterp/Framework/Domains.lean
@@ -1,1 +1,2 @@
 import AbsInterp.Framework.Domains.GammaOnly
+import AbsInterp.Framework.Domains.Backward

--- a/AbsInterp/Framework/Domains/Backward.lean
+++ b/AbsInterp/Framework/Domains/Backward.lean
@@ -1,0 +1,69 @@
+import Cslib.Init
+
+namespace AbsInterp
+namespace Framework
+namespace Domains
+
+universe u v
+
+/-!
+# Backward Abstract Operators
+
+Generic backward (refinement) operator types and soundness predicates,
+following the gamma-only approach.
+
+Backward operators refine abstract values given relational knowledge about
+their concretizations:
+
+- **Unary assume**: refine `a` given a property `P` of the concrete value.
+- **Binary backward refinement**: refine a pair `(a₁, a₂)` given a relational
+  constraint between their concrete values (N40AI slide 6 style).
+-/
+
+/--
+Soundness of a unary backward refinement (assume) operator.
+
+If `c ∈ γ(a)` and the property `P c` holds, then `c ∈ γ(assume a)`.
+
+The existing `assumeNonzero` / `assumeZero` operators in concrete domains
+are instances of this pattern.
+-/
+def SoundAssume
+    {Abstract : Type u} {Concrete : Type v}
+    (gamma : Abstract → Set Concrete)
+    (P : Concrete → Prop)
+    (assume_ : Abstract → Abstract) : Prop :=
+  ∀ (a : Abstract) (c : Concrete),
+    c ∈ gamma a → P c → c ∈ gamma (assume_ a)
+
+/--
+Soundness of a binary backward refinement operator (N40AI-style).
+
+Given `refine : A → A → A × A`, soundness means: if `c₁ ∈ γ(a₁)`,
+`c₂ ∈ γ(a₂)`, and the relational constraint `rel c₁ c₂` holds, then
+`c₁ ∈ γ((refine a₁ a₂).1)` and `c₂ ∈ γ((refine a₁ a₂).2)`.
+
+This matches Leroy's N40AI backward operator formulation:
+`(a'₁, a'₂) = (a₁ op⁻¹♯ a₂)` means
+`v₁ ∈ γ(a₁) ∧ v₂ ∈ γ(a₂) ∧ v₁ op v₂ ⇒ v₁ ∈ γ(a'₁) ∧ v₂ ∈ γ(a'₂)`.
+-/
+def SoundBackwardRefine
+    {Abstract : Type u} {Concrete : Type v}
+    (gamma : Abstract → Set Concrete)
+    (rel : Concrete → Concrete → Prop)
+    (refine : Abstract → Abstract → Abstract × Abstract) : Prop :=
+  ∀ (a₁ a₂ : Abstract) (c₁ c₂ : Concrete),
+    c₁ ∈ gamma a₁ → c₂ ∈ gamma a₂ → rel c₁ c₂ →
+    c₁ ∈ gamma (refine a₁ a₂).1 ∧ c₂ ∈ gamma (refine a₁ a₂).2
+
+/-- The identity backward refinement is trivially sound for any relation. -/
+theorem soundBackwardRefine_id
+    {Abstract : Type u} {Concrete : Type v}
+    {gamma : Abstract → Set Concrete}
+    {rel : Concrete → Concrete → Prop} :
+    SoundBackwardRefine gamma rel (fun a₁ a₂ => (a₁, a₂)) :=
+  fun _ _ _ _ h₁ h₂ _ => ⟨h₁, h₂⟩
+
+end Domains
+end Framework
+end AbsInterp

--- a/AbsInterp/Framework/Domains/Backward.lean
+++ b/AbsInterp/Framework/Domains/Backward.lean
@@ -64,6 +64,16 @@ theorem soundBackwardRefine_id
     SoundBackwardRefine gamma rel (fun a₁ a₂ => (a₁, a₂)) :=
   fun _ _ _ _ h₁ h₂ _ => ⟨h₁, h₂⟩
 
+/-!
+## Usage note
+
+These predicates are framework-level abstractions intended for reuse across
+different language instantiations. The current IMP layer
+(`Examples/IMP/Analysis/Generic/Domain.lean`) restates equivalent contracts
+inline as `IMPAnalysisDomain` structure fields. A future refactor may wire
+the IMP fields through these predicates directly.
+-/
+
 end Domains
 end Framework
 end AbsInterp

--- a/Examples/IMP/Analysis/Generic/Defs.lean
+++ b/Examples/IMP/Analysis/Generic/Defs.lean
@@ -38,6 +38,10 @@ def assumeTrueStoreOf (d : IMPAnalysisDomain A) (cond : Expr)
   match cond with
   | .lit n => if n = 0 then botStoreSharp else ρ
   | .var x => updateStoreSharp ρ x (d.assumeNonzero (ρ x))
+  | .add (.var x) e2 =>
+      updateStoreSharp ρ x (d.assumeNonzeroAdd (ρ x) (evalExpr d ρ e2)).1
+  | .add e1 (.var y) =>
+      updateStoreSharp ρ y (d.assumeNonzeroAdd (evalExpr d ρ e1) (ρ y)).2
   | _ => ρ
 
 /-- Refine an abstract store under a not-taken `if` branch. -/
@@ -46,6 +50,10 @@ def assumeFalseStoreOf (d : IMPAnalysisDomain A) (cond : Expr)
   match cond with
   | .lit n => if n = 0 then ρ else botStoreSharp
   | .var x => updateStoreSharp ρ x (d.assumeZero (ρ x))
+  | .add (.var x) e2 =>
+      updateStoreSharp ρ x (d.assumeZeroAdd (ρ x) (evalExpr d ρ e2)).1
+  | .add e1 (.var y) =>
+      updateStoreSharp ρ y (d.assumeZeroAdd (evalExpr d ρ e1) (ρ y)).2
   | _ => ρ
 
 /--

--- a/Examples/IMP/Analysis/Generic/Defs.lean
+++ b/Examples/IMP/Analysis/Generic/Defs.lean
@@ -32,17 +32,21 @@ def evalExpr (d : IMPAnalysisDomain A) (ρ : StoreSharp A) : Expr → A
   | .var x => ρ x
   | .add e1 e2 => d.addTransfer (evalExpr d ρ e1) (evalExpr d ρ e2)
 
+/-- Refine variables in an abstract store using a backward-refined pair.
+    Each sub-expression that is a variable gets its store entry updated. -/
+def refineAddStore
+    (ρ : StoreSharp A) (e1 e2 : Expr) (pair : A × A) : StoreSharp A :=
+  let ρ' := match e1 with | .var x => updateStoreSharp ρ x pair.1 | _ => ρ
+  match e2 with | .var y => updateStoreSharp ρ' y pair.2 | _ => ρ'
+
 /-- Refine an abstract store under a taken `if` branch. -/
 def assumeTrueStoreOf (d : IMPAnalysisDomain A) (cond : Expr)
     (ρ : StoreSharp A) : StoreSharp A :=
   match cond with
   | .lit n => if n = 0 then botStoreSharp else ρ
   | .var x => updateStoreSharp ρ x (d.assumeNonzero (ρ x))
-  | .add (.var x) e2 =>
-      updateStoreSharp ρ x (d.assumeNonzeroAdd (ρ x) (evalExpr d ρ e2)).1
-  | .add e1 (.var y) =>
-      updateStoreSharp ρ y (d.assumeNonzeroAdd (evalExpr d ρ e1) (ρ y)).2
-  | _ => ρ
+  | .add e1 e2 =>
+      refineAddStore ρ e1 e2 (d.assumeNonzeroAdd (evalExpr d ρ e1) (evalExpr d ρ e2))
 
 /-- Refine an abstract store under a not-taken `if` branch. -/
 def assumeFalseStoreOf (d : IMPAnalysisDomain A) (cond : Expr)
@@ -50,11 +54,8 @@ def assumeFalseStoreOf (d : IMPAnalysisDomain A) (cond : Expr)
   match cond with
   | .lit n => if n = 0 then ρ else botStoreSharp
   | .var x => updateStoreSharp ρ x (d.assumeZero (ρ x))
-  | .add (.var x) e2 =>
-      updateStoreSharp ρ x (d.assumeZeroAdd (ρ x) (evalExpr d ρ e2)).1
-  | .add e1 (.var y) =>
-      updateStoreSharp ρ y (d.assumeZeroAdd (evalExpr d ρ e1) (ρ y)).2
-  | _ => ρ
+  | .add e1 e2 =>
+      refineAddStore ρ e1 e2 (d.assumeZeroAdd (evalExpr d ρ e1) (evalExpr d ρ e2))
 
 /--
 Generic transfer for the labeled IMP LTS, parameterized by an IMP analysis

--- a/Examples/IMP/Analysis/Generic/Domain.lean
+++ b/Examples/IMP/Analysis/Generic/Domain.lean
@@ -58,6 +58,24 @@ structure IMPAnalysisDomain (A : Type u) [Bot A] where
   /-- Zero refinement is sound. -/
   assumeZero_sound : ∀ {a : A} {v : Int},
     v ∈ scalarDomain.gamma a → v = 0 → v ∈ scalarDomain.gamma (assumeZero a)
+  /-- Backward refinement for addition under nonzero constraint.
+      Given `v₁ ∈ γ(a₁)`, `v₂ ∈ γ(a₂)`, and `v₁ + v₂ ≠ 0`, refine both. -/
+  assumeNonzeroAdd : A → A → A × A := fun a₁ a₂ => (a₁, a₂)
+  /-- Nonzero-add backward refinement is sound. -/
+  assumeNonzeroAdd_sound : ∀ {a₁ a₂ : A} {v₁ v₂ : Int},
+    v₁ ∈ scalarDomain.gamma a₁ → v₂ ∈ scalarDomain.gamma a₂ →
+    v₁ + v₂ ≠ 0 →
+    v₁ ∈ scalarDomain.gamma (assumeNonzeroAdd a₁ a₂).1 ∧
+    v₂ ∈ scalarDomain.gamma (assumeNonzeroAdd a₁ a₂).2
+  /-- Backward refinement for addition under zero constraint.
+      Given `v₁ ∈ γ(a₁)`, `v₂ ∈ γ(a₂)`, and `v₁ + v₂ = 0`, refine both. -/
+  assumeZeroAdd : A → A → A × A := fun a₁ a₂ => (a₁, a₂)
+  /-- Zero-add backward refinement is sound. -/
+  assumeZeroAdd_sound : ∀ {a₁ a₂ : A} {v₁ v₂ : Int},
+    v₁ ∈ scalarDomain.gamma a₁ → v₂ ∈ scalarDomain.gamma a₂ →
+    v₁ + v₂ = 0 →
+    v₁ ∈ scalarDomain.gamma (assumeZeroAdd a₁ a₂).1 ∧
+    v₂ ∈ scalarDomain.gamma (assumeZeroAdd a₁ a₂).2
 
 namespace IMPAnalysisDomain
 

--- a/Examples/IMP/Analysis/Generic/Lemmas.lean
+++ b/Examples/IMP/Analysis/Generic/Lemmas.lean
@@ -166,6 +166,28 @@ theorem mem_gammaStoreOf_refineVar
   · subst hEq; simp [updateStoreSharp]; exact hx
   · simp [updateStoreSharp, hEq]; exact hσ y
 
+theorem mem_gammaStoreOf_refineAddStore
+    {ρ : StoreSharp A}
+    {σ : Store}
+    {e1 e2 : Expr}
+    {pair : A × A}
+    (hσ : σ ∈ gammaStoreOf d.scalarDomain.gamma ρ)
+    (h1 : eval σ e1 ∈ d.scalarDomain.gamma pair.1)
+    (h2 : eval σ e2 ∈ d.scalarDomain.gamma pair.2) :
+    σ ∈ gammaStoreOf d.scalarDomain.gamma (refineAddStore ρ e1 e2 pair) := by
+  cases e1 with
+  | var x =>
+      simp only [refineAddStore]
+      cases e2 with
+      | var y =>
+          exact mem_gammaStoreOf_refineVar d (mem_gammaStoreOf_refineVar d hσ h1) h2
+      | _ => exact mem_gammaStoreOf_refineVar d hσ h1
+  | _ =>
+      simp only [refineAddStore]
+      cases e2 with
+      | var y => exact mem_gammaStoreOf_refineVar d hσ h2
+      | _ => exact hσ
+
 theorem mem_gammaStoreOf_assumeTrueStoreOf
     {cond : Expr}
     {ρ : StoreSharp A}
@@ -185,25 +207,11 @@ theorem mem_gammaStoreOf_assumeTrueStoreOf
         exact d.assumeNonzero_sound (hσ x) hCond
       · simp [assumeTrueStoreOf, updateStoreSharp, hEq, hσ y]
   | add e1 e2 =>
-      cases e1 with
-      | var x =>
-          exact mem_gammaStoreOf_refineVar d hσ
-            (d.assumeNonzeroAdd_sound (hσ x) (evalExpr_sound d hσ)
-              (by simpa [eval] using hCond)).1
-      | lit n₁ =>
-          cases e2 with
-          | var y =>
-              exact mem_gammaStoreOf_refineVar d hσ
-                (d.assumeNonzeroAdd_sound (evalExpr_sound d hσ) (hσ y)
-                  (by simpa [eval] using hCond)).2
-          | _ => simpa [assumeTrueStoreOf] using hσ
-      | add ea eb =>
-          cases e2 with
-          | var y =>
-              exact mem_gammaStoreOf_refineVar d hσ
-                (d.assumeNonzeroAdd_sound (evalExpr_sound d hσ) (hσ y)
-                  (by simpa [eval] using hCond)).2
-          | _ => simpa [assumeTrueStoreOf] using hσ
+      simp only [assumeTrueStoreOf]
+      have hPair := d.assumeNonzeroAdd_sound
+        (evalExpr_sound d hσ (e := e1)) (evalExpr_sound d hσ (e := e2))
+        (by simpa [eval] using hCond)
+      exact mem_gammaStoreOf_refineAddStore d hσ hPair.1 hPair.2
 
 theorem mem_gammaStoreOf_assumeFalseStoreOf
     {cond : Expr}
@@ -224,24 +232,10 @@ theorem mem_gammaStoreOf_assumeFalseStoreOf
         exact d.assumeZero_sound (hσ x) hCond
       · simp [assumeFalseStoreOf, updateStoreSharp, hEq, hσ y]
   | add e1 e2 =>
-      cases e1 with
-      | var x =>
-          exact mem_gammaStoreOf_refineVar d hσ
-            (d.assumeZeroAdd_sound (hσ x) (evalExpr_sound d hσ)
-              (by simpa [eval] using hCond)).1
-      | lit n₁ =>
-          cases e2 with
-          | var y =>
-              exact mem_gammaStoreOf_refineVar d hσ
-                (d.assumeZeroAdd_sound (evalExpr_sound d hσ) (hσ y)
-                  (by simpa [eval] using hCond)).2
-          | _ => simpa [assumeFalseStoreOf] using hσ
-      | add ea eb =>
-          cases e2 with
-          | var y =>
-              exact mem_gammaStoreOf_refineVar d hσ
-                (d.assumeZeroAdd_sound (evalExpr_sound d hσ) (hσ y)
-                  (by simpa [eval] using hCond)).2
-          | _ => simpa [assumeFalseStoreOf] using hσ
+      simp only [assumeFalseStoreOf]
+      have hPair := d.assumeZeroAdd_sound
+        (evalExpr_sound d hσ (e := e1)) (evalExpr_sound d hσ (e := e2))
+        (by simpa [eval] using hCond)
+      exact mem_gammaStoreOf_refineAddStore d hσ hPair.1 hPair.2
 
 end Examples.IMP

--- a/Examples/IMP/Analysis/Generic/Lemmas.lean
+++ b/Examples/IMP/Analysis/Generic/Lemmas.lean
@@ -151,6 +151,21 @@ theorem mem_gammaStoreOf_updateStoreSharp_of
     simpa [Store.update, updateStoreSharp] using hv
   · simp [Store.update, updateStoreSharp, hEq, hσ y]
 
+/-- Backward refinement of a single variable in an abstract store is sound.
+    If `σ ∈ γ(ρ)` and `σ(x) ∈ γ(a)`, then `σ ∈ γ(ρ[x ↦ a])`. -/
+theorem mem_gammaStoreOf_refineVar
+    {ρ : StoreSharp A}
+    {σ : Store}
+    {x : Var}
+    {a : A}
+    (hσ : σ ∈ gammaStoreOf d.scalarDomain.gamma ρ)
+    (hx : σ x ∈ d.scalarDomain.gamma a) :
+    σ ∈ gammaStoreOf d.scalarDomain.gamma (updateStoreSharp ρ x a) := by
+  intro y
+  by_cases hEq : x = y
+  · subst hEq; simp [updateStoreSharp]; exact hx
+  · simp [updateStoreSharp, hEq]; exact hσ y
+
 theorem mem_gammaStoreOf_assumeTrueStoreOf
     {cond : Expr}
     {ρ : StoreSharp A}
@@ -169,8 +184,26 @@ theorem mem_gammaStoreOf_assumeTrueStoreOf
         simp [assumeTrueStoreOf, updateStoreSharp]
         exact d.assumeNonzero_sound (hσ x) hCond
       · simp [assumeTrueStoreOf, updateStoreSharp, hEq, hσ y]
-  | add =>
-      simpa [assumeTrueStoreOf] using hσ
+  | add e1 e2 =>
+      cases e1 with
+      | var x =>
+          exact mem_gammaStoreOf_refineVar d hσ
+            (d.assumeNonzeroAdd_sound (hσ x) (evalExpr_sound d hσ)
+              (by simpa [eval] using hCond)).1
+      | lit n₁ =>
+          cases e2 with
+          | var y =>
+              exact mem_gammaStoreOf_refineVar d hσ
+                (d.assumeNonzeroAdd_sound (evalExpr_sound d hσ) (hσ y)
+                  (by simpa [eval] using hCond)).2
+          | _ => simpa [assumeTrueStoreOf] using hσ
+      | add ea eb =>
+          cases e2 with
+          | var y =>
+              exact mem_gammaStoreOf_refineVar d hσ
+                (d.assumeNonzeroAdd_sound (evalExpr_sound d hσ) (hσ y)
+                  (by simpa [eval] using hCond)).2
+          | _ => simpa [assumeTrueStoreOf] using hσ
 
 theorem mem_gammaStoreOf_assumeFalseStoreOf
     {cond : Expr}
@@ -190,7 +223,25 @@ theorem mem_gammaStoreOf_assumeFalseStoreOf
         simp [assumeFalseStoreOf, updateStoreSharp]
         exact d.assumeZero_sound (hσ x) hCond
       · simp [assumeFalseStoreOf, updateStoreSharp, hEq, hσ y]
-  | add =>
-      simpa [assumeFalseStoreOf] using hσ
+  | add e1 e2 =>
+      cases e1 with
+      | var x =>
+          exact mem_gammaStoreOf_refineVar d hσ
+            (d.assumeZeroAdd_sound (hσ x) (evalExpr_sound d hσ)
+              (by simpa [eval] using hCond)).1
+      | lit n₁ =>
+          cases e2 with
+          | var y =>
+              exact mem_gammaStoreOf_refineVar d hσ
+                (d.assumeZeroAdd_sound (evalExpr_sound d hσ) (hσ y)
+                  (by simpa [eval] using hCond)).2
+          | _ => simpa [assumeFalseStoreOf] using hσ
+      | add ea eb =>
+          cases e2 with
+          | var y =>
+              exact mem_gammaStoreOf_refineVar d hσ
+                (d.assumeZeroAdd_sound (evalExpr_sound d hσ) (hσ y)
+                  (by simpa [eval] using hCond)).2
+          | _ => simpa [assumeFalseStoreOf] using hσ
 
 end Examples.IMP

--- a/Examples/IMP/Analysis/Interval/Defs.lean
+++ b/Examples/IMP/Analysis/Interval/Defs.lean
@@ -30,6 +30,8 @@ def intervalAnalysisDomain : IMPAnalysisDomain Interval where
   assumeNonzero_sound := assumeNonzeroInterval_sound
   assumeZero := assumeZeroInterval
   assumeZero_sound := assumeZeroInterval_sound
+  assumeNonzeroAdd_sound := fun h₁ h₂ _ => ⟨h₁, h₂⟩
+  assumeZeroAdd_sound := fun h₁ h₂ _ => ⟨h₁, h₂⟩
 
 -- Public API wrappers preserving backward-compatible names.
 

--- a/Examples/IMP/Analysis/Parity/Defs.lean
+++ b/Examples/IMP/Analysis/Parity/Defs.lean
@@ -30,6 +30,8 @@ def parityAnalysisDomain : IMPAnalysisDomain Parity where
   assumeNonzero_sound := assumeNonzeroParity_sound
   assumeZero := assumeZeroParity
   assumeZero_sound := assumeZeroParity_sound
+  assumeNonzeroAdd_sound := fun h₁ h₂ _ => ⟨h₁, h₂⟩
+  assumeZeroAdd_sound := fun h₁ h₂ _ => ⟨h₁, h₂⟩
 
 /-- The generic Parity concretization for a fixed IMP program. -/
 def gammaProgramParity (program : Stmt) : Framework.Gamma (ConfigSharp Parity) Config :=

--- a/Examples/IMP/Analysis/Sign/Defs.lean
+++ b/Examples/IMP/Analysis/Sign/Defs.lean
@@ -30,6 +30,10 @@ def signAnalysisDomain : IMPAnalysisDomain Sign where
   assumeNonzero_sound := assumeNonzero_sound
   assumeZero := assumeZero
   assumeZero_sound := assumeZero_sound
+  assumeNonzeroAdd := assumeNonzeroAddSign
+  assumeNonzeroAdd_sound := assumeNonzeroAddSign_sound
+  assumeZeroAdd := assumeZeroAddSign
+  assumeZeroAdd_sound := assumeZeroAddSign_sound
 
 -- Public API wrappers preserving backward-compatible names.
 

--- a/Tests/Domains/Sign.lean
+++ b/Tests/Domains/Sign.lean
@@ -50,6 +50,28 @@ example (n : Int) (hn : n ∈ gammaSign Sign.nonneg) :
     -n ∈ gammaSign (negTransfer Sign.nonneg) := by
   exact negTransfer_sound hn
 
+-- meetSign tests
+example : meetSign Sign.neg Sign.nonneg = Sign.bot := by rfl
+example : meetSign Sign.top Sign.pos = Sign.pos := by rfl
+example : meetSign Sign.nonpos Sign.nonneg = Sign.zero := by rfl
+example : meetSign Sign.neg Sign.nonpos = Sign.neg := by rfl
+
+-- assumeNonzeroAddSign tests
+/-- nonneg + zero ≠ 0 refines nonneg to pos. -/
+example : (assumeNonzeroAddSign Sign.nonneg Sign.zero).1 = Sign.pos := by rfl
+/-- zero + top ≠ 0 refines top to top (nonzero). -/
+example : (assumeNonzeroAddSign Sign.zero Sign.top).2 = Sign.top := by rfl
+
+-- assumeZeroAddSign tests
+/-- top + pos = 0 refines top to neg. -/
+example : (assumeZeroAddSign Sign.top Sign.pos).1 = Sign.neg := by rfl
+/-- pos + top = 0 refines top to neg. -/
+example : (assumeZeroAddSign Sign.pos Sign.top).2 = Sign.neg := by rfl
+/-- nonneg + zero = 0 refines nonneg to zero. -/
+example : (assumeZeroAddSign Sign.nonneg Sign.zero).1 = Sign.zero := by rfl
+/-- top + nonneg = 0 refines top to nonpos. -/
+example : (assumeZeroAddSign Sign.top Sign.nonneg).1 = Sign.nonpos := by rfl
+
 open AbsInterp.Framework
 
 /-- The identity abstract transformer is monotone over Sign. -/

--- a/Tests/Domains/Sign.lean
+++ b/Tests/Domains/Sign.lean
@@ -59,10 +59,16 @@ example : meetSign Sign.neg Sign.nonpos = Sign.neg := by rfl
 -- assumeNonzeroAddSign tests
 /-- nonneg + zero ≠ 0 refines nonneg to pos. -/
 example : (assumeNonzeroAddSign Sign.nonneg Sign.zero).1 = Sign.pos := by rfl
-/-- zero + top ≠ 0 refines top to top (nonzero). -/
+/-- zero + top ≠ 0 refines top to top (already covers all nonzero). -/
 example : (assumeNonzeroAddSign Sign.zero Sign.top).2 = Sign.top := by rfl
+/-- bot propagation: if either operand is bot, both become bot. -/
+example : (assumeNonzeroAddSign Sign.top Sign.bot) = (.bot, .bot) := by rfl
+example : (assumeNonzeroAddSign Sign.bot Sign.pos) = (.bot, .bot) := by rfl
 
 -- assumeZeroAddSign tests
+/-- bot propagation: if either operand is bot, both become bot. -/
+example : (assumeZeroAddSign Sign.top Sign.bot).1 = Sign.bot := by rfl
+example : (assumeZeroAddSign Sign.bot Sign.pos).2 = Sign.bot := by rfl
 /-- top + pos = 0 refines top to neg. -/
 example : (assumeZeroAddSign Sign.top Sign.pos).1 = Sign.neg := by rfl
 /-- pos + top = 0 refines top to neg. -/


### PR DESCRIPTION
## Summary

- Add N40AI-style backward refinement operators for refining abstract values under relational constraints
- Framework-level `SoundAssume` and `SoundBackwardRefine` soundness predicates
- Sign domain validation with `meetSign`, `assumeNonzeroAddSign`, `assumeZeroAddSign`
- `IMPAnalysisDomain` extended with `assumeNonzeroAdd`/`assumeZeroAdd` fields
- Transfer functions now handle `add (var x) e` / `add e (var y)` backward refinement
- All existing tests pass, axiom cleanliness maintained

Closes #37

## Design decisions

- **Gamma-only backward operators**: follows Leroy's N40AI formulation without requiring Galois connections
- **Scalar-level interface in `IMPAnalysisDomain`**: backward add operators are scalar (`A → A → A × A`), keeping store-level logic in the generic transfer function
- **Identity defaults**: `assumeNonzeroAdd`/`assumeZeroAdd` default to identity (no refinement), so Interval and Parity instances compile with trivial proofs
- **Sign overrides**: Sign instance provides actual refinement (e.g., `top + pos = 0` refines first operand to `neg`)

## Scope

| Layer | Changes |
|---|---|
| Framework | New `Backward.lean` with `SoundAssume`, `SoundBackwardRefine` |
| Domains | `meetSign`, `assumeNonzeroAddSign`, `assumeZeroAddSign` + soundness |
| Generic IMP | `IMPAnalysisDomain` extended, transfer functions enhanced, proofs updated |
| Instances | Sign overrides, Interval/Parity trivial proofs |
| Tests | Unit tests for all new Sign operators |

## Test plan

- [x] `lake build` — 832 jobs success
- [x] `lake build Tests` — 846 jobs success
- [x] `lake test` — all build checks passed
- [x] Axiom cleanliness: soundness path uses only `propext`, `Classical.choice`, `Quot.sound`

🤖 Generated with [Claude Code](https://claude.com/claude-code)