### PR TITLE
[codex] clean up Session 3 domain layering

### DIFF
--- a/AbsInterp/Domains.lean
+++ b/AbsInterp/Domains.lean
@@ -2,4 +2,5 @@ import Cslib.Init
 
 import AbsInterp.Domains.Sign
 import AbsInterp.Domains.Interval
+import AbsInterp.Domains.Interval.Widening
 import AbsInterp.Domains.Parity

--- a/AbsInterp/Domains/Interval.lean
+++ b/AbsInterp/Domains/Interval.lean
@@ -1,6 +1,5 @@
 import Cslib.Init
 import AbsInterp.Framework.Domains
-import AbsInterp.Framework.Iteration.Widening.Defs
 
 namespace AbsInterp
 namespace Domains
@@ -146,8 +145,6 @@ def joinInterval (a b : Interval) : Interval :=
   | .range lo1 hi1 h1, .range lo2 hi2 h2 =>
       .range (min lo1 lo2) (max hi1 hi2) (by omega)
 
-instance : Max Interval := ⟨joinInterval⟩
-
 theorem joinInterval_le_left (a b : Interval) : leInterval a (joinInterval a b) := by
   intro n hn
   cases a with
@@ -231,14 +228,6 @@ instance : SemilatticeSup Interval where
   le_sup_left := joinInterval_le_left
   le_sup_right := joinInterval_le_right
   sup_le _ _ _ ha hb := joinInterval_le_of_le ha hb
-
-/-- `joinInterval` soundly over-approximates union concretization. -/
-theorem joinInterval_sound (a b : Interval) :
-    gammaInterval a ∪ gammaInterval b ⊆ gammaInterval (joinInterval a b) := by
-  intro n hn
-  rcases hn with ha | hb
-  · exact joinInterval_le_left a b ha
-  · exact joinInterval_le_right a b hb
 
 /-- Meet of two canonical intervals. -/
 def meetInterval (a b : Interval) : Interval :=
@@ -491,70 +480,6 @@ theorem filterZeroInterval_reductive :
         subst this
         simpa [gammaInterval, Set.mem_setOf_eq] using hContainsZero
       · simp [filterZeroInterval, hContainsZero, gammaInterval] at hn
-
-/--
-Widening on intervals: if the new interval `b` exceeds `a`'s bounds in
-either direction, jump to `⊤`. This aggressive strategy guarantees
-termination in at most one widening step.
--/
-def widenInterval (a b : Interval) : Interval :=
-  match a, b with
-  | .bot, b => b
-  | a, .bot => a
-  | .top, _ => .top
-  | _, .top => .top
-  | .range lo1 hi1 h1, .range lo2 hi2 _ =>
-      if lo2 < lo1 ∨ hi1 < hi2 then .top else .range lo1 hi1 h1
-
-/-- `widenInterval` is an upper bound: `a ≤ widen a b`. -/
-theorem widenInterval_left (a b : Interval) :
-    leInterval a (widenInterval a b) := by
-  intro n hn
-  cases a with
-  | bot => simp only [gammaInterval, Set.mem_empty_iff_false] at hn
-  | top =>
-    cases b with
-    | bot => simp only [widenInterval]; exact hn
-    | top => simp only [widenInterval]; exact hn
-    | range _ _ _ => simp only [widenInterval, gammaInterval]; exact Set.mem_univ n
-  | range lo1 hi1 h1 =>
-    cases b with
-    | bot => simp only [widenInterval]; exact hn
-    | top => simp only [widenInterval, gammaInterval]; exact Set.mem_univ n
-    | range lo2 hi2 _ =>
-      simp only [widenInterval]
-      split_ifs with hcond
-      · exact Set.mem_univ n
-      · exact hn
-
-/-- `widenInterval` is an upper bound: `b ≤ widen a b`. -/
-theorem widenInterval_right (a b : Interval) :
-    leInterval b (widenInterval a b) := by
-  intro n hn
-  cases b with
-  | bot => simp only [gammaInterval, Set.mem_empty_iff_false] at hn
-  | top =>
-    cases a with
-    | bot => simp only [widenInterval, gammaInterval]; exact Set.mem_univ n
-    | top => simp only [widenInterval, gammaInterval]; exact Set.mem_univ n
-    | range _ _ _ => simp only [widenInterval, gammaInterval]; exact Set.mem_univ n
-  | range lo2 hi2 h2 =>
-    cases a with
-    | bot => simp only [widenInterval]; exact hn
-    | top => simp only [widenInterval, gammaInterval]; exact Set.mem_univ n
-    | range lo1 hi1 h1 =>
-      simp only [widenInterval]
-      split_ifs with hcond
-      · exact Set.mem_univ n
-      · push Not at hcond
-        simp only [gammaInterval, Set.mem_setOf_eq] at hn ⊢
-        omega
-
-/-- `widenInterval` satisfies the framework `WidenUpperBound` contract. -/
-theorem widenInterval_upperBound :
-    AbsInterp.Framework.Iteration.WidenUpperBound leInterval widenInterval where
-  left := widenInterval_left
-  right := widenInterval_right
 
 /-- Concretization-domain instance for the interval domain. -/
 def intervalConcretizationDomain :

--- a/AbsInterp/Domains/Interval/Widening.lean
+++ b/AbsInterp/Domains/Interval/Widening.lean
@@ -1,0 +1,80 @@
+import AbsInterp.Domains.Interval
+import AbsInterp.Framework.Iteration.Widening.Defs
+
+/-!
+# Interval widening
+
+Widening operator and upper-bound lemmas for the baseline interval domain.
+Lives in the iteration/solver layer so that `AbsInterp.Domains.Interval`
+remains free of framework iteration dependencies.
+-/
+
+namespace AbsInterp
+namespace Domains
+
+/--
+Widening on intervals: if the new interval `b` exceeds `a`'s bounds in
+either direction, jump to `⊤`. This aggressive strategy guarantees
+termination in at most one widening step.
+-/
+def widenInterval (a b : Interval) : Interval :=
+  match a, b with
+  | .bot, b => b
+  | a, .bot => a
+  | .top, _ => .top
+  | _, .top => .top
+  | .range lo1 hi1 h1, .range lo2 hi2 _ =>
+      if lo2 < lo1 ∨ hi1 < hi2 then .top else .range lo1 hi1 h1
+
+/-- `widenInterval` is an upper bound: `a ≤ widen a b`. -/
+theorem widenInterval_left (a b : Interval) :
+    leInterval a (widenInterval a b) := by
+  intro n hn
+  cases a with
+  | bot => simp only [gammaInterval, Set.mem_empty_iff_false] at hn
+  | top =>
+    cases b with
+    | bot => simp only [widenInterval]; exact hn
+    | top => simp only [widenInterval]; exact hn
+    | range _ _ _ => simp only [widenInterval, gammaInterval]; exact Set.mem_univ n
+  | range lo1 hi1 h1 =>
+    cases b with
+    | bot => simp only [widenInterval]; exact hn
+    | top => simp only [widenInterval, gammaInterval]; exact Set.mem_univ n
+    | range lo2 hi2 _ =>
+      simp only [widenInterval]
+      split_ifs with hcond
+      · exact Set.mem_univ n
+      · exact hn
+
+/-- `widenInterval` is an upper bound: `b ≤ widen a b`. -/
+theorem widenInterval_right (a b : Interval) :
+    leInterval b (widenInterval a b) := by
+  intro n hn
+  cases b with
+  | bot => simp only [gammaInterval, Set.mem_empty_iff_false] at hn
+  | top =>
+    cases a with
+    | bot => simp only [widenInterval, gammaInterval]; exact Set.mem_univ n
+    | top => simp only [widenInterval, gammaInterval]; exact Set.mem_univ n
+    | range _ _ _ => simp only [widenInterval, gammaInterval]; exact Set.mem_univ n
+  | range lo2 hi2 h2 =>
+    cases a with
+    | bot => simp only [widenInterval]; exact hn
+    | top => simp only [widenInterval, gammaInterval]; exact Set.mem_univ n
+    | range lo1 hi1 h1 =>
+      simp only [widenInterval]
+      split_ifs with hcond
+      · exact Set.mem_univ n
+      · push Not at hcond
+        simp only [gammaInterval, Set.mem_setOf_eq] at hn ⊢
+        omega
+
+/-- `widenInterval` satisfies the framework `WidenUpperBound` contract. -/
+theorem widenInterval_upperBound :
+    AbsInterp.Framework.Iteration.WidenUpperBound leInterval widenInterval where
+  left := widenInterval_left
+  right := widenInterval_right
+
+end Domains
+end AbsInterp

--- a/AbsInterp/Domains/Parity.lean
+++ b/AbsInterp/Domains/Parity.lean
@@ -72,13 +72,6 @@ def joinParity : Parity → Parity → Parity
   | .odd, .odd => .odd
   | _, _ => .top
 
-instance : Max Parity := ⟨joinParity⟩
-
-theorem joinParity_sound : ∀ a b : Parity, gammaParity a ∪ gammaParity b ⊆ gammaParity (a ⊔ b) := by
-  intro a b n hn
-  show n ∈ gammaParity (joinParity a b)
-  cases a <;> cases b <;> simp [joinParity, gammaParity] at hn ⊢ <;> tauto
-
 theorem joinParity_le_left (a b : Parity) : a ≤ joinParity a b := by
   cases a <;> cases b <;> simp [LE.le, leParity, joinParity]
 

--- a/AbsInterp/Domains/Sign.lean
+++ b/AbsInterp/Domains/Sign.lean
@@ -141,13 +141,9 @@ def joinSign (a b : Sign) : Sign :=
     (hasZero a || hasZero b)
     (hasPos a || hasPos b)
 
-instance : Max Sign := ⟨joinSign⟩
-
-/-- `joinSign` soundly over-approximates union concretization. -/
-theorem joinSign_sound (a b : Sign) :
-    gammaSign a ∪ gammaSign b ⊆ gammaSign (a ⊔ b) := by
+private theorem joinSign_sound_local (a b : Sign) :
+    gammaSign a ∪ gammaSign b ⊆ gammaSign (joinSign a b) := by
   intro n hn
-  show n ∈ gammaSign (joinSign a b)
   cases a <;> cases b <;>
     simp [gammaSign, joinSign, signOfFlags, hasNeg, hasZero, hasPos] at hn ⊢ <;>
     tauto
@@ -161,10 +157,10 @@ theorem joinSign_sound (a b : Sign) :
   cases a <;> rfl
 
 theorem joinSign_le_left (a b : Sign) : a ≤ joinSign a b :=
-  fun _ hn => joinSign_sound a b (Or.inl hn)
+  fun _ hn => joinSign_sound_local a b (Or.inl hn)
 
 theorem joinSign_le_right (a b : Sign) : b ≤ joinSign a b :=
-  fun _ hn => joinSign_sound a b (Or.inr hn)
+  fun _ hn => joinSign_sound_local a b (Or.inr hn)
 
 theorem joinSign_le_of_le {a b c : Sign} (ha : a ≤ c) (hb : b ≤ c) :
     joinSign a b ≤ c := by

--- a/AbsInterp/Domains/Sign.lean
+++ b/AbsInterp/Domains/Sign.lean
@@ -141,13 +141,6 @@ def joinSign (a b : Sign) : Sign :=
     (hasZero a || hasZero b)
     (hasPos a || hasPos b)
 
-private theorem joinSign_sound_local (a b : Sign) :
-    gammaSign a ∪ gammaSign b ⊆ gammaSign (joinSign a b) := by
-  intro n hn
-  cases a <;> cases b <;>
-    simp [gammaSign, joinSign, signOfFlags, hasNeg, hasZero, hasPos] at hn ⊢ <;>
-    tauto
-
 @[simp] theorem joinSign_bot_left (a : Sign) :
     joinSign .bot a = a := by
   cases a <;> rfl
@@ -156,11 +149,17 @@ private theorem joinSign_sound_local (a b : Sign) :
     joinSign a .bot = a := by
   cases a <;> rfl
 
-theorem joinSign_le_left (a b : Sign) : a ≤ joinSign a b :=
-  fun _ hn => joinSign_sound_local a b (Or.inl hn)
+theorem joinSign_le_left (a b : Sign) : a ≤ joinSign a b := by
+  intro n hn
+  cases a <;> cases b <;>
+    simp [gammaSign, joinSign, signOfFlags, hasNeg, hasZero, hasPos] at hn ⊢ <;>
+    tauto
 
-theorem joinSign_le_right (a b : Sign) : b ≤ joinSign a b :=
-  fun _ hn => joinSign_sound_local a b (Or.inr hn)
+theorem joinSign_le_right (a b : Sign) : b ≤ joinSign a b := by
+  intro n hn
+  cases a <;> cases b <;>
+    simp [gammaSign, joinSign, signOfFlags, hasNeg, hasZero, hasPos] at hn ⊢ <;>
+    tauto
 
 theorem joinSign_le_of_le {a b c : Sign} (ha : a ≤ c) (hb : b ≤ c) :
     joinSign a b ≤ c := by

--- a/Examples/IMP/Programs/LoopShowcase.lean
+++ b/Examples/IMP/Programs/LoopShowcase.lean
@@ -35,6 +35,7 @@ All theorems in this file are axiom-clean (`propext`, `Quot.sound`,
 namespace Examples.IMP.Programs
 
 open AbsInterp.Domains
+open AbsInterp.Framework.Domains
 open AbsInterp.Framework.Iteration
 
 /-! ## The IMP program -/
@@ -85,14 +86,16 @@ theorem loopBodySign_sound
     (under `n ≠ 0`) are both in `γ(loopTransferSign a)`. -/
 theorem loopTransferSign_sound_init (a : Sign) :
     (5 : Int) ∈ gammaSign (loopTransferSign a) :=
-  joinSign_sound _ _ (Or.inl (constSign_sound 5))
+  ConcretizationDomain.gamma_union_subset_sup signConcretizationDomain _ _
+    (Or.inl (constSign_sound 5))
 
 theorem loopTransferSign_sound_body
     {a : Sign} {n : Int}
     (hn : n ∈ gammaSign a)
     (hNz : n ≠ 0) :
     n + (-1) ∈ gammaSign (loopTransferSign a) :=
-  joinSign_sound _ _ (Or.inr (loopBodySign_sound hn hNz))
+  ConcretizationDomain.gamma_union_subset_sup signConcretizationDomain _ _
+    (Or.inr (loopBodySign_sound hn hNz))
 
 /-! ## Concrete exit property
 


### PR DESCRIPTION
## Summary
This PR finishes the Session 3 layering cleanup by separating interval widening from the scalar interval domain module and removing stale domain-specific join API that is now covered by the generic concretization theorem.

## What changed
- moved interval widening definitions and upper-bound proofs into `AbsInterp/Domains/Interval/Widening.lean`
- removed widening-related framework imports from `AbsInterp/Domains/Interval.lean`
- removed stale `Max` instances for `Sign`, `Parity`, and `Interval`
- removed or localized old public `join*_sound` helpers
- migrated `LoopShowcase` to use `ConcretizationDomain.gamma_union_subset_sup`
- updated `AbsInterp/Domains.lean` so top-level domain imports still expose interval widening

## Why
After the recent `ConcretizationDomain` and capability-layer refactors, widening belongs with the iteration/solver layer rather than inside the scalar interval core. Likewise, concretization-level join soundness should come from the generic framework theorem instead of domain-specific legacy lemmas.

## Impact
- Session 3 and Session 4 boundaries are cleaner
- interval domain core no longer depends on framework widening definitions
- public domain API is less cluttered with stale pre-refactor join artifacts

## Validation
- `lake build`
- `lake build Tests`
- `lake test`