### PR TITLE
[codex] add layered domain capabilities

### DIFF
--- a/AbsInterp/Framework/Domains.lean
+++ b/AbsInterp/Framework/Domains.lean
@@ -1,3 +1,5 @@
 import AbsInterp.Framework.Domains.Concretization
+import AbsInterp.Framework.Domains.Capabilities
+import AbsInterp.Framework.Domains.Transfer
 import AbsInterp.Framework.Domains.Backward
 import AbsInterp.Framework.Domains.Interop.GaloisConnection

--- a/AbsInterp/Framework/Domains/Backward.lean
+++ b/AbsInterp/Framework/Domains/Backward.lean
@@ -84,6 +84,48 @@ def ReductiveBackwardOperator
   ∀ a₁ a₂ : Abstract,
     (backward a₁ a₂).1 ≤ a₁ ∧ (backward a₁ a₂).2 ≤ a₂
 
+/-- Bundled unary filter operator with soundness and reductiveness proofs. -/
+structure FilterOperator
+    (Abstract : Type u) [Preorder Abstract]
+    {Concrete : Type v}
+    (gamma : Concretization Abstract Concrete)
+    (P : Concrete → Prop) where
+  operator : Abstract → Abstract
+  sound : SoundFilter gamma P operator
+  reductive : ReductiveFilter operator
+
+instance
+    {Abstract : Type u} [Preorder Abstract]
+    {Concrete : Type v}
+    {gamma : Concretization Abstract Concrete}
+    {P : Concrete → Prop} :
+    CoeFun (FilterOperator Abstract (gamma := gamma) P)
+      (fun _ => Abstract → Abstract) where
+  coe filterOperator := filterOperator.operator
+
+/--
+Bundled binary backward operator with soundness and reductiveness proofs.
+
+This is the bundled capability form of `BackwardOperator`.
+-/
+structure RelationalBackwardOperator
+    (Abstract : Type u) [Preorder Abstract]
+    {Concrete : Type v}
+    (gamma : Concretization Abstract Concrete)
+    (rel : Concrete → Concrete → Prop) where
+  operator : BackwardOperator Abstract
+  sound : SoundBackwardOperator gamma rel operator
+  reductive : ReductiveBackwardOperator operator
+
+instance
+    {Abstract : Type u} [Preorder Abstract]
+    {Concrete : Type v}
+    {gamma : Concretization Abstract Concrete}
+    {rel : Concrete → Concrete → Prop} :
+    CoeFun (RelationalBackwardOperator Abstract (gamma := gamma) rel)
+      (fun _ => Abstract → Abstract → Abstract × Abstract) where
+  coe backwardOperator := backwardOperator.operator
+
 namespace ReductiveFilter
 
 /-- The identity filter is reductive. -/
@@ -93,6 +135,23 @@ theorem id
   fun _ => le_rfl
 
 end ReductiveFilter
+
+namespace FilterOperator
+
+/-- The identity filter operator is sound and reductive for any property. -/
+def id
+    {Abstract : Type u} [Preorder Abstract]
+    {Concrete : Type v}
+    {gamma : Concretization Abstract Concrete}
+    {P : Concrete → Prop} :
+    FilterOperator Abstract (gamma := gamma) P where
+  operator := fun a => a
+  sound := by
+    intro a c hc _
+    exact hc
+  reductive := ReductiveFilter.id
+
+end FilterOperator
 
 namespace SoundBackwardOperator
 
@@ -116,16 +175,30 @@ theorem id
 
 end ReductiveBackwardOperator
 
+namespace RelationalBackwardOperator
+
+/-- The identity backward operator bundle is sound and reductive. -/
+def id
+    {Abstract : Type u} [Preorder Abstract]
+    {Concrete : Type v}
+    {gamma : Concretization Abstract Concrete}
+    {rel : Concrete → Concrete → Prop} :
+    RelationalBackwardOperator Abstract (gamma := gamma) rel where
+  operator := fun a₁ a₂ => (a₁, a₂)
+  sound := SoundBackwardOperator.id
+  reductive := ReductiveBackwardOperator.id
+
+end RelationalBackwardOperator
+
 /-!
 ## Usage note
 
 These predicates are the canonical contract for unary filters and binary
 backward operators. `Examples/IMP/Analysis/Generic/Domain.lean` wires the
-`IMPAnalysisDomain` filter and backward-operator fields through
-`SoundFilter`, `ReductiveFilter`, `SoundBackwardOperator`, and
-`ReductiveBackwardOperator` directly. `SoundBackwardOperator.id` and
-`ReductiveBackwardOperator.id` are reused as defaults for domains (e.g.
-Parity, Interval) that do not override the binary backward operators.
+`IMPAnalysisDomain` filter and backward-operator fields through the bundled
+`FilterOperator` and `RelationalBackwardOperator` capabilities, whose proof
+fields are still expressed with `SoundFilter`, `ReductiveFilter`,
+`SoundBackwardOperator`, and `ReductiveBackwardOperator`.
 -/
 
 end Domains

--- a/AbsInterp/Framework/Domains/Capabilities.lean
+++ b/AbsInterp/Framework/Domains/Capabilities.lean
@@ -1,0 +1,70 @@
+import Mathlib.Data.Set.Defs
+import Mathlib.Order.Basic
+
+import AbsInterp.Framework.Concretization
+
+namespace AbsInterp
+namespace Framework
+namespace Domains
+
+universe u v
+
+/-!
+# Domain Capabilities
+
+Small reusable capabilities that sit above the semantic `ConcretizationDomain`
+kernel and below language-specific analysis adapters.
+
+These structures intentionally avoid forcing full lattice structure. They encode
+the minimum contracts needed by consumers such as generic IMP analyses.
+-/
+
+/-- A bottom element whose concretization is empty. -/
+structure BottomConcretization
+    (Abstract : Type u) [Bot Abstract]
+    {Concrete : Type v}
+    (gamma : Concretization Abstract Concrete) where
+  gamma_bot : gamma ⊥ = ∅
+
+/-- Point abstraction of concrete values into the abstract domain. -/
+structure PointAbstraction
+    (Abstract : Type u)
+    {Concrete : Type v}
+    (gamma : Concretization Abstract Concrete) where
+  point : Concrete → Abstract
+  sound : ∀ c : Concrete, c ∈ gamma (point c)
+
+instance
+    {Abstract : Type u}
+    {Concrete : Type v}
+    {gamma : Concretization Abstract Concrete} :
+    CoeFun (PointAbstraction Abstract (gamma := gamma))
+      (fun _ => Concrete → Abstract) where
+  coe pointAbstraction := pointAbstraction.point
+
+/--
+A meet-like combinator that preserves common concrete witnesses and is
+reductive in both arguments.
+
+This is intentionally weaker than requiring a `SemilatticeInf`.
+-/
+structure MeetLike
+    (Abstract : Type u) [Preorder Abstract]
+    {Concrete : Type v}
+    (gamma : Concretization Abstract Concrete) where
+  meetLike : Abstract → Abstract → Abstract
+  sound : ∀ {a₁ a₂ : Abstract} {c : Concrete},
+    c ∈ gamma a₁ → c ∈ gamma a₂ → c ∈ gamma (meetLike a₁ a₂)
+  reductive : ∀ a₁ a₂ : Abstract, meetLike a₁ a₂ ≤ a₁ ∧ meetLike a₁ a₂ ≤ a₂
+
+instance
+    {Abstract : Type u} [Preorder Abstract]
+    {Concrete : Type v}
+    {gamma : Concretization Abstract Concrete} :
+    CoeFun (MeetLike Abstract (gamma := gamma))
+      (fun _ => Abstract → Abstract → Abstract) where
+  coe meetLike := meetLike.meetLike
+
+end Domains
+end Framework
+end AbsInterp

--- a/AbsInterp/Framework/Domains/Capabilities.lean
+++ b/AbsInterp/Framework/Domains/Capabilities.lean
@@ -48,14 +48,26 @@ reductive in both arguments.
 
 This is intentionally weaker than requiring a `SemilatticeInf`.
 -/
+def SoundMeetLike
+    {Abstract : Type u} {Concrete : Type v}
+    (gamma : Concretization Abstract Concrete)
+    (meetLike : Abstract → Abstract → Abstract) : Prop :=
+  ∀ {a₁ a₂ : Abstract} {c : Concrete},
+    c ∈ gamma a₁ → c ∈ gamma a₂ → c ∈ gamma (meetLike a₁ a₂)
+
+/-- A meet-like operator is reductive when it stays below both inputs. -/
+def ReductiveMeetLike
+    {Abstract : Type u} [Preorder Abstract]
+    (meetLike : Abstract → Abstract → Abstract) : Prop :=
+  ∀ a₁ a₂ : Abstract, meetLike a₁ a₂ ≤ a₁ ∧ meetLike a₁ a₂ ≤ a₂
+
 structure MeetLike
     (Abstract : Type u) [Preorder Abstract]
     {Concrete : Type v}
     (gamma : Concretization Abstract Concrete) where
   meetLike : Abstract → Abstract → Abstract
-  sound : ∀ {a₁ a₂ : Abstract} {c : Concrete},
-    c ∈ gamma a₁ → c ∈ gamma a₂ → c ∈ gamma (meetLike a₁ a₂)
-  reductive : ∀ a₁ a₂ : Abstract, meetLike a₁ a₂ ≤ a₁ ∧ meetLike a₁ a₂ ≤ a₂
+  sound : SoundMeetLike gamma meetLike
+  reductive : ReductiveMeetLike meetLike
 
 instance
     {Abstract : Type u} [Preorder Abstract]

--- a/AbsInterp/Framework/Domains/Transfer.lean
+++ b/AbsInterp/Framework/Domains/Transfer.lean
@@ -1,0 +1,71 @@
+import Mathlib.Order.Basic
+
+import AbsInterp.Framework.Concretization
+
+namespace AbsInterp
+namespace Framework
+namespace Domains
+
+universe u v
+
+/-!
+# Transfer Capabilities
+
+Bundled abstract transformers and generic monotonicity predicates. These sit
+between the semantic kernel and language-specific analysis adapters.
+-/
+
+/-- Bundled sound unary transfer for a concrete operation `op`. -/
+structure UnaryTransfer
+    (Abstract : Type u)
+    {Concrete : Type v}
+    (gamma : Concretization Abstract Concrete)
+    (op : Concrete → Concrete) where
+  transfer : Abstract → Abstract
+  sound : ∀ {a : Abstract} {c : Concrete},
+    c ∈ gamma a → op c ∈ gamma (transfer a)
+
+instance
+    {Abstract : Type u}
+    {Concrete : Type v}
+    {gamma : Concretization Abstract Concrete}
+    {op : Concrete → Concrete} :
+    CoeFun (UnaryTransfer Abstract (gamma := gamma) op)
+      (fun _ => Abstract → Abstract) where
+  coe transfer := transfer.transfer
+
+/-- Bundled sound binary transfer for a concrete operation `op`. -/
+structure BinaryTransfer
+    (Abstract : Type u)
+    {Concrete : Type v}
+    (gamma : Concretization Abstract Concrete)
+    (op : Concrete → Concrete → Concrete) where
+  transfer : Abstract → Abstract → Abstract
+  sound : ∀ {a₁ a₂ : Abstract} {c₁ c₂ : Concrete},
+    c₁ ∈ gamma a₁ → c₂ ∈ gamma a₂ → op c₁ c₂ ∈ gamma (transfer a₁ a₂)
+
+instance
+    {Abstract : Type u}
+    {Concrete : Type v}
+    {gamma : Concretization Abstract Concrete}
+    {op : Concrete → Concrete → Concrete} :
+    CoeFun (BinaryTransfer Abstract (gamma := gamma) op)
+      (fun _ => Abstract → Abstract → Abstract) where
+  coe transfer := transfer.transfer
+
+/-- Monotonicity of a unary abstract transformer. -/
+def MonotoneUnaryTransfer
+    {Abstract : Type u} [Preorder Abstract]
+    (transfer : Abstract → Abstract) : Prop :=
+  ∀ {a b : Abstract}, a ≤ b → transfer a ≤ transfer b
+
+/-- Monotonicity of a binary abstract transformer in both arguments. -/
+def MonotoneBinaryTransfer
+    {Abstract : Type u} [Preorder Abstract]
+    (transfer : Abstract → Abstract → Abstract) : Prop :=
+  ∀ {a₁ b₁ a₂ b₂ : Abstract},
+    a₁ ≤ b₁ → a₂ ≤ b₂ → transfer a₁ a₂ ≤ transfer b₁ b₂
+
+end Domains
+end Framework
+end AbsInterp

--- a/AbsInterp/Framework/Domains/Transfer.lean
+++ b/AbsInterp/Framework/Domains/Transfer.lean
@@ -15,6 +15,15 @@ Bundled abstract transformers and generic monotonicity predicates. These sit
 between the semantic kernel and language-specific analysis adapters.
 -/
 
+/-- Soundness of a unary abstract transfer for a concrete operation `op`. -/
+def SoundUnaryTransfer
+    {Abstract : Type u} {Concrete : Type v}
+    (gamma : Concretization Abstract Concrete)
+    (op : Concrete → Concrete)
+    (transfer : Abstract → Abstract) : Prop :=
+  ∀ {a : Abstract} {c : Concrete},
+    c ∈ gamma a → op c ∈ gamma (transfer a)
+
 /-- Bundled sound unary transfer for a concrete operation `op`. -/
 structure UnaryTransfer
     (Abstract : Type u)
@@ -22,8 +31,7 @@ structure UnaryTransfer
     (gamma : Concretization Abstract Concrete)
     (op : Concrete → Concrete) where
   transfer : Abstract → Abstract
-  sound : ∀ {a : Abstract} {c : Concrete},
-    c ∈ gamma a → op c ∈ gamma (transfer a)
+  sound : SoundUnaryTransfer gamma op transfer
 
 instance
     {Abstract : Type u}
@@ -34,6 +42,15 @@ instance
       (fun _ => Abstract → Abstract) where
   coe transfer := transfer.transfer
 
+/-- Soundness of a binary abstract transfer for a concrete operation `op`. -/
+def SoundBinaryTransfer
+    {Abstract : Type u} {Concrete : Type v}
+    (gamma : Concretization Abstract Concrete)
+    (op : Concrete → Concrete → Concrete)
+    (transfer : Abstract → Abstract → Abstract) : Prop :=
+  ∀ {a₁ a₂ : Abstract} {c₁ c₂ : Concrete},
+    c₁ ∈ gamma a₁ → c₂ ∈ gamma a₂ → op c₁ c₂ ∈ gamma (transfer a₁ a₂)
+
 /-- Bundled sound binary transfer for a concrete operation `op`. -/
 structure BinaryTransfer
     (Abstract : Type u)
@@ -41,8 +58,7 @@ structure BinaryTransfer
     (gamma : Concretization Abstract Concrete)
     (op : Concrete → Concrete → Concrete) where
   transfer : Abstract → Abstract → Abstract
-  sound : ∀ {a₁ a₂ : Abstract} {c₁ c₂ : Concrete},
-    c₁ ∈ gamma a₁ → c₂ ∈ gamma a₂ → op c₁ c₂ ∈ gamma (transfer a₁ a₂)
+  sound : SoundBinaryTransfer gamma op transfer
 
 instance
     {Abstract : Type u}

--- a/Examples/IMP/Analysis/Generic/Domain.lean
+++ b/Examples/IMP/Analysis/Generic/Domain.lean
@@ -18,87 +18,125 @@ abstract analysis, so that transfer functions and soundness proofs can be
 written once generically.
 
 The interface sits between the scalar abstract domain (`ConcretizationDomain A Int`)
-and the IMP-specific analysis machinery. A concrete instance must supply:
+and the IMP-specific analysis machinery by bundling reusable framework
+capabilities:
 
-- scalar expression evaluation primitives (`const`, `addTransfer`) with
-  soundness,
-- a scalar intersection operator used to combine same-variable backward refinements,
-- branch filter operators (`filterNonzero`, `filterZero`) with soundness,
-- a proof that the bottom element has empty concretization.
+- bottom soundness,
+- point abstraction of integer literals,
+- sound addition transfer,
+- a meet-like combinator used to combine same-variable backward refinements,
+- branch filter operators,
+- relational backward operators for addition tests.
 -/
 
 /--
 Domain-specific obligations for a generic IMP abstract analysis.
 
 An instance packages a scalar `ConcretizationDomain` together with the transfer
-primitives and soundness contracts needed by the generic IMP transfer function
-and its soundness proof.
+capabilities needed by the generic IMP transfer function and its soundness
+proof.
 -/
 structure IMPAnalysisDomain
     (A : Type u) [Bot A] [SemilatticeSup A] [OrderTop A] where
   /-- The underlying scalar concretization domain over integers. -/
   scalarDomain : ConcretizationDomain A Int
   /-- The bottom element has empty concretization. -/
-  gamma_bot : scalarDomain.gamma ⊥ = ∅
-  /-- Abstract a concrete integer constant. -/
-  const : Int → A
-  /-- Constant abstraction is sound. -/
-  const_sound : ∀ n : Int, n ∈ scalarDomain.gamma (const n)
-  /-- Abstract addition transfer. -/
-  addTransfer : A → A → A
-  /-- Addition transfer is sound. -/
-  addTransfer_sound : ∀ {a₁ a₂ : A} {v₁ v₂ : Int},
-    v₁ ∈ scalarDomain.gamma a₁ → v₂ ∈ scalarDomain.gamma a₂ →
-    v₁ + v₂ ∈ scalarDomain.gamma (addTransfer a₁ a₂)
+  bottom : BottomConcretization A scalarDomain.gamma
+  /-- Point abstraction for integer literals. -/
+  const : PointAbstraction A scalarDomain.gamma
+  /-- Addition transfer. -/
+  addTransfer : BinaryTransfer A scalarDomain.gamma (· + ·)
   /-- Combine two scalar refinements for the same concrete value. -/
-  intersect : A → A → A
-  /-- Intersection is sound for concrete values that belong to both inputs. -/
-  intersect_sound : ∀ {a₁ a₂ : A} {v : Int},
-    v ∈ scalarDomain.gamma a₁ → v ∈ scalarDomain.gamma a₂ →
-    v ∈ scalarDomain.gamma (intersect a₁ a₂)
-  /-- Intersection is reductive in both arguments. -/
-  intersect_reductive : ∀ a₁ a₂ : A, intersect a₁ a₂ ≤ a₁ ∧ intersect a₁ a₂ ≤ a₂
+  intersect : MeetLike A scalarDomain.gamma
   /-- Filter an abstract value under a nonzero assumption. -/
-  filterNonzero : A → A
-  /-- Nonzero filtering is sound (`SoundFilter` with `P := (· ≠ 0)`). -/
-  filterNonzero_sound :
-    SoundFilter scalarDomain.gamma (· ≠ 0) filterNonzero
-  /-- Nonzero filtering does not enlarge the abstract value. -/
-  filterNonzero_reductive :
-    ReductiveFilter filterNonzero
+  filterNonzero : FilterOperator A scalarDomain.gamma (· ≠ 0)
   /-- Filter an abstract value under a zero assumption. -/
-  filterZero : A → A
-  /-- Zero filtering is sound (`SoundFilter` with `P := (· = 0)`). -/
-  filterZero_sound :
-    SoundFilter scalarDomain.gamma (· = 0) filterZero
-  /-- Zero filtering does not enlarge the abstract value. -/
-  filterZero_reductive :
-    ReductiveFilter filterZero
+  filterZero : FilterOperator A scalarDomain.gamma (· = 0)
   /-- Backward operator for addition under nonzero constraint.
       Given `v₁ ∈ γ(a₁)`, `v₂ ∈ γ(a₂)`, and `v₁ + v₂ ≠ 0`, refine both. -/
-  backwardAddNonzero : BackwardOperator A := fun a₁ a₂ => (a₁, a₂)
-  /-- Nonzero-add backward operator is sound. -/
-  backwardAddNonzero_sound :
-    SoundBackwardOperator scalarDomain.gamma
-      (fun v₁ v₂ => v₁ + v₂ ≠ 0) backwardAddNonzero
-  /-- Nonzero-add backward operator is reductive. -/
-  backwardAddNonzero_reductive :
-    ReductiveBackwardOperator backwardAddNonzero
+  backwardAddNonzero :
+    RelationalBackwardOperator A scalarDomain.gamma
+      (fun v₁ v₂ => v₁ + v₂ ≠ 0)
   /-- Backward operator for addition under zero constraint.
       Given `v₁ ∈ γ(a₁)`, `v₂ ∈ γ(a₂)`, and `v₁ + v₂ = 0`, refine both. -/
-  backwardAddZero : BackwardOperator A := fun a₁ a₂ => (a₁, a₂)
-  /-- Zero-add backward operator is sound. -/
-  backwardAddZero_sound :
-    SoundBackwardOperator scalarDomain.gamma
-      (fun v₁ v₂ => v₁ + v₂ = 0) backwardAddZero
-  /-- Zero-add backward operator is reductive. -/
-  backwardAddZero_reductive :
-    ReductiveBackwardOperator backwardAddZero
+  backwardAddZero :
+    RelationalBackwardOperator A scalarDomain.gamma
+      (fun v₁ v₂ => v₁ + v₂ = 0)
 
 namespace IMPAnalysisDomain
 
 variable {A : Type u} [Bot A] [SemilatticeSup A] [OrderTop A]
 variable (d : IMPAnalysisDomain A)
+
+/-- Bottom soundness accessor. -/
+theorem gamma_bot : d.scalarDomain.gamma ⊥ = ∅ :=
+  d.bottom.gamma_bot
+
+/-- Constant abstraction soundness accessor. -/
+theorem const_sound (n : Int) :
+    n ∈ d.scalarDomain.gamma (d.const n) :=
+  d.const.sound n
+
+/-- Addition-transfer soundness accessor. -/
+theorem addTransfer_sound
+    {a₁ a₂ : A} {v₁ v₂ : Int} :
+    v₁ ∈ d.scalarDomain.gamma a₁ → v₂ ∈ d.scalarDomain.gamma a₂ →
+    v₁ + v₂ ∈ d.scalarDomain.gamma (d.addTransfer a₁ a₂) :=
+  d.addTransfer.sound
+
+/-- Meet-like soundness accessor. -/
+theorem intersect_sound
+    {a₁ a₂ : A} {v : Int} :
+    v ∈ d.scalarDomain.gamma a₁ → v ∈ d.scalarDomain.gamma a₂ →
+    v ∈ d.scalarDomain.gamma (d.intersect a₁ a₂) :=
+  d.intersect.sound
+
+/-- Meet-like reductiveness accessor. -/
+theorem intersect_reductive (a₁ a₂ : A) :
+    d.intersect a₁ a₂ ≤ a₁ ∧ d.intersect a₁ a₂ ≤ a₂ :=
+  d.intersect.reductive a₁ a₂
+
+/-- Nonzero-filter soundness accessor. -/
+theorem filterNonzero_sound :
+    SoundFilter d.scalarDomain.gamma (· ≠ 0) d.filterNonzero :=
+  d.filterNonzero.sound
+
+/-- Nonzero-filter reductiveness accessor. -/
+theorem filterNonzero_reductive :
+    ReductiveFilter d.filterNonzero :=
+  d.filterNonzero.reductive
+
+/-- Zero-filter soundness accessor. -/
+theorem filterZero_sound :
+    SoundFilter d.scalarDomain.gamma (· = 0) d.filterZero :=
+  d.filterZero.sound
+
+/-- Zero-filter reductiveness accessor. -/
+theorem filterZero_reductive :
+    ReductiveFilter d.filterZero :=
+  d.filterZero.reductive
+
+/-- Nonzero-add backward-operator soundness accessor. -/
+theorem backwardAddNonzero_sound :
+    SoundBackwardOperator d.scalarDomain.gamma
+      (fun v₁ v₂ => v₁ + v₂ ≠ 0) d.backwardAddNonzero :=
+  d.backwardAddNonzero.sound
+
+/-- Nonzero-add backward-operator reductiveness accessor. -/
+theorem backwardAddNonzero_reductive :
+    ReductiveBackwardOperator d.backwardAddNonzero :=
+  d.backwardAddNonzero.reductive
+
+/-- Zero-add backward-operator soundness accessor. -/
+theorem backwardAddZero_sound :
+    SoundBackwardOperator d.scalarDomain.gamma
+      (fun v₁ v₂ => v₁ + v₂ = 0) d.backwardAddZero :=
+  d.backwardAddZero.sound
+
+/-- Zero-add backward-operator reductiveness accessor. -/
+theorem backwardAddZero_reductive :
+    ReductiveBackwardOperator d.backwardAddZero :=
+  d.backwardAddZero.reductive
 
 /-- Convenience accessor for the scalar concretization function. -/
 abbrev gamma : A → Set Int := d.scalarDomain.gamma

--- a/Examples/IMP/Analysis/Generic/Domain.lean
+++ b/Examples/IMP/Analysis/Generic/Domain.lean
@@ -56,12 +56,18 @@ structure IMPAnalysisDomain
       Given `v₁ ∈ γ(a₁)`, `v₂ ∈ γ(a₂)`, and `v₁ + v₂ ≠ 0`, refine both. -/
   backwardAddNonzero :
     RelationalBackwardOperator A scalarDomain.gamma
-      (fun v₁ v₂ => v₁ + v₂ ≠ 0)
+      (fun v₁ v₂ => v₁ + v₂ ≠ 0) :=
+    RelationalBackwardOperator.id
+      (gamma := scalarDomain.gamma)
+      (rel := fun v₁ v₂ => v₁ + v₂ ≠ 0)
   /-- Backward operator for addition under zero constraint.
       Given `v₁ ∈ γ(a₁)`, `v₂ ∈ γ(a₂)`, and `v₁ + v₂ = 0`, refine both. -/
   backwardAddZero :
     RelationalBackwardOperator A scalarDomain.gamma
-      (fun v₁ v₂ => v₁ + v₂ = 0)
+      (fun v₁ v₂ => v₁ + v₂ = 0) :=
+    RelationalBackwardOperator.id
+      (gamma := scalarDomain.gamma)
+      (rel := fun v₁ v₂ => v₁ + v₂ = 0)
 
 namespace IMPAnalysisDomain
 
@@ -78,23 +84,19 @@ theorem const_sound (n : Int) :
   d.const.sound n
 
 /-- Addition-transfer soundness accessor. -/
-theorem addTransfer_sound
-    {a₁ a₂ : A} {v₁ v₂ : Int} :
-    v₁ ∈ d.scalarDomain.gamma a₁ → v₂ ∈ d.scalarDomain.gamma a₂ →
-    v₁ + v₂ ∈ d.scalarDomain.gamma (d.addTransfer a₁ a₂) :=
+theorem addTransfer_sound :
+    SoundBinaryTransfer d.scalarDomain.gamma (· + ·) d.addTransfer :=
   d.addTransfer.sound
 
 /-- Meet-like soundness accessor. -/
-theorem intersect_sound
-    {a₁ a₂ : A} {v : Int} :
-    v ∈ d.scalarDomain.gamma a₁ → v ∈ d.scalarDomain.gamma a₂ →
-    v ∈ d.scalarDomain.gamma (d.intersect a₁ a₂) :=
+theorem intersect_sound :
+    SoundMeetLike d.scalarDomain.gamma d.intersect :=
   d.intersect.sound
 
 /-- Meet-like reductiveness accessor. -/
-theorem intersect_reductive (a₁ a₂ : A) :
-    d.intersect a₁ a₂ ≤ a₁ ∧ d.intersect a₁ a₂ ≤ a₂ :=
-  d.intersect.reductive a₁ a₂
+theorem intersect_reductive :
+    ReductiveMeetLike d.intersect :=
+  d.intersect.reductive
 
 /-- Nonzero-filter soundness accessor. -/
 theorem filterNonzero_sound :

--- a/Examples/IMP/Analysis/Interval/Defs.lean
+++ b/Examples/IMP/Analysis/Interval/Defs.lean
@@ -35,12 +35,6 @@ def intervalAnalysisDomain : IMPAnalysisDomain Interval where
     sound := filterZeroInterval_sound
     reductive := filterZeroInterval_reductive
   }
-  backwardAddNonzero :=
-    RelationalBackwardOperator.id (gamma := intervalConcretizationDomain.gamma)
-      (rel := fun v₁ v₂ => v₁ + v₂ ≠ 0)
-  backwardAddZero :=
-    RelationalBackwardOperator.id (gamma := intervalConcretizationDomain.gamma)
-      (rel := fun v₁ v₂ => v₁ + v₂ = 0)
 
 -- Public API wrappers.
 

--- a/Examples/IMP/Analysis/Interval/Defs.lean
+++ b/Examples/IMP/Analysis/Interval/Defs.lean
@@ -21,28 +21,26 @@ All transfer functions and soundness proofs are inherited from `Generic/`.
 /-- IMP analysis domain instance for Interval. -/
 def intervalAnalysisDomain : IMPAnalysisDomain Interval where
   scalarDomain := intervalConcretizationDomain
-  gamma_bot := rfl
-  const := constInterval
-  const_sound := constInterval_sound
-  addTransfer := addIntervalTransfer
-  addTransfer_sound := addIntervalTransfer_sound
-  intersect := meetInterval
-  intersect_sound := meetInterval_sound
-  intersect_reductive := meetInterval_reductive
-  filterNonzero := filterNonzeroInterval
-  filterNonzero_sound := filterNonzeroInterval_sound
-  filterNonzero_reductive := filterNonzeroInterval_reductive
-  filterZero := filterZeroInterval
-  filterZero_sound := filterZeroInterval_sound
-  filterZero_reductive := filterZeroInterval_reductive
-  backwardAddNonzero_sound :=
-    SoundBackwardOperator.id (gamma := intervalConcretizationDomain.gamma)
+  bottom := { gamma_bot := rfl }
+  const := { point := constInterval, sound := constInterval_sound }
+  addTransfer := { transfer := addIntervalTransfer, sound := addIntervalTransfer_sound }
+  intersect := { meetLike := meetInterval, sound := meetInterval_sound, reductive := meetInterval_reductive }
+  filterNonzero := {
+    operator := filterNonzeroInterval
+    sound := filterNonzeroInterval_sound
+    reductive := filterNonzeroInterval_reductive
+  }
+  filterZero := {
+    operator := filterZeroInterval
+    sound := filterZeroInterval_sound
+    reductive := filterZeroInterval_reductive
+  }
+  backwardAddNonzero :=
+    RelationalBackwardOperator.id (gamma := intervalConcretizationDomain.gamma)
       (rel := fun v₁ v₂ => v₁ + v₂ ≠ 0)
-  backwardAddNonzero_reductive := ReductiveBackwardOperator.id
-  backwardAddZero_sound :=
-    SoundBackwardOperator.id (gamma := intervalConcretizationDomain.gamma)
+  backwardAddZero :=
+    RelationalBackwardOperator.id (gamma := intervalConcretizationDomain.gamma)
       (rel := fun v₁ v₂ => v₁ + v₂ = 0)
-  backwardAddZero_reductive := ReductiveBackwardOperator.id
 
 -- Public API wrappers.
 

--- a/Examples/IMP/Analysis/Parity/Defs.lean
+++ b/Examples/IMP/Analysis/Parity/Defs.lean
@@ -35,12 +35,6 @@ def parityAnalysisDomain : IMPAnalysisDomain Parity where
     sound := filterZeroParity_sound
     reductive := filterZeroParity_reductive
   }
-  backwardAddNonzero :=
-    RelationalBackwardOperator.id (gamma := parityConcretizationDomain.gamma)
-      (rel := fun v₁ v₂ => v₁ + v₂ ≠ 0)
-  backwardAddZero :=
-    RelationalBackwardOperator.id (gamma := parityConcretizationDomain.gamma)
-      (rel := fun v₁ v₂ => v₁ + v₂ = 0)
 
 /-- The generic Parity concretization for a fixed IMP program. -/
 def gammaProgramParity (program : Stmt) : Framework.Concretization (ConfigSharp Parity) Config :=

--- a/Examples/IMP/Analysis/Parity/Defs.lean
+++ b/Examples/IMP/Analysis/Parity/Defs.lean
@@ -21,28 +21,26 @@ Validates that adding a new domain to the generic framework requires minimal cod
 /-- IMP analysis domain instance for Parity. -/
 def parityAnalysisDomain : IMPAnalysisDomain Parity where
   scalarDomain := parityConcretizationDomain
-  gamma_bot := rfl
-  const := constParity
-  const_sound := constParity_sound
-  addTransfer := addParityTransfer
-  addTransfer_sound := addParityTransfer_sound
-  intersect := intersectParity
-  intersect_sound := intersectParity_sound
-  intersect_reductive := intersectParity_reductive
-  filterNonzero := filterNonzeroParity
-  filterNonzero_sound := filterNonzeroParity_sound
-  filterNonzero_reductive := filterNonzeroParity_reductive
-  filterZero := filterZeroParity
-  filterZero_sound := filterZeroParity_sound
-  filterZero_reductive := filterZeroParity_reductive
-  backwardAddNonzero_sound :=
-    SoundBackwardOperator.id (gamma := parityConcretizationDomain.gamma)
+  bottom := { gamma_bot := rfl }
+  const := { point := constParity, sound := constParity_sound }
+  addTransfer := { transfer := addParityTransfer, sound := addParityTransfer_sound }
+  intersect := { meetLike := intersectParity, sound := intersectParity_sound, reductive := intersectParity_reductive }
+  filterNonzero := {
+    operator := filterNonzeroParity
+    sound := filterNonzeroParity_sound
+    reductive := filterNonzeroParity_reductive
+  }
+  filterZero := {
+    operator := filterZeroParity
+    sound := filterZeroParity_sound
+    reductive := filterZeroParity_reductive
+  }
+  backwardAddNonzero :=
+    RelationalBackwardOperator.id (gamma := parityConcretizationDomain.gamma)
       (rel := fun v₁ v₂ => v₁ + v₂ ≠ 0)
-  backwardAddNonzero_reductive := ReductiveBackwardOperator.id
-  backwardAddZero_sound :=
-    SoundBackwardOperator.id (gamma := parityConcretizationDomain.gamma)
+  backwardAddZero :=
+    RelationalBackwardOperator.id (gamma := parityConcretizationDomain.gamma)
       (rel := fun v₁ v₂ => v₁ + v₂ = 0)
-  backwardAddZero_reductive := ReductiveBackwardOperator.id
 
 /-- The generic Parity concretization for a fixed IMP program. -/
 def gammaProgramParity (program : Stmt) : Framework.Concretization (ConfigSharp Parity) Config :=

--- a/Examples/IMP/Analysis/Sign/Defs.lean
+++ b/Examples/IMP/Analysis/Sign/Defs.lean
@@ -21,26 +21,30 @@ All transfer functions and soundness proofs are inherited from `Generic/`.
 /-- IMP analysis domain instance for Sign. -/
 def signAnalysisDomain : IMPAnalysisDomain Sign where
   scalarDomain := signConcretizationDomain
-  gamma_bot := rfl
-  const := constSign
-  const_sound := constSign_sound
-  addTransfer := addTransfer
-  addTransfer_sound := addTransfer_sound
-  intersect := meetSign
-  intersect_sound := meetSign_sound
-  intersect_reductive := meetSign_reductive
-  filterNonzero := filterNonzeroSign
-  filterNonzero_sound := filterNonzeroSign_sound
-  filterNonzero_reductive := filterNonzeroSign_reductive
-  filterZero := filterZeroSign
-  filterZero_sound := filterZeroSign_sound
-  filterZero_reductive := filterZeroSign_reductive
-  backwardAddNonzero := backwardAddNonzeroSign
-  backwardAddNonzero_sound := backwardAddNonzeroSign_sound
-  backwardAddNonzero_reductive := backwardAddNonzeroSign_reductive
-  backwardAddZero := backwardAddZeroSign
-  backwardAddZero_sound := backwardAddZeroSign_sound
-  backwardAddZero_reductive := backwardAddZeroSign_reductive
+  bottom := { gamma_bot := rfl }
+  const := { point := constSign, sound := constSign_sound }
+  addTransfer := { transfer := addTransfer, sound := addTransfer_sound }
+  intersect := { meetLike := meetSign, sound := meetSign_sound, reductive := meetSign_reductive }
+  filterNonzero := {
+    operator := filterNonzeroSign
+    sound := filterNonzeroSign_sound
+    reductive := filterNonzeroSign_reductive
+  }
+  filterZero := {
+    operator := filterZeroSign
+    sound := filterZeroSign_sound
+    reductive := filterZeroSign_reductive
+  }
+  backwardAddNonzero := {
+    operator := backwardAddNonzeroSign
+    sound := backwardAddNonzeroSign_sound
+    reductive := backwardAddNonzeroSign_reductive
+  }
+  backwardAddZero := {
+    operator := backwardAddZeroSign
+    sound := backwardAddZeroSign_sound
+    reductive := backwardAddZeroSign_reductive
+  }
 
 -- Public API wrappers.
 

--- a/Tests.lean
+++ b/Tests.lean
@@ -6,6 +6,7 @@ import Tests.Domains.Parity
 import Tests.Domains.Sign
 import Tests.Examples.IMP.Smoke
 import Tests.Examples.IMP.ParitySmoke
+import Tests.Framework.Domains.Capabilities
 import Tests.Framework.Domains.Concretization
 import Tests.Instances.LTS.Smoke
 import Tests.Instances.LTS.Collecting

--- a/Tests/Framework/Domains/Capabilities.lean
+++ b/Tests/Framework/Domains/Capabilities.lean
@@ -1,0 +1,50 @@
+import Cslib.Init
+
+import AbsInterp
+import Examples.IMP.Analysis
+
+namespace Tests
+namespace FrameworkDomainsCapabilities
+
+open AbsInterp
+open AbsInterp.Domains
+open AbsInterp.Framework.Domains
+open Examples.IMP
+
+/-! ## Smoke tests: reusable domain capabilities -/
+
+example :
+    signAnalysisDomain.scalarDomain.gamma (⊥ : Sign) = ∅ := by
+  simpa using signAnalysisDomain.gamma_bot
+
+example :
+    (0 : Int) ∈ signAnalysisDomain.scalarDomain.gamma (signAnalysisDomain.const 0) := by
+  simpa using signAnalysisDomain.const_sound 0
+
+example :
+    (0 : Int) ∈
+      signAnalysisDomain.scalarDomain.gamma
+        (signAnalysisDomain.intersect Sign.nonneg Sign.nonpos) := by
+  exact signAnalysisDomain.intersect_sound
+    (by
+      change (0 : Int) ∈ gammaSign Sign.nonneg
+      simp [gammaSign])
+    (by
+      change (0 : Int) ∈ gammaSign Sign.nonpos
+      simp [gammaSign])
+
+example :
+    (FilterOperator.id (Abstract := Sign)
+      (gamma := signConcretizationDomain.gamma)
+      (P := fun n : Int => n ≠ 0)) Sign.zero = Sign.zero := by
+  rfl
+
+example :
+    (RelationalBackwardOperator.id (Abstract := Parity)
+      (gamma := parityConcretizationDomain.gamma)
+      (rel := fun v₁ v₂ : Int => v₁ + v₂ = 0)) Parity.even Parity.odd =
+      (Parity.even, Parity.odd) := by
+  rfl
+
+end FrameworkDomainsCapabilities
+end Tests


### PR DESCRIPTION
## Summary
This PR adds a reusable capability layer above `ConcretizationDomain` and refactors the generic IMP adapter to consume those capabilities instead of carrying one large proof bundle.

## What changed
- added framework capability modules for:
  - `BottomConcretization`
  - `PointAbstraction`
  - `MeetLike`
  - `UnaryTransfer` / `BinaryTransfer`
  - bundled `FilterOperator` / `RelationalBackwardOperator`
- kept `ConcretizationDomain` as the semantic kernel and exported the new capability layer through `AbsInterp.Framework.Domains`
- refactored `IMPAnalysisDomain` so it is now an adapter bundle built from those reusable capabilities
- preserved convenient accessor theorems so the generic IMP transfer/soundness code stays readable
- updated Sign, Interval, and Parity IMP adapters to construct the new capability bundles
- added framework smoke tests for the new capability layer

## Why
The current `ConcretizationDomain + filter/backward operator + IMPAnalysisDomain` design already has a good semantic kernel, but `IMPAnalysisDomain` was still carrying language-specific proof fields directly. This PR makes the layering more library-friendly:
- semantic kernel stays small
- domain/transfer capabilities become reusable across languages
- IMP remains an adapter layer rather than the shape of the public framework API

## Impact
- Session 1 now has an explicit capability layer above the concretization kernel
- IMP generic analysis is less monolithic and closer to the intended CSLib layering
- future language adapters can reuse the same capability bundles instead of cloning IMP-specific field structure

## Validation
- `lake build`
- `lake test`