### PR TITLE
feat(framework): upgrade GammaOnlyDomain from [Max] to [SemilatticeSup]

### DIFF
--- a/AbsInterp/Domains/Parity.lean
+++ b/AbsInterp/Domains/Parity.lean
@@ -70,8 +70,9 @@ def joinParity : Parity → Parity → Parity
 
 instance : Max Parity := ⟨joinParity⟩
 
-theorem joinParity_sound : ∀ a b : Parity, gammaParity a ∪ gammaParity b ⊆ gammaParity (joinParity a b) := by
+theorem joinParity_sound : ∀ a b : Parity, gammaParity a ∪ gammaParity b ⊆ gammaParity (a ⊔ b) := by
   intro a b n hn
+  show n ∈ gammaParity (joinParity a b)
   cases a <;> cases b <;> simp_all [joinParity, gammaParity, Set.mem_union, Set.mem_empty_iff_false]
 
 /-- The complete gamma-only domain instance for Parity. -/

--- a/AbsInterp/Domains/Parity.lean
+++ b/AbsInterp/Domains/Parity.lean
@@ -48,10 +48,14 @@ theorem leParity_refl : ∀ a : Parity, leParity a a := by
 theorem leParity_trans : ∀ {a b c : Parity}, leParity a b → leParity b c → leParity a c := by
   intro a b c hab hbc; cases a <;> cases b <;> cases c <;> simp_all [leParity]
 
-instance : Preorder Parity where
+theorem leParity_antisymm : ∀ {a b : Parity}, leParity a b → leParity b a → a = b := by
+  intro a b hab hba; cases a <;> cases b <;> simp_all [leParity]
+
+instance : PartialOrder Parity where
   le := leParity
   le_refl := leParity_refl
   le_trans := @leParity_trans
+  le_antisymm _ _ := leParity_antisymm
 
 instance : OrderTop Parity where
   top := .top
@@ -75,21 +79,19 @@ theorem joinParity_sound : ∀ a b : Parity, gammaParity a ∪ gammaParity b ⊆
   show n ∈ gammaParity (joinParity a b)
   cases a <;> cases b <;> simp_all [joinParity, gammaParity, Set.mem_union, Set.mem_empty_iff_false]
 
-/-- The complete gamma-only domain instance for Parity. -/
-def parityGammaOnlyDomain : GammaOnlyDomain Parity Int where
-  gamma := gammaParity
-  gamma_monotone := gammaParity_monotone
-  gamma_top := fun _ => Set.mem_univ _
-  join_sound := joinParity_sound
-
 theorem joinParity_le_left (a b : Parity) : a ≤ joinParity a b := by
+  show leParity a (joinParity a b)
   cases a <;> cases b <;> simp [leParity, joinParity]
 
 theorem joinParity_le_right (a b : Parity) : b ≤ joinParity a b := by
+  show leParity b (joinParity a b)
   cases a <;> cases b <;> simp [leParity, joinParity]
 
 theorem joinParity_le_of_le {a b c : Parity} (ha : a ≤ c) (hb : b ≤ c) :
     joinParity a b ≤ c := by
+  show leParity (joinParity a b) c
+  have ha' : leParity a c := ha
+  have hb' : leParity b c := hb
   cases a <;> cases b <;> cases c <;> simp_all [leParity, joinParity]
 
 instance : SemilatticeSup Parity where
@@ -97,6 +99,13 @@ instance : SemilatticeSup Parity where
   le_sup_left := joinParity_le_left
   le_sup_right := joinParity_le_right
   sup_le _ _ _ ha hb := joinParity_le_of_le ha hb
+
+/-- The complete gamma-only domain instance for Parity. -/
+def parityGammaOnlyDomain : GammaOnlyDomain Parity Int where
+  gamma := gammaParity
+  gamma_monotone := gammaParity_monotone
+  gamma_top := fun _ => Set.mem_univ _
+  join_sound := joinParity_sound
 
 /-- Abstract a concrete integer constant by its parity. -/
 def constParity (n : Int) : Parity :=

--- a/AbsInterp/Domains/Parity.lean
+++ b/AbsInterp/Domains/Parity.lean
@@ -82,6 +82,22 @@ def parityGammaOnlyDomain : GammaOnlyDomain Parity Int where
   gamma_top := fun _ => Set.mem_univ _
   join_sound := joinParity_sound
 
+theorem joinParity_le_left (a b : Parity) : a ≤ joinParity a b := by
+  cases a <;> cases b <;> simp [leParity, joinParity]
+
+theorem joinParity_le_right (a b : Parity) : b ≤ joinParity a b := by
+  cases a <;> cases b <;> simp [leParity, joinParity]
+
+theorem joinParity_le_of_le {a b c : Parity} (ha : a ≤ c) (hb : b ≤ c) :
+    joinParity a b ≤ c := by
+  cases a <;> cases b <;> cases c <;> simp_all [leParity, joinParity]
+
+instance : SemilatticeSup Parity where
+  sup := joinParity
+  le_sup_left := joinParity_le_left
+  le_sup_right := joinParity_le_right
+  sup_le _ _ _ ha hb := joinParity_le_of_le ha hb
+
 /-- Abstract a concrete integer constant by its parity. -/
 def constParity (n : Int) : Parity :=
   if n % 2 = 0 then .even else .odd

--- a/AbsInterp/Domains/Parity.lean
+++ b/AbsInterp/Domains/Parity.lean
@@ -77,7 +77,7 @@ instance : Max Parity := ⟨joinParity⟩
 theorem joinParity_sound : ∀ a b : Parity, gammaParity a ∪ gammaParity b ⊆ gammaParity (a ⊔ b) := by
   intro a b n hn
   show n ∈ gammaParity (joinParity a b)
-  cases a <;> cases b <;> simp_all [joinParity, gammaParity, Set.mem_union, Set.mem_empty_iff_false]
+  cases a <;> cases b <;> simp [joinParity, gammaParity] at hn ⊢ <;> tauto
 
 theorem joinParity_le_left (a b : Parity) : a ≤ joinParity a b := by
   cases a <;> cases b <;> simp [LE.le, leParity, joinParity]

--- a/AbsInterp/Domains/Parity.lean
+++ b/AbsInterp/Domains/Parity.lean
@@ -80,19 +80,14 @@ theorem joinParity_sound : ∀ a b : Parity, gammaParity a ∪ gammaParity b ⊆
   cases a <;> cases b <;> simp_all [joinParity, gammaParity, Set.mem_union, Set.mem_empty_iff_false]
 
 theorem joinParity_le_left (a b : Parity) : a ≤ joinParity a b := by
-  show leParity a (joinParity a b)
-  cases a <;> cases b <;> simp [leParity, joinParity]
+  cases a <;> cases b <;> simp [LE.le, leParity, joinParity]
 
 theorem joinParity_le_right (a b : Parity) : b ≤ joinParity a b := by
-  show leParity b (joinParity a b)
-  cases a <;> cases b <;> simp [leParity, joinParity]
+  cases a <;> cases b <;> simp [LE.le, leParity, joinParity]
 
 theorem joinParity_le_of_le {a b c : Parity} (ha : a ≤ c) (hb : b ≤ c) :
     joinParity a b ≤ c := by
-  show leParity (joinParity a b) c
-  have ha' : leParity a c := ha
-  have hb' : leParity b c := hb
-  cases a <;> cases b <;> cases c <;> simp_all [leParity, joinParity]
+  cases a <;> cases b <;> cases c <;> simp_all [LE.le, leParity, joinParity]
 
 instance : SemilatticeSup Parity where
   sup := joinParity

--- a/AbsInterp/Domains/Sign.lean
+++ b/AbsInterp/Domains/Sign.lean
@@ -41,24 +41,6 @@ theorem leSign_refl (a : Sign) : leSign a a :=
 theorem leSign_trans {a b c : Sign} (hAB : leSign a b) (hBC : leSign b c) : leSign a c :=
   fun _ hn => hBC (hAB hn)
 
-instance : Preorder Sign where
-  le := leSign
-  le_refl := leSign_refl
-  le_trans := @leSign_trans
-
-instance : OrderTop Sign where
-  top := .top
-  le_top _ := Set.subset_univ _
-
-theorem gammaSign_monotone_of_leSign {a b : Sign} (hAB : a ≤ b) :
-    gammaSign a ⊆ gammaSign b :=
-  hAB
-
-/-- `top` concretizes to all integers. -/
-theorem gammaSign_top (n : Int) : n ∈ gammaSign Sign.top := by
-  change True
-  trivial
-
 private def hasNeg : Sign -> Bool
   | .bot => false
   | .neg => true
@@ -85,6 +67,61 @@ private def hasPos : Sign -> Bool
   | .nonpos => false
   | .nonneg => true
   | .top => true
+
+/-- If `γ(a) ⊆ γ(b)` and `a` has a negative witness, so does `b`. -/
+private theorem hasNeg_of_leSign {a b : Sign} (h : leSign a b) (hN : hasNeg a = true) :
+    hasNeg b = true := by
+  have hMem : (-1 : Int) ∈ gammaSign a := by
+    cases a <;> simp_all [hasNeg, gammaSign]
+  have hMemB := h hMem
+  cases b <;> simp_all [hasNeg, gammaSign]
+
+/-- If `γ(a) ⊆ γ(b)` and `a` has a zero witness, so does `b`. -/
+private theorem hasZero_of_leSign {a b : Sign} (h : leSign a b) (hZ : hasZero a = true) :
+    hasZero b = true := by
+  have hMem : (0 : Int) ∈ gammaSign a := by
+    cases a <;> simp_all [hasZero, gammaSign]
+  have hMemB := h hMem
+  cases b <;> simp_all [hasZero, gammaSign]
+
+/-- If `γ(a) ⊆ γ(b)` and `a` has a positive witness, so does `b`. -/
+private theorem hasPos_of_leSign {a b : Sign} (h : leSign a b) (hP : hasPos a = true) :
+    hasPos b = true := by
+  have hMem : (1 : Int) ∈ gammaSign a := by
+    cases a <;> simp_all [hasPos, gammaSign]
+  have hMemB := h hMem
+  cases b <;> simp_all [hasPos, gammaSign]
+
+theorem leSign_antisymm {a b : Sign} (hab : leSign a b) (hba : leSign b a) : a = b := by
+  have hN1 := hasNeg_of_leSign hab
+  have hN2 := hasNeg_of_leSign hba
+  have hZ1 := hasZero_of_leSign hab
+  have hZ2 := hasZero_of_leSign hba
+  have hP1 := hasPos_of_leSign hab
+  have hP2 := hasPos_of_leSign hba
+  cases a <;> cases b <;>
+    first
+    | rfl
+    | (exfalso; simp_all [hasNeg, hasZero, hasPos])
+
+instance : PartialOrder Sign where
+  le := leSign
+  le_refl := leSign_refl
+  le_trans := @leSign_trans
+  le_antisymm := fun _ _ => leSign_antisymm
+
+instance : OrderTop Sign where
+  top := .top
+  le_top _ := Set.subset_univ _
+
+theorem gammaSign_monotone_of_leSign {a b : Sign} (hAB : a ≤ b) :
+    gammaSign a ⊆ gammaSign b :=
+  hAB
+
+/-- `top` concretizes to all integers. -/
+theorem gammaSign_top (n : Int) : n ∈ gammaSign Sign.top := by
+  change True
+  trivial
 
 private def signOfFlags (neg zero pos : Bool) : Sign :=
   match neg, zero, pos with
@@ -124,16 +161,22 @@ theorem joinSign_sound (a b : Sign) :
   cases a <;> rfl
 
 theorem joinSign_le_left (a b : Sign) : a ≤ joinSign a b :=
-  fun n hn => joinSign_sound a b (Or.inl hn)
+  fun _ hn => joinSign_sound a b (Or.inl hn)
 
 theorem joinSign_le_right (a b : Sign) : b ≤ joinSign a b :=
-  fun n hn => joinSign_sound a b (Or.inr hn)
+  fun _ hn => joinSign_sound a b (Or.inr hn)
 
 theorem joinSign_le_of_le {a b c : Sign} (ha : a ≤ c) (hb : b ≤ c) :
     joinSign a b ≤ c := by
+  have hN_ac := hasNeg_of_leSign ha
+  have hN_bc := hasNeg_of_leSign hb
+  have hZ_ac := hasZero_of_leSign ha
+  have hZ_bc := hasZero_of_leSign hb
+  have hP_ac := hasPos_of_leSign ha
+  have hP_bc := hasPos_of_leSign hb
+  intro n hn
   cases a <;> cases b <;> cases c <;>
-    simp_all [leSign, gammaSign, joinSign, signOfFlags, hasNeg, hasZero, hasPos] <;>
-    tauto
+    simp_all [gammaSign, joinSign, signOfFlags, hasNeg, hasZero, hasPos]
 
 instance : SemilatticeSup Sign where
   sup := joinSign

--- a/AbsInterp/Domains/Sign.lean
+++ b/AbsInterp/Domains/Sign.lean
@@ -123,6 +123,24 @@ theorem joinSign_sound (a b : Sign) :
     joinSign a .bot = a := by
   cases a <;> rfl
 
+theorem joinSign_le_left (a b : Sign) : a ≤ joinSign a b :=
+  fun n hn => joinSign_sound a b (Or.inl hn)
+
+theorem joinSign_le_right (a b : Sign) : b ≤ joinSign a b :=
+  fun n hn => joinSign_sound a b (Or.inr hn)
+
+theorem joinSign_le_of_le {a b c : Sign} (ha : a ≤ c) (hb : b ≤ c) :
+    joinSign a b ≤ c := by
+  cases a <;> cases b <;> cases c <;>
+    simp_all [leSign, gammaSign, joinSign, signOfFlags, hasNeg, hasZero, hasPos] <;>
+    tauto
+
+instance : SemilatticeSup Sign where
+  sup := joinSign
+  le_sup_left := joinSign_le_left
+  le_sup_right := joinSign_le_right
+  sup_le _ _ _ ha hb := joinSign_le_of_le ha hb
+
 /-- Exact sign for an integer literal. -/
 def constSign (n : Int) : Sign :=
   if n < 0 then .neg else if n = 0 then .zero else .pos

--- a/AbsInterp/Domains/Sign.lean
+++ b/AbsInterp/Domains/Sign.lean
@@ -108,8 +108,9 @@ instance : Max Sign := ⟨joinSign⟩
 
 /-- `joinSign` soundly over-approximates union concretization. -/
 theorem joinSign_sound (a b : Sign) :
-    gammaSign a ∪ gammaSign b ⊆ gammaSign (joinSign a b) := by
+    gammaSign a ∪ gammaSign b ⊆ gammaSign (a ⊔ b) := by
   intro n hn
+  show n ∈ gammaSign (joinSign a b)
   cases a <;> cases b <;>
     simp [gammaSign, joinSign, signOfFlags, hasNeg, hasZero, hasPos] at hn ⊢ <;>
     tauto

--- a/AbsInterp/Framework/Domains/GammaOnly.lean
+++ b/AbsInterp/Framework/Domains/GammaOnly.lean
@@ -53,7 +53,7 @@ law required here is the γ-level `join_sound`. Domains that additionally
 satisfy `SemilatticeSup` are welcome to provide it as an opt-in instance.
 -/
 structure GammaOnlyDomain
-    (Abstract : Type u) [Preorder Abstract] [OrderTop Abstract] [Max Abstract]
+    (Abstract : Type u) [Preorder Abstract] [OrderTop Abstract] [SemilatticeSup Abstract]
     (Concrete : Type v) where
   /-- The concretization function mapping abstract elements to concrete sets. -/
   gamma : Gamma Abstract Concrete
@@ -63,7 +63,7 @@ structure GammaOnlyDomain
 
 namespace GammaOnlyDomain
 
-variable {Abstract : Type u} [Preorder Abstract] [OrderTop Abstract] [Max Abstract]
+variable {Abstract : Type u} [Preorder Abstract] [OrderTop Abstract] [SemilatticeSup Abstract]
 variable {Concrete : Type v}
 variable (cfg : GammaOnlyDomain Abstract Concrete)
 

--- a/AbsInterp/Framework/Domains/GammaOnly.lean
+++ b/AbsInterp/Framework/Domains/GammaOnly.lean
@@ -11,11 +11,11 @@ a concretization function `gamma` together with monotonicity, top-coverage, and
 join-soundness obligations. No abstraction function `α` or Galois-connection
 obligation is required.
 
-The abstract carrier is required to carry `[Preorder] [OrderTop] [Max]` Mathlib
-instances. Domains that additionally satisfy `[SemilatticeSup]` may provide it
-as an opt-in instance. `GammaOnlyDomain.ofGaloisConnection` bridges the γ-only
-interface with the standard Mathlib `GaloisConnection` for domains that do have
-an `α`.
+The abstract carrier is required to carry `[Preorder] [OrderTop] [SemilatticeSup]`
+Mathlib instances. `[SemilatticeSup]` subsumes `[Max]` via `SemilatticeSup.toMax`,
+so the join `⊔` is available uniformly. `GammaOnlyDomain.ofGaloisConnection`
+bridges the γ-only interface with the standard Mathlib `GaloisConnection` for
+domains that do have an `α`.
 
 ## References
 
@@ -38,8 +38,8 @@ abbrev Gamma (Abstract : Type u) (Concrete : Type v) := Abstract -> Set Concrete
 /--
 `gamma`-only abstract-domain contract.
 
-The abstract carrier is a Mathlib-style ordered type with a top element and a
-binary `⊔` operation (`Preorder + OrderTop + Max`). The contract pins down the
+The abstract carrier is a Mathlib-style ordered join-semilattice with a top
+element (`Preorder + OrderTop + SemilatticeSup`). The contract pins down the
 γ-only obligations:
 
 - `gamma` : the concretization function,
@@ -47,10 +47,11 @@ binary `⊔` operation (`Preorder + OrderTop + Max`). The contract pins down the
 - `gamma_top` : `⊤` over-approximates every concrete element,
 - `join_sound` : `⊔` soundly over-approximates concrete unions.
 
-This deliberately omits `α` / Galois-connection / abstract-level LUB
-obligations. The `Max` typeclass carries no laws on its own; the only join
-law required here is the γ-level `join_sound`. Domains that additionally
-satisfy `SemilatticeSup` are welcome to provide it as an opt-in instance.
+This deliberately omits `α` / Galois-connection obligations. While
+`SemilatticeSup` already provides the abstract-level LUB laws
+(`le_sup_left`, `le_sup_right`, `sup_le`), the γ-level `join_sound` is a
+separate semantic soundness statement that the framework explicitly
+requires.
 -/
 structure GammaOnlyDomain
     (Abstract : Type u) [Preorder Abstract] [OrderTop Abstract] [SemilatticeSup Abstract]

--- a/Examples/IMP/Abstraction/Defs.lean
+++ b/Examples/IMP/Abstraction/Defs.lean
@@ -109,7 +109,7 @@ def botConfigSharp
 /-!
 ## Pointwise lifts of `GammaOnlyDomain`
 
-The Mathlib `Pi` instances (`Pi.preorder`, `Pi.instOrderTop`, `Pi.instMax`)
+The Mathlib `Pi` instances (`Pi.preorder`, `Pi.instOrderTop`, `Pi.instSemilatticeSup`)
 give us `≤`, `⊤`, and `⊔` on `Var → Abstract` and `Stmt → Var → Abstract`
 automatically, so the lifted domain only has to supply the γ-level
 soundness obligations.
@@ -118,7 +118,7 @@ soundness obligations.
 /-- Pointwise IMP-store domain lifted from a scalar integer domain. -/
 def storeGammaOnlyDomain
     {Abstract : Type u}
-    [Preorder Abstract] [OrderTop Abstract] [Max Abstract]
+    [Preorder Abstract] [OrderTop Abstract] [SemilatticeSup Abstract]
     (cfg : GammaOnlyDomain Abstract Int) :
     GammaOnlyDomain (StoreSharp Abstract) Store where
   gamma := gammaStoreOf cfg.gamma
@@ -138,7 +138,7 @@ def storeGammaOnlyDomain
 /-- Pointwise IMP-configuration domain lifted from a scalar integer domain. -/
 def configGammaOnlyDomain
     {Abstract : Type u}
-    [Preorder Abstract] [OrderTop Abstract] [Max Abstract]
+    [Preorder Abstract] [OrderTop Abstract] [SemilatticeSup Abstract]
     (cfg : GammaOnlyDomain Abstract Int) :
     GammaOnlyDomain (ConfigSharp Abstract) Config where
   gamma := gammaConfigOf cfg.gamma
@@ -166,7 +166,7 @@ intentionally unused beyond helping type inference.
 -/
 def joinConfig
     {Abstract : Type u}
-    [Preorder Abstract] [OrderTop Abstract] [Max Abstract]
+    [Preorder Abstract] [OrderTop Abstract] [SemilatticeSup Abstract]
     (_cfg : GammaOnlyDomain Abstract Int) :
     ConfigSharp Abstract → ConfigSharp Abstract → ConfigSharp Abstract :=
   fun κ₁ κ₂ pc x => κ₁ pc x ⊔ κ₂ pc x

--- a/Examples/IMP/Analysis/Generic/Defs.lean
+++ b/Examples/IMP/Analysis/Generic/Defs.lean
@@ -17,7 +17,7 @@ open AbsInterp.Instances.LTS
 
 universe u
 
-variable {A : Type u} [Bot A] [Preorder A] [OrderTop A] [Max A]
+variable {A : Type u} [Bot A] [Preorder A] [OrderTop A] [SemilatticeSup A]
 
 /-!
 # Generic IMP Transfer Functions

--- a/Examples/IMP/Analysis/Generic/Domain.lean
+++ b/Examples/IMP/Analysis/Generic/Domain.lean
@@ -84,7 +84,7 @@ variable (d : IMPAnalysisDomain A)
 /-- Convenience accessor for the scalar concretization function. -/
 abbrev gamma : A → Set Int := d.scalarDomain.gamma
 
-/-- Convenience accessor for the scalar join (`⊔` from the `Max A` instance). -/
+/-- Convenience accessor for the scalar join (`⊔` from the `SemilatticeSup A` instance). -/
 abbrev join : A → A → A := (· ⊔ ·)
 
 /-- Convenience accessor for the scalar top element (from `OrderTop A`). -/

--- a/Examples/IMP/Analysis/Generic/Domain.lean
+++ b/Examples/IMP/Analysis/Generic/Domain.lean
@@ -34,7 +34,7 @@ primitives and soundness contracts needed by the generic IMP transfer function
 and its soundness proof.
 -/
 structure IMPAnalysisDomain
-    (A : Type u) [Bot A] [Preorder A] [OrderTop A] [Max A] where
+    (A : Type u) [Bot A] [Preorder A] [OrderTop A] [SemilatticeSup A] where
   /-- The underlying scalar gamma-only domain over integers. -/
   scalarDomain : GammaOnlyDomain A Int
   /-- The bottom element has empty concretization. -/
@@ -78,7 +78,7 @@ structure IMPAnalysisDomain
 
 namespace IMPAnalysisDomain
 
-variable {A : Type u} [Bot A] [Preorder A] [OrderTop A] [Max A]
+variable {A : Type u} [Bot A] [Preorder A] [OrderTop A] [SemilatticeSup A]
 variable (d : IMPAnalysisDomain A)
 
 /-- Convenience accessor for the scalar concretization function. -/

--- a/Examples/IMP/Analysis/Generic/Lemmas.lean
+++ b/Examples/IMP/Analysis/Generic/Lemmas.lean
@@ -14,7 +14,7 @@ open AbsInterp.Instances.LTS
 
 universe u
 
-variable {A : Type u} [Bot A] [Preorder A] [OrderTop A] [Max A] (d : IMPAnalysisDomain A)
+variable {A : Type u} [Bot A] [Preorder A] [OrderTop A] [SemilatticeSup A] (d : IMPAnalysisDomain A)
 
 /-!
 # Generic IMP Analysis Lemmas

--- a/Examples/IMP/Analysis/Generic/Soundness.lean
+++ b/Examples/IMP/Analysis/Generic/Soundness.lean
@@ -14,7 +14,7 @@ open AbsInterp.Instances.LTS
 
 universe u
 
-variable {A : Type u} [Bot A] [Preorder A] [OrderTop A] [Max A] (d : IMPAnalysisDomain A)
+variable {A : Type u} [Bot A] [Preorder A] [OrderTop A] [SemilatticeSup A] (d : IMPAnalysisDomain A)
 
 /-!
 # Generic IMP Soundness Proof

--- a/Tests/Framework/Domains/GammaOnly.lean
+++ b/Tests/Framework/Domains/GammaOnly.lean
@@ -10,8 +10,8 @@ open AbsInterp.Domains
 
 /-! ## Smoke tests: the γ-only domain contract
 
-After the alignment with Mathlib `[Preorder] [OrderTop] [Max]`, `≤`, `⊤`,
-and `⊔` come from typeclass instances rather than domain fields.
+After the alignment with Mathlib `[Preorder] [OrderTop] [SemilatticeSup]`,
+`≤`, `⊤`, and `⊔` come from typeclass instances rather than domain fields.
 -/
 
 example :


### PR DESCRIPTION
## Summary

- Upgrade `GammaOnlyDomain` typeclass requirement from `[Max Abstract]` to `[SemilatticeSup Abstract]` (Option A).
- Promote `Sign` and `Parity` from `Preorder` to `PartialOrder` and add lawful `SemilatticeSup` instances (matches the Interval pattern already established by #101).
- Realign `joinSign_sound` / `joinParity_sound` statements with Mathlib's `⊔` notation.
- Refresh `GammaOnlyDomain` module + structure docstrings, plus tests header, to reflect the new typeclass shape.

## Linked issue

Closes #104
Supersedes #102 (original "align `joinX_sound` with `⊔` notation" scope is now the first commit of this upgrade)

## Scope

- Framework: `AbsInterp/Framework/Domains/GammaOnly.lean`
- Domains: `AbsInterp/Domains/Sign.lean`, `AbsInterp/Domains/Parity.lean`
- IMP layer: `Examples/IMP/Abstraction/Defs.lean`, `Examples/IMP/Analysis/Generic/{Domain,Defs,Lemmas,Soundness}.lean`
- Tests header: `Tests/Framework/Domains/GammaOnly.lean`

## Commits

1. `9411ac9` refactor(domains): align `joinSign_sound` and `joinParity_sound` with Mathlib `⊔` notation
2. `5bb2bb9` feat(domains): add SemilatticeSup instances to Sign and Parity
3. `be5b110` fix(domains): upgrade Sign and Parity to PartialOrder for lawful SemilatticeSup
4. `174fc7a` refactor(framework): upgrade GammaOnlyDomain from [Max] to [SemilatticeSup]
5. `06dc3a7` docs(framework): align Codex review — refresh [SemilatticeSup] docs, simplify Parity

## Validation

- `lake build` ✓
- `lake build Tests` ✓
- `lake test` (hygiene + lint-style included) ✓
- Codex reviewed (no blocking correctness bug; low-severity docstring/coherence notes applied in commit 5)
- No new axioms introduced (Tests/Axioms.lean unchanged)
- 0 sorries

## Review notes

- `Sign` keeps three private flag helpers (`hasNeg_of_leSign`, `hasZero_of_leSign`, `hasPos_of_leSign`) to bridge γ-level set inclusion and syntactic flag reasoning. Codex suggested a one-liner `cases a <;> cases b <;> simp [leSign, gammaSign] at ha hb hn ⊢`, but empirically `simp_all` needs the flag hypotheses to unfold the `signOfFlags` normalization on `joinSign` and to discharge the false-inclusion cases (e.g., `{0} ⊆ {n | n < 0}`). The helper-based proof is the minimal robust form.
- `Parity` uses a syntactic `leParity` order, so `joinParity_le_{left,right,of_le}` close with `cases a <;> cases b <;> simp [LE.le, leParity, joinParity]` (commit 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)