### PR TITLE
feat(framework): align GammaOnlyDomain with Mathlib [Preorder][OrderTop][Max] (Option D)

### DIFF
--- a/AbsInterp/Domains/Interval.lean
+++ b/AbsInterp/Domains/Interval.lean
@@ -54,6 +54,10 @@ instance : Preorder Interval where
   le_refl := leInterval_refl
   le_trans := @leInterval_trans
 
+instance : OrderTop Interval where
+  top := .top
+  le_top _ := Set.subset_univ _
+
 theorem gammaInterval_monotone_of_leInterval {a b : Interval} (hAB : a ≤ b) :
     gammaInterval a ⊆ gammaInterval b :=
   hAB
@@ -107,6 +111,8 @@ def joinInterval (a b : Interval) : Interval :=
   | .top, _ => .top
   | _, .top => .top
   | .range lo1 hi1, .range lo2 hi2 => mk (min lo1 lo2) (max hi1 hi2)
+
+instance : Max Interval := ⟨joinInterval⟩
 
 /-- `joinInterval` soundly over-approximates union concretization. -/
 theorem joinInterval_sound (a b : Interval) :
@@ -399,13 +405,8 @@ theorem widenInterval_upperBound :
 def intervalGammaOnlyDomain :
     AbsInterp.Framework.Domains.GammaOnlyDomain Interval Int where
   gamma := gammaInterval
-  le := leInterval
-  le_refl := leInterval_refl
-  le_trans := leInterval_trans
   gamma_monotone := gammaInterval_monotone_of_leInterval
-  top := Interval.top
   gamma_top := gammaInterval_top
-  join := joinInterval
   join_sound := joinInterval_sound
 
 end Domains

--- a/AbsInterp/Domains/Parity.lean
+++ b/AbsInterp/Domains/Parity.lean
@@ -49,6 +49,15 @@ theorem leParity_refl : ∀ a : Parity, leParity a a := by
 theorem leParity_trans : ∀ {a b c : Parity}, leParity a b → leParity b c → leParity a c := by
   intro a b c hab hbc; cases a <;> cases b <;> cases c <;> simp_all [leParity]
 
+instance : Preorder Parity where
+  le := leParity
+  le_refl := leParity_refl
+  le_trans := @leParity_trans
+
+instance : OrderTop Parity where
+  top := .top
+  le_top a := by cases a <;> simp [leParity, LE.le]
+
 theorem gammaParity_monotone : ∀ {a b : Parity}, leParity a b → gammaParity a ⊆ gammaParity b := by
   intro a b hab; cases a <;> cases b <;> simp_all [leParity, gammaParity, Set.subset_univ]
 
@@ -60,6 +69,8 @@ def joinParity : Parity → Parity → Parity
   | .odd, .odd => .odd
   | _, _ => .top
 
+instance : Max Parity := ⟨joinParity⟩
+
 theorem joinParity_sound : ∀ a b : Parity, gammaParity a ∪ gammaParity b ⊆ gammaParity (joinParity a b) := by
   intro a b n hn
   cases a <;> cases b <;> simp_all [joinParity, gammaParity, Set.mem_union, Set.mem_empty_iff_false]
@@ -67,13 +78,8 @@ theorem joinParity_sound : ∀ a b : Parity, gammaParity a ∪ gammaParity b ⊆
 /-- The complete gamma-only domain instance for Parity. -/
 def parityGammaOnlyDomain : GammaOnlyDomain Parity Int where
   gamma := gammaParity
-  le := leParity
-  le_refl := leParity_refl
-  le_trans := leParity_trans
   gamma_monotone := gammaParity_monotone
-  top := .top
   gamma_top := fun _ => Set.mem_univ _
-  join := joinParity
   join_sound := joinParity_sound
 
 /-- Abstract a concrete integer constant by its parity. -/

--- a/AbsInterp/Domains/Sign.lean
+++ b/AbsInterp/Domains/Sign.lean
@@ -47,6 +47,10 @@ instance : Preorder Sign where
   le_refl := leSign_refl
   le_trans := @leSign_trans
 
+instance : OrderTop Sign where
+  top := .top
+  le_top _ := Set.subset_univ _
+
 theorem gammaSign_monotone_of_leSign {a b : Sign} (hAB : a ≤ b) :
     gammaSign a ⊆ gammaSign b :=
   hAB
@@ -100,6 +104,8 @@ def joinSign (a b : Sign) : Sign :=
     (hasNeg a || hasNeg b)
     (hasZero a || hasZero b)
     (hasPos a || hasPos b)
+
+instance : Max Sign := ⟨joinSign⟩
 
 /-- `joinSign` soundly over-approximates union concretization. -/
 theorem joinSign_sound (a b : Sign) :
@@ -331,13 +337,8 @@ theorem negTransfer_sound {a : Sign} {n : Int} (hn : n ∈ gammaSign a) :
 def signGammaOnlyDomain :
     AbsInterp.Framework.Domains.GammaOnlyDomain Sign Int where
   gamma := gammaSign
-  le := leSign
-  le_refl := leSign_refl
-  le_trans := leSign_trans
   gamma_monotone := gammaSign_monotone_of_leSign
-  top := Sign.top
   gamma_top := gammaSign_top
-  join := joinSign
   join_sound := joinSign_sound
 
 end Domains

--- a/AbsInterp/Framework/Domains/GammaOnly.lean
+++ b/AbsInterp/Framework/Domains/GammaOnly.lean
@@ -1,4 +1,7 @@
 import Cslib.Init
+import Mathlib.Order.GaloisConnection.Defs
+import Mathlib.Order.GaloisConnection.Basic
+import Mathlib.Order.Lattice
 
 namespace AbsInterp
 namespace Framework
@@ -12,47 +15,88 @@ abbrev Gamma (Abstract : Type u) (Concrete : Type v) := Abstract -> Set Concrete
 /--
 `gamma`-only abstract-domain contract.
 
-This interface fixes the minimal obligations used by the current framework:
-order (`le`), concretization monotonicity, top coverage, and join soundness.
-It intentionally does not include `alpha` or Galois-connection fields.
+The abstract carrier is a Mathlib-style ordered type with a top element and a
+binary `⊔` operation (`Preorder + OrderTop + Max`). The contract pins down the
+γ-only obligations:
+
+- `gamma` : the concretization function,
+- `gamma_monotone` : `≤`-monotonicity of `gamma`,
+- `gamma_top` : `⊤` over-approximates every concrete element,
+- `join_sound` : `⊔` soundly over-approximates concrete unions.
+
+This deliberately omits `α` / Galois-connection / abstract-level LUB
+obligations. The `Max` typeclass carries no laws on its own; the only join
+law required here is the γ-level `join_sound`. Domains that additionally
+satisfy `SemilatticeSup` are welcome to provide it as an opt-in instance.
 -/
-structure GammaOnlyDomain (Abstract : Type u) (Concrete : Type v) where
+structure GammaOnlyDomain
+    (Abstract : Type u) [Preorder Abstract] [OrderTop Abstract] [Max Abstract]
+    (Concrete : Type v) where
   gamma : Gamma Abstract Concrete
-  le : Abstract -> Abstract -> Prop
-  le_refl : ∀ a : Abstract, le a a
-  le_trans : ∀ {a b c : Abstract}, le a b -> le b c -> le a c
-  gamma_monotone : ∀ {a b : Abstract}, le a b -> gamma a ⊆ gamma b
-  top : Abstract
-  gamma_top : ∀ c : Concrete, c ∈ gamma top
-  join : Abstract -> Abstract -> Abstract
-  join_sound :
-    ∀ a b : Abstract, gamma a ∪ gamma b ⊆ gamma (join a b)
+  gamma_monotone : ∀ {a b : Abstract}, a ≤ b → gamma a ⊆ gamma b
+  gamma_top : ∀ c : Concrete, c ∈ gamma ⊤
+  join_sound : ∀ a b : Abstract, gamma a ∪ gamma b ⊆ gamma (a ⊔ b)
 
 namespace GammaOnlyDomain
 
-variable {Abstract : Type u} {Concrete : Type v}
+variable {Abstract : Type u} [Preorder Abstract] [OrderTop Abstract] [Max Abstract]
+variable {Concrete : Type v}
 variable (cfg : GammaOnlyDomain Abstract Concrete)
 
-/-- The order relation carried by a `GammaOnlyDomain`. -/
-abbrev LE : Abstract -> Abstract -> Prop :=
-  cfg.le
-
 /-- Concretization monotonicity as a named theorem. -/
-theorem gamma_monotone_of_le {a b : Abstract} (h : cfg.le a b) :
+theorem gamma_monotone_of_le {a b : Abstract} (h : a ≤ b) :
     cfg.gamma a ⊆ cfg.gamma b :=
   cfg.gamma_monotone h
 
-/-- Every concrete element is in the concretization of `top`. -/
+/-- Every concrete element is in the concretization of `⊤`. -/
 theorem mem_gamma_top (c : Concrete) :
-    c ∈ cfg.gamma cfg.top :=
+    c ∈ cfg.gamma (⊤ : Abstract) :=
   cfg.gamma_top c
 
 /-- Join is sound w.r.t. concretization union. -/
 theorem gamma_union_subset_join (a b : Abstract) :
-    cfg.gamma a ∪ cfg.gamma b ⊆ cfg.gamma (cfg.join a b) :=
+    cfg.gamma a ∪ cfg.gamma b ⊆ cfg.gamma (a ⊔ b) :=
   cfg.join_sound a b
 
 end GammaOnlyDomain
+
+/--
+Bridge: build a `GammaOnlyDomain` from a Mathlib `GaloisConnection` between
+`Abstract` and `Set Concrete` (with subset order).
+
+`α : Set Concrete → Abstract` is the abstraction map and `γ : Abstract → Set Concrete`
+is the concretization. A `GaloisConnection α γ` automatically yields:
+
+- γ-monotonicity (from `gc.monotone_u`),
+- `c ∈ γ ⊤` for every `c` (from `α univ ≤ ⊤` and the Galois adjoint),
+- soundness of `⊔` on the abstract side (from `α`'s preservation of binary
+  unions, which requires `[SemilatticeSup Abstract]`).
+
+This helper is opt-in; the framework does not require a `GaloisConnection`
+to use γ-only soundness.
+-/
+def GammaOnlyDomain.ofGaloisConnection
+    {Abstract : Type u} [SemilatticeSup Abstract] [OrderTop Abstract]
+    {Concrete : Type v}
+    (gamma : Abstract → Set Concrete)
+    (alpha : Set Concrete → Abstract)
+    (gc : GaloisConnection alpha gamma) :
+    GammaOnlyDomain Abstract Concrete where
+  gamma := gamma
+  gamma_monotone := @(gc.monotone_u)
+  gamma_top := by
+    intro c
+    have hLeTop : alpha Set.univ ≤ (⊤ : Abstract) := le_top
+    exact (gc _ _).mp hLeTop (Set.mem_univ c)
+  join_sound := by
+    intro a b
+    have hsup : alpha (gamma a ∪ gamma b) ≤ a ⊔ b := by
+      have ha : alpha (gamma a) ≤ a := gc.l_u_le a
+      have hb : alpha (gamma b) ≤ b := gc.l_u_le b
+      calc alpha (gamma a ∪ gamma b)
+          = alpha (gamma a) ⊔ alpha (gamma b) := gc.l_sup
+        _ ≤ a ⊔ b := sup_le_sup ha hb
+    exact (gc _ _).mp hsup
 
 end Domains
 end Framework

--- a/Examples/IMP/Abstraction/Defs.lean
+++ b/Examples/IMP/Abstraction/Defs.lean
@@ -1,5 +1,8 @@
 import Cslib.Init
 import Mathlib.Data.Set.Lattice
+import Mathlib.Order.Basic
+import Mathlib.Order.Lattice
+import Mathlib.Order.BoundedOrder.Basic
 
 import AbsInterp.Framework.Domains
 import Examples.IMP.Semantics
@@ -68,21 +71,13 @@ def gammaConfigOf
     Gamma (ConfigSharp Abstract) Config :=
   fun κ => { c : Config | storeOfConfig c ∈ gammaStoreOf gamma (κ (controlOfConfig c)) }
 
-/-- Pointwise order on abstract IMP stores. -/
-def leStoreSharp
-    {Abstract : Type u}
-    (cfg : GammaOnlyDomain Abstract Int) :
-    StoreSharp Abstract → StoreSharp Abstract → Prop :=
-  fun ρ₁ ρ₂ => ∀ x : Var, cfg.le (ρ₁ x) (ρ₂ x)
+/--
+Pointwise bottom element on abstract IMP stores.
 
-/-- Pointwise top element on abstract IMP stores. -/
-def topStoreSharp
-    {Abstract : Type u}
-    (cfg : GammaOnlyDomain Abstract Int) :
-    StoreSharp Abstract :=
-  fun _ => cfg.top
-
-/-- Pointwise bottom element on abstract IMP stores. -/
+Bottom is an opt-in requirement (`[Bot Abstract]`); it is not carried by
+`GammaOnlyDomain` itself but is needed for "unreachable control location"
+configurations like `singletonConfig`.
+-/
 def botStoreSharp
     {Abstract : Type u}
     [Bot Abstract] :
@@ -95,55 +90,6 @@ def botStoreSharp
     (x : Var) :
     botStoreSharp (Abstract := Abstract) x = (⊥ : Abstract) :=
   rfl
-
-/-- Pointwise join on abstract IMP stores. -/
-def joinStoreSharp
-    {Abstract : Type u}
-    (cfg : GammaOnlyDomain Abstract Int) :
-    StoreSharp Abstract → StoreSharp Abstract → StoreSharp Abstract :=
-  fun ρ₁ ρ₂ x => cfg.join (ρ₁ x) (ρ₂ x)
-
-/-- Pointwise IMP-store domain lifted from a scalar integer domain. -/
-def storeGammaOnlyDomain
-    {Abstract : Type u}
-    (cfg : GammaOnlyDomain Abstract Int) :
-    GammaOnlyDomain (StoreSharp Abstract) Store where
-  gamma := gammaStoreOf cfg.gamma
-  le := leStoreSharp cfg
-  le_refl := by
-    intro ρ x
-    exact cfg.le_refl (ρ x)
-  le_trans := by
-    intro ρ₁ ρ₂ ρ₃ h12 h23 x
-    exact cfg.le_trans (h12 x) (h23 x)
-  gamma_monotone := by
-    intro ρ₁ ρ₂ hLe σ hσ x
-    exact cfg.gamma_monotone (hLe x) (hσ x)
-  top := topStoreSharp cfg
-  gamma_top := by
-    intro σ x
-    exact cfg.gamma_top (σ x)
-  join := joinStoreSharp cfg
-  join_sound := by
-    intro ρ₁ ρ₂ σ hUnion x
-    apply cfg.join_sound
-    rcases hUnion with hLeft | hRight
-    · exact Or.inl (hLeft x)
-    · exact Or.inr (hRight x)
-
-/-- Pointwise order on abstract IMP configurations. -/
-def leConfigSharp
-    {Abstract : Type u}
-    (cfg : GammaOnlyDomain (StoreSharp Abstract) Store) :
-    ConfigSharp Abstract → ConfigSharp Abstract → Prop :=
-  fun κ₁ κ₂ => ∀ s : Control, cfg.le (κ₁ s) (κ₂ s)
-
-/-- Pointwise top element on abstract IMP configurations. -/
-def topConfigSharp
-    {Abstract : Type u}
-    (cfg : GammaOnlyDomain (StoreSharp Abstract) Store) :
-    ConfigSharp Abstract :=
-  fun _ => cfg.top
 
 /-- Pointwise bottom element on abstract IMP configurations. -/
 def botConfigSharp
@@ -160,12 +106,70 @@ def botConfigSharp
     botConfigSharp (Abstract := Abstract) s x = (⊥ : Abstract) :=
   rfl
 
-/-- Pointwise join on abstract IMP configurations. -/
-def joinConfigSharp
+/-!
+## Pointwise lifts of `GammaOnlyDomain`
+
+The Mathlib `Pi` instances (`Pi.preorder`, `Pi.instOrderTop`, `Pi.instMax`)
+give us `≤`, `⊤`, and `⊔` on `Var → Abstract` and `Stmt → Var → Abstract`
+automatically, so the lifted domain only has to supply the γ-level
+soundness obligations.
+-/
+
+/-- Pointwise IMP-store domain lifted from a scalar integer domain. -/
+def storeGammaOnlyDomain
     {Abstract : Type u}
-    (cfg : GammaOnlyDomain (StoreSharp Abstract) Store) :
+    [Preorder Abstract] [OrderTop Abstract] [Max Abstract]
+    (cfg : GammaOnlyDomain Abstract Int) :
+    GammaOnlyDomain (StoreSharp Abstract) Store where
+  gamma := gammaStoreOf cfg.gamma
+  gamma_monotone := by
+    intro ρ₁ ρ₂ hLe σ hσ x
+    exact cfg.gamma_monotone (hLe x) (hσ x)
+  gamma_top := by
+    intro σ x
+    exact cfg.gamma_top (σ x)
+  join_sound := by
+    intro ρ₁ ρ₂ σ hUnion x
+    apply cfg.join_sound
+    rcases hUnion with hLeft | hRight
+    · exact Or.inl (hLeft x)
+    · exact Or.inr (hRight x)
+
+/-- Pointwise IMP-configuration domain lifted from a scalar integer domain. -/
+def configGammaOnlyDomain
+    {Abstract : Type u}
+    [Preorder Abstract] [OrderTop Abstract] [Max Abstract]
+    (cfg : GammaOnlyDomain Abstract Int) :
+    GammaOnlyDomain (ConfigSharp Abstract) Config where
+  gamma := gammaConfigOf cfg.gamma
+  gamma_monotone := by
+    intro κ₁ κ₂ hLe c hc
+    exact (storeGammaOnlyDomain cfg).gamma_monotone (hLe (controlOfConfig c)) hc
+  gamma_top := by
+    intro c
+    exact (storeGammaOnlyDomain cfg).gamma_top (storeOfConfig c)
+  join_sound := by
+    intro κ₁ κ₂ c hc
+    change
+      storeOfConfig c ∈ gammaStoreOf cfg.gamma (κ₁ (controlOfConfig c)) ∪
+        gammaStoreOf cfg.gamma (κ₂ (controlOfConfig c)) at hc
+    exact (storeGammaOnlyDomain cfg).join_sound
+      (κ₁ (controlOfConfig c)) (κ₂ (controlOfConfig c)) hc
+
+/--
+Pointwise join on abstract IMP configurations.
+
+Retained as a named alias so that `Generic/Defs.lean` and
+`Generic/Soundness.lean` can refer to `joinConfig d.scalarDomain` without
+caring about the underlying `Pi`-instance `⊔`. The `cfg` argument is
+intentionally unused beyond helping type inference.
+-/
+def joinConfig
+    {Abstract : Type u}
+    [Preorder Abstract] [OrderTop Abstract] [Max Abstract]
+    (_cfg : GammaOnlyDomain Abstract Int) :
     ConfigSharp Abstract → ConfigSharp Abstract → ConfigSharp Abstract :=
-  fun κ₁ κ₂ pc => cfg.join (κ₁ pc) (κ₂ pc)
+  fun κ₁ κ₂ pc x => κ₁ pc x ⊔ κ₂ pc x
 
 /-- One-target abstract configuration contribution. -/
 def singletonConfig
@@ -202,43 +206,5 @@ def liftSeqConfig
     ConfigSharp Abstract
   | .seq s s2' => if s2' = s2 then κ s else botStoreSharp
   | _ => botStoreSharp
-
-/-- Join on IMP abstract configurations lifted from a scalar domain. -/
-def joinConfig
-    {Abstract : Type u}
-    (cfg : GammaOnlyDomain Abstract Int) :
-    ConfigSharp Abstract → ConfigSharp Abstract → ConfigSharp Abstract :=
-  joinConfigSharp (storeGammaOnlyDomain cfg)
-
-/-- Pointwise IMP-configuration domain lifted from a scalar integer domain. -/
-def configGammaOnlyDomain
-    {Abstract : Type u}
-    (cfg : GammaOnlyDomain Abstract Int) :
-    GammaOnlyDomain (ConfigSharp Abstract) Config :=
-  let storeCfg := storeGammaOnlyDomain cfg
-  {
-    gamma := gammaConfigOf cfg.gamma
-    le := leConfigSharp storeCfg
-    le_refl := by
-      intro κ pc
-      exact storeCfg.le_refl (κ pc)
-    le_trans := by
-      intro κ₁ κ₂ κ₃ h12 h23 pc
-      exact storeCfg.le_trans (h12 pc) (h23 pc)
-    gamma_monotone := by
-      intro κ₁ κ₂ hLe c hc
-      exact storeCfg.gamma_monotone (hLe (controlOfConfig c)) hc
-    top := topConfigSharp storeCfg
-    gamma_top := by
-      intro c
-      exact storeCfg.gamma_top (storeOfConfig c)
-    join := joinConfigSharp storeCfg
-    join_sound := by
-      intro κ₁ κ₂ c hc
-      change
-        storeOfConfig c ∈ gammaStoreOf cfg.gamma (κ₁ (controlOfConfig c)) ∪
-          gammaStoreOf cfg.gamma (κ₂ (controlOfConfig c)) at hc
-      exact storeCfg.join_sound (κ₁ (controlOfConfig c)) (κ₂ (controlOfConfig c)) hc
-  }
 
 end Examples.IMP

--- a/Examples/IMP/Analysis/Generic/Defs.lean
+++ b/Examples/IMP/Analysis/Generic/Defs.lean
@@ -17,7 +17,7 @@ open AbsInterp.Instances.LTS
 
 universe u
 
-variable {A : Type u} [Bot A]
+variable {A : Type u} [Bot A] [Preorder A] [OrderTop A] [Max A]
 
 /-!
 # Generic IMP Transfer Functions

--- a/Examples/IMP/Analysis/Generic/Domain.lean
+++ b/Examples/IMP/Analysis/Generic/Domain.lean
@@ -33,7 +33,8 @@ An instance packages a scalar `GammaOnlyDomain` together with the transfer
 primitives and soundness contracts needed by the generic IMP transfer function
 and its soundness proof.
 -/
-structure IMPAnalysisDomain (A : Type u) [Bot A] where
+structure IMPAnalysisDomain
+    (A : Type u) [Bot A] [Preorder A] [OrderTop A] [Max A] where
   /-- The underlying scalar gamma-only domain over integers. -/
   scalarDomain : GammaOnlyDomain A Int
   /-- The bottom element has empty concretization. -/
@@ -79,16 +80,17 @@ structure IMPAnalysisDomain (A : Type u) [Bot A] where
 
 namespace IMPAnalysisDomain
 
-variable {A : Type u} [Bot A] (d : IMPAnalysisDomain A)
+variable {A : Type u} [Bot A] [Preorder A] [OrderTop A] [Max A]
+variable (d : IMPAnalysisDomain A)
 
 /-- Convenience accessor for the scalar concretization function. -/
 abbrev gamma : A → Set Int := d.scalarDomain.gamma
 
-/-- Convenience accessor for the scalar join. -/
-abbrev join : A → A → A := d.scalarDomain.join
+/-- Convenience accessor for the scalar join (`⊔` from the `Max A` instance). -/
+abbrev join : A → A → A := (· ⊔ ·)
 
-/-- Convenience accessor for the scalar top element. -/
-abbrev top : A := d.scalarDomain.top
+/-- Convenience accessor for the scalar top element (from `OrderTop A`). -/
+abbrev top : A := ⊤
 
 end IMPAnalysisDomain
 

--- a/Examples/IMP/Analysis/Generic/Lemmas.lean
+++ b/Examples/IMP/Analysis/Generic/Lemmas.lean
@@ -14,7 +14,7 @@ open AbsInterp.Instances.LTS
 
 universe u
 
-variable {A : Type u} [Bot A] (d : IMPAnalysisDomain A)
+variable {A : Type u} [Bot A] [Preorder A] [OrderTop A] [Max A] (d : IMPAnalysisDomain A)
 
 /-!
 # Generic IMP Analysis Lemmas

--- a/Examples/IMP/Analysis/Generic/Soundness.lean
+++ b/Examples/IMP/Analysis/Generic/Soundness.lean
@@ -14,7 +14,7 @@ open AbsInterp.Instances.LTS
 
 universe u
 
-variable {A : Type u} [Bot A] (d : IMPAnalysisDomain A)
+variable {A : Type u} [Bot A] [Preorder A] [OrderTop A] [Max A] (d : IMPAnalysisDomain A)
 
 /-!
 # Generic IMP Soundness Proof

--- a/Tests/Framework/Domains/GammaOnly.lean
+++ b/Tests/Framework/Domains/GammaOnly.lean
@@ -8,28 +8,33 @@ namespace FrameworkDomainsGammaOnly
 open AbsInterp
 open AbsInterp.Domains
 
+/-! ## Smoke tests: the γ-only domain contract
+
+After the alignment with Mathlib `[Preorder] [OrderTop] [Max]`, `≤`, `⊤`,
+and `⊔` come from typeclass instances rather than domain fields.
+-/
+
 example :
     (0 : Int) ∈
-      Domains.signGammaOnlyDomain.gamma Domains.signGammaOnlyDomain.top := by
+      Domains.signGammaOnlyDomain.gamma (⊤ : Sign) := by
   simpa using Domains.signGammaOnlyDomain.gamma_top 0
 
 example :
     Domains.signGammaOnlyDomain.gamma Sign.neg ∪
       Domains.signGammaOnlyDomain.gamma Sign.zero ⊆
-      Domains.signGammaOnlyDomain.gamma
-        (Domains.signGammaOnlyDomain.join Sign.neg Sign.zero) := by
+      Domains.signGammaOnlyDomain.gamma (Sign.neg ⊔ Sign.zero) := by
   simpa using Domains.signGammaOnlyDomain.join_sound Sign.neg Sign.zero
 
 example :
     (3 : Int) ∈
-      Domains.intervalGammaOnlyDomain.gamma Domains.intervalGammaOnlyDomain.top := by
+      Domains.intervalGammaOnlyDomain.gamma (⊤ : Interval) := by
   simpa using Domains.intervalGammaOnlyDomain.gamma_top 3
 
 example :
     Domains.intervalGammaOnlyDomain.gamma (Domains.mk 1 2) ∪
       Domains.intervalGammaOnlyDomain.gamma (Domains.mk 4 5) ⊆
       Domains.intervalGammaOnlyDomain.gamma
-        (Domains.intervalGammaOnlyDomain.join (Domains.mk 1 2) (Domains.mk 4 5)) := by
+        (Domains.mk 1 2 ⊔ Domains.mk 4 5) := by
   simpa using
     Domains.intervalGammaOnlyDomain.join_sound (Domains.mk 1 2) (Domains.mk 4 5)
 


### PR DESCRIPTION
## Summary
- Align `GammaOnlyDomain` with Mathlib's order-typeclass surface per the CSLib-upstream design review (Option D).
- Abstract carrier now requires `[Preorder A] [OrderTop A] [Max A]`; the structure retains only the γ-specific obligations `gamma`, `gamma_monotone`, `gamma_top`, `join_sound`.
- `SemilatticeSup` is intentionally **not** required — γ-only soundness does not depend on abstract-level LUB, and requiring it would force a representation canonicalization on `Interval` (`range 3 1` and `bot` both concretize to ∅ but are distinct, breaking antisymmetry). Domains with a canonical partial order may add `SemilatticeSup` as an opt-in instance.
- Add `GammaOnlyDomain.ofGaloisConnection` helper for domains that do carry `[SemilatticeSup A] [OrderTop A]`.

## Linked issue
Closes #93.

## Scope
- `AbsInterp/Framework/Domains/GammaOnly.lean` — full rewrite to Option D + `ofGaloisConnection` bridge.
- `AbsInterp/Domains/Sign.lean` — add `OrderTop Sign`, `Max Sign`; reshape `signGammaOnlyDomain`.
- `AbsInterp/Domains/Parity.lean` — add `Preorder Parity` (previously missing), `OrderTop Parity`, `Max Parity`; reshape `parityGammaOnlyDomain`.
- `AbsInterp/Domains/Interval.lean` — add `OrderTop Interval`, `Max Interval`; reshape `intervalGammaOnlyDomain`.
- `Examples/IMP/Abstraction/Defs.lean` — rewrite `storeGammaOnlyDomain` / `configGammaOnlyDomain` to use Mathlib pointwise Pi instances. Thread typeclass constraints through `joinConfig`.
- `Examples/IMP/Analysis/Generic/Domain.lean` — thread `[Preorder A] [OrderTop A] [Max A]` through `IMPAnalysisDomain`. Accessor `join` / `top` now use `⊔` / `⊤` notation.
- `Examples/IMP/Analysis/Generic/{Defs,Lemmas,Soundness}.lean` — extend variable blocks with the same typeclass constraints.
- `Tests/Framework/Domains/GammaOnly.lean` — use `⊤` / `⊔` notation instead of removed structure fields.

## Validation
- lake build: 907 jobs, 0 errors.
- lake build Tests: 921 jobs, 0 errors. Tests.Axioms audited six core soundness declarations (soundTrace_of_soundStep, LTSAbstraction.soundTraceLifted, soundStep_impSign, impSignAbstraction, soundStep_impInterval, impIntervalAbstraction); each depends only on propext / Classical.choice / Quot.sound.
- lake test: all build checks passed.

## Out of scope (follow-up)
- Interval representation canonicalization (needed before PartialOrder / SemilatticeSup can be instantiated).
- SemilatticeSup opt-in instances on Sign / Parity.
- Backward-operator unification (P0.3).
- native_decide boundary (P0.5).
- push_neg deprecation warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)