### PR TITLE
docs: document native_decide axiom boundary across demo/test modules

### DIFF
--- a/Examples/IMP/Programs/WidenShowcase.lean
+++ b/Examples/IMP/Programs/WidenShowcase.lean
@@ -8,6 +8,16 @@ Demonstrates the framework widening interfaces (`pfp`, `WAcc`,
 `WidenUpperBound`) on a simple while-loop IMP program analyzed with
 the Interval domain.
 
+## Axiom note
+
+The `loopPfp_eq_top` theorem uses `native_decide` to compute the
+widening post-fixpoint result. This pulls in `Lean.ofReduceBool` and
+`Lean.trustCompiler`. The kernel-only `decide` tactic cannot reduce
+the `pfp` computation within its heartbeat limits.
+
+This is acceptable for validation code: the upstream-candidate
+soundness path is axiom-clean (see `Tests/Axioms.lean`).
+
 ## Program
 
 ```

--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ contribution, rather than treating this repository as a one-off example dump.
 - Read `Examples/IMP/Programs/Tutorial` only if you want the smaller teaching
   examples first.
 
+## Axiom boundary
+
+The upstream-candidate soundness path (Framework, Instances/LTS, and
+the generic IMP analysis) uses only standard axioms (`propext`,
+`Quot.sound`, `Classical.choice`). This is enforced at compile time by
+`Tests/Axioms.lean`, which uses `#guard_msgs in #print axioms` to pin
+the exact axiom set of 13 key declarations.
+
+Some demonstration and test modules (`Programs/Showcase`,
+`Programs/WidenShowcase`, `Tests/Examples/IMP/Smoke`, etc.)
+intentionally use `native_decide` for computed validation of abstract
+analysis output. These modules are clearly marked with "Axiom note"
+headers and are not part of the upstream-candidate path.
+
 ## Build and test
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -62,11 +62,15 @@ the generic IMP analysis) uses only standard axioms (`propext`,
 `Tests/Axioms.lean`, which uses `#guard_msgs in #print axioms` to pin
 the exact axiom set of 13 key declarations.
 
-Some demonstration and test modules (`Programs/Showcase`,
-`Programs/WidenShowcase`, `Tests/Examples/IMP/Smoke`, etc.)
+Some demonstration and test modules
+(`Examples/IMP/Programs/Showcase.lean`,
+`Examples/IMP/Programs/WidenShowcase.lean`,
+`Tests/Examples/IMP/Smoke.lean`,
+`Tests/Examples/IMP/ParitySmoke.lean`,
+`Tests/Framework/Iteration/Widening.lean`)
 intentionally use `native_decide` for computed validation of abstract
-analysis output. These modules are clearly marked with "Axiom note"
-headers and are not part of the upstream-candidate path.
+analysis output. These modules are clearly marked with axiom-note
+documentation and are not part of the upstream-candidate path.
 
 ## Build and test
 

--- a/Tests/Examples/IMP/ParitySmoke.lean
+++ b/Tests/Examples/IMP/ParitySmoke.lean
@@ -14,7 +14,10 @@ open Examples.IMP
 /-!
 # Parity Analysis Smoke Tests
 
-Validates the Parity domain instantiation of the generic IMP analysis framework.
+Validates the Parity domain instantiation of the generic IMP analysis
+framework. Uses `native_decide` to evaluate abstract transfer results;
+this is test-only code and the upstream soundness path is axiom-clean
+(see `Tests/Axioms.lean`).
 -/
 
 /-- `x0 := 5` assigns an odd value. -/

--- a/Tests/Examples/IMP/Smoke.lean
+++ b/Tests/Examples/IMP/Smoke.lean
@@ -5,6 +5,15 @@ import Examples
 namespace Tests
 namespace ExamplesIMPSmoke
 
+/-!
+# Sign Analysis Smoke Tests
+
+Computed validation of Sign analysis output on small IMP programs.
+Uses `native_decide` to evaluate abstract transfer results; this is
+test-only code and the upstream soundness path is axiom-clean
+(see `Tests/Axioms.lean`).
+-/
+
 open AbsInterp
 open AbsInterp.Domains
 open AbsInterp.Framework

--- a/Tests/Framework/Iteration/Widening.lean
+++ b/Tests/Framework/Iteration/Widening.lean
@@ -12,6 +12,10 @@ open AbsInterp.Framework.Iteration
 
 A toy 3-element flat lattice `{bot, mid, top}` exercising
 `WAcc`, `witer`, `pfp`, `IsPostFixpoint`, and `sound_of_isPostFixpoint`.
+
+The `pfp_eq_top` theorem uses `native_decide` to compute the widening
+result. This is test-only code; the upstream soundness path is
+axiom-clean (see `Tests/Axioms.lean`).
 -/
 
 /-- Three-element flat lattice. -/


### PR DESCRIPTION
## Summary
- Add "Axiom note" headers to the four modules that use `native_decide` but lacked documentation: `WidenShowcase.lean`, `Smoke.lean`, `ParitySmoke.lean`, `Widening.lean`.
- Add an "Axiom boundary" section to `README.md` explaining the upstream-candidate path is axiom-clean (enforced by `Tests/Axioms.lean` `#guard_msgs`) and that demo/test modules intentionally use `native_decide`.
- Documentation-only change; no code modifications.

## Scope
- 5 files: `Examples/IMP/Programs/WidenShowcase.lean`, `Tests/Examples/IMP/Smoke.lean`, `Tests/Examples/IMP/ParitySmoke.lean`, `Tests/Framework/Iteration/Widening.lean`, `README.md`.
- Physical module separation (splitting demo from upstream) is deferred to P0.7.

## Validation
- `lake build`, `lake build Tests`, `lake test`: all pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)