### PR TITLE
refactor(framework): wire IMPAnalysisDomain backward obligations through Backward predicates

### DIFF
--- a/AbsInterp/Framework/Domains/Backward.lean
+++ b/AbsInterp/Framework/Domains/Backward.lean
@@ -33,7 +33,7 @@ def SoundAssume
     (gamma : Abstract → Set Concrete)
     (P : Concrete → Prop)
     (assume_ : Abstract → Abstract) : Prop :=
-  ∀ (a : Abstract) (c : Concrete),
+  ∀ {a : Abstract} {c : Concrete},
     c ∈ gamma a → P c → c ∈ gamma (assume_ a)
 
 /--
@@ -52,26 +52,32 @@ def SoundBackwardRefine
     (gamma : Abstract → Set Concrete)
     (rel : Concrete → Concrete → Prop)
     (refine : Abstract → Abstract → Abstract × Abstract) : Prop :=
-  ∀ (a₁ a₂ : Abstract) (c₁ c₂ : Concrete),
+  ∀ {a₁ a₂ : Abstract} {c₁ c₂ : Concrete},
     c₁ ∈ gamma a₁ → c₂ ∈ gamma a₂ → rel c₁ c₂ →
     c₁ ∈ gamma (refine a₁ a₂).1 ∧ c₂ ∈ gamma (refine a₁ a₂).2
 
+namespace SoundBackwardRefine
+
 /-- The identity backward refinement is trivially sound for any relation. -/
-theorem soundBackwardRefine_id
+theorem id
     {Abstract : Type u} {Concrete : Type v}
     {gamma : Abstract → Set Concrete}
     {rel : Concrete → Concrete → Prop} :
     SoundBackwardRefine gamma rel (fun a₁ a₂ => (a₁, a₂)) :=
-  fun _ _ _ _ h₁ h₂ _ => ⟨h₁, h₂⟩
+  fun h₁ h₂ _ => ⟨h₁, h₂⟩
+
+end SoundBackwardRefine
 
 /-!
 ## Usage note
 
-These predicates are framework-level abstractions intended for reuse across
-different language instantiations. The current IMP layer
-(`Examples/IMP/Analysis/Generic/Domain.lean`) restates equivalent contracts
-inline as `IMPAnalysisDomain` structure fields. A future refactor may wire
-the IMP fields through these predicates directly.
+These predicates are the canonical contract for backward refinement.
+`Examples/IMP/Analysis/Generic/Domain.lean` wires the four `IMPAnalysisDomain`
+backward soundness fields (`assumeNonzero_sound`, `assumeZero_sound`,
+`assumeNonzeroAdd_sound`, `assumeZeroAdd_sound`) through `SoundAssume` and
+`SoundBackwardRefine` directly, and `SoundBackwardRefine.id` is reused as
+the default refinement for domains (e.g. Parity, Interval) that do not
+override the binary backward operators.
 -/
 
 end Domains

--- a/Examples/IMP/Analysis/Generic/Domain.lean
+++ b/Examples/IMP/Analysis/Generic/Domain.lean
@@ -51,32 +51,30 @@ structure IMPAnalysisDomain
     v₁ + v₂ ∈ scalarDomain.gamma (addTransfer a₁ a₂)
   /-- Refine an abstract value under a nonzero assumption. -/
   assumeNonzero : A → A
-  /-- Nonzero refinement is sound. -/
-  assumeNonzero_sound : ∀ {a : A} {v : Int},
-    v ∈ scalarDomain.gamma a → v ≠ 0 → v ∈ scalarDomain.gamma (assumeNonzero a)
+  /-- Nonzero refinement is sound (`SoundAssume` with `P := (· ≠ 0)`). -/
+  assumeNonzero_sound :
+    SoundAssume scalarDomain.gamma (· ≠ 0) assumeNonzero
   /-- Refine an abstract value under a zero assumption. -/
   assumeZero : A → A
-  /-- Zero refinement is sound. -/
-  assumeZero_sound : ∀ {a : A} {v : Int},
-    v ∈ scalarDomain.gamma a → v = 0 → v ∈ scalarDomain.gamma (assumeZero a)
+  /-- Zero refinement is sound (`SoundAssume` with `P := (· = 0)`). -/
+  assumeZero_sound :
+    SoundAssume scalarDomain.gamma (· = 0) assumeZero
   /-- Backward refinement for addition under nonzero constraint.
       Given `v₁ ∈ γ(a₁)`, `v₂ ∈ γ(a₂)`, and `v₁ + v₂ ≠ 0`, refine both. -/
   assumeNonzeroAdd : A → A → A × A := fun a₁ a₂ => (a₁, a₂)
-  /-- Nonzero-add backward refinement is sound. -/
-  assumeNonzeroAdd_sound : ∀ {a₁ a₂ : A} {v₁ v₂ : Int},
-    v₁ ∈ scalarDomain.gamma a₁ → v₂ ∈ scalarDomain.gamma a₂ →
-    v₁ + v₂ ≠ 0 →
-    v₁ ∈ scalarDomain.gamma (assumeNonzeroAdd a₁ a₂).1 ∧
-    v₂ ∈ scalarDomain.gamma (assumeNonzeroAdd a₁ a₂).2
+  /-- Nonzero-add backward refinement is sound (`SoundBackwardRefine` with
+      `rel := fun v₁ v₂ => v₁ + v₂ ≠ 0`). -/
+  assumeNonzeroAdd_sound :
+    SoundBackwardRefine scalarDomain.gamma
+      (fun v₁ v₂ => v₁ + v₂ ≠ 0) assumeNonzeroAdd
   /-- Backward refinement for addition under zero constraint.
       Given `v₁ ∈ γ(a₁)`, `v₂ ∈ γ(a₂)`, and `v₁ + v₂ = 0`, refine both. -/
   assumeZeroAdd : A → A → A × A := fun a₁ a₂ => (a₁, a₂)
-  /-- Zero-add backward refinement is sound. -/
-  assumeZeroAdd_sound : ∀ {a₁ a₂ : A} {v₁ v₂ : Int},
-    v₁ ∈ scalarDomain.gamma a₁ → v₂ ∈ scalarDomain.gamma a₂ →
-    v₁ + v₂ = 0 →
-    v₁ ∈ scalarDomain.gamma (assumeZeroAdd a₁ a₂).1 ∧
-    v₂ ∈ scalarDomain.gamma (assumeZeroAdd a₁ a₂).2
+  /-- Zero-add backward refinement is sound (`SoundBackwardRefine` with
+      `rel := fun v₁ v₂ => v₁ + v₂ = 0`). -/
+  assumeZeroAdd_sound :
+    SoundBackwardRefine scalarDomain.gamma
+      (fun v₁ v₂ => v₁ + v₂ = 0) assumeZeroAdd
 
 namespace IMPAnalysisDomain
 

--- a/Examples/IMP/Analysis/Interval/Defs.lean
+++ b/Examples/IMP/Analysis/Interval/Defs.lean
@@ -30,8 +30,12 @@ def intervalAnalysisDomain : IMPAnalysisDomain Interval where
   assumeNonzero_sound := assumeNonzeroInterval_sound
   assumeZero := assumeZeroInterval
   assumeZero_sound := assumeZeroInterval_sound
-  assumeNonzeroAdd_sound := fun h₁ h₂ _ => ⟨h₁, h₂⟩
-  assumeZeroAdd_sound := fun h₁ h₂ _ => ⟨h₁, h₂⟩
+  assumeNonzeroAdd_sound :=
+    SoundBackwardRefine.id (gamma := intervalGammaOnlyDomain.gamma)
+      (rel := fun v₁ v₂ => v₁ + v₂ ≠ 0)
+  assumeZeroAdd_sound :=
+    SoundBackwardRefine.id (gamma := intervalGammaOnlyDomain.gamma)
+      (rel := fun v₁ v₂ => v₁ + v₂ = 0)
 
 -- Public API wrappers preserving backward-compatible names.
 

--- a/Examples/IMP/Analysis/Parity/Defs.lean
+++ b/Examples/IMP/Analysis/Parity/Defs.lean
@@ -30,8 +30,12 @@ def parityAnalysisDomain : IMPAnalysisDomain Parity where
   assumeNonzero_sound := assumeNonzeroParity_sound
   assumeZero := assumeZeroParity
   assumeZero_sound := assumeZeroParity_sound
-  assumeNonzeroAdd_sound := fun h₁ h₂ _ => ⟨h₁, h₂⟩
-  assumeZeroAdd_sound := fun h₁ h₂ _ => ⟨h₁, h₂⟩
+  assumeNonzeroAdd_sound :=
+    SoundBackwardRefine.id (gamma := parityGammaOnlyDomain.gamma)
+      (rel := fun v₁ v₂ => v₁ + v₂ ≠ 0)
+  assumeZeroAdd_sound :=
+    SoundBackwardRefine.id (gamma := parityGammaOnlyDomain.gamma)
+      (rel := fun v₁ v₂ => v₁ + v₂ = 0)
 
 /-- The generic Parity concretization for a fixed IMP program. -/
 def gammaProgramParity (program : Stmt) : Framework.Gamma (ConfigSharp Parity) Config :=


### PR DESCRIPTION
## Summary
- Switch `SoundAssume` and `SoundBackwardRefine` in `AbsInterp/Framework/Domains/Backward.lean` from explicit to implicit binders so domain-level lemmas can be assigned verbatim into `IMPAnalysisDomain` structure fields. Hoist `soundBackwardRefine_id` into the `SoundBackwardRefine` namespace as `SoundBackwardRefine.id`.
- Replace the four inline soundness obligations on `IMPAnalysisDomain` (`assumeNonzero_sound`, `assumeZero_sound`, `assumeNonzeroAdd_sound`, `assumeZeroAdd_sound`) with direct applications of `SoundAssume` / `SoundBackwardRefine`. The framework predicates unfold definitionally to the prior shape so consumers in `Generic/Lemmas.lean`, `Generic/Soundness.lean`, and the Sign/Parity/Interval analysis-domain instances continue to elaborate untouched.
- Adopt `SoundBackwardRefine.id` as the default for `assumeNonzeroAdd_sound` / `assumeZeroAdd_sound` in the Parity and Interval IMP analysis-domain instances, providing the new namespace its first real consumers.

This is interface cleanup, not a correctness change. The framework module that previously had zero downstream consumers now has the canonical contract that the IMP layer goes through.

## Linked issue
Closes #84.

## Scope
- `AbsInterp/Framework/Domains/Backward.lean` — implicit binders + `SoundBackwardRefine.id` namespace + updated usage note.
- `Examples/IMP/Analysis/Generic/Domain.lean` — four obligations rewritten as `SoundAssume` / `SoundBackwardRefine` applications.
- `Examples/IMP/Analysis/Parity/Defs.lean` and `Examples/IMP/Analysis/Interval/Defs.lean` — `assumeNonzeroAdd_sound` / `assumeZeroAdd_sound` defaults switched to `SoundBackwardRefine.id` (with explicit `(gamma := ...)` and `(rel := ...)` to help unification with the structure-field default).

## Validation
- `lake build`: 907 jobs, 0 errors.
- `lake build Tests`: 921 jobs, 0 errors.
- `lake test`: `all build checks passed`.
- `Tests.Axioms` continues to report only `propext` / `Classical.choice` / `Quot.sound` for the six audited declarations (`soundTrace_of_soundStep`, `LTSAbstraction.soundTraceLifted`, `soundStep_impSign`, `impSignAbstraction`, `soundStep_impInterval`, `impIntervalAbstraction`).

## Out of scope (follow-up)
- n-ary backward refinement (defer until a real ternary use case appears).
- Additional combinators (`compose`, `symm`, `map_gamma`, `SoundAssume.id`).
- Sign domain binder changes — the four backward soundness lemmas in `AbsInterp/Domains/Sign.lean` already use implicit binders.
- Set-valued property API (`P : Set Concrete`).
- Axiom-audit extension to `SoundBackwardRefine.id` and the Parity trace path (P0.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)