### PR TITLE
[codex] add generic fixpoint collecting bridge

### DIFF
--- a/AbsInterp/Framework/Iteration.lean
+++ b/AbsInterp/Framework/Iteration.lean
@@ -1,3 +1,4 @@
 import AbsInterp.Framework.Iteration.NatIter
 import AbsInterp.Framework.Iteration.Collecting
+import AbsInterp.Framework.Iteration.Fixpoint
 import AbsInterp.Framework.Iteration.Widening

--- a/AbsInterp/Framework/Iteration/Fixpoint.lean
+++ b/AbsInterp/Framework/Iteration/Fixpoint.lean
@@ -1,0 +1,3 @@
+import AbsInterp.Framework.Iteration.Fixpoint.Defs
+import AbsInterp.Framework.Iteration.Fixpoint.Lemmas
+import AbsInterp.Framework.Iteration.Fixpoint.Collecting

--- a/AbsInterp/Framework/Iteration/Fixpoint/Collecting.lean
+++ b/AbsInterp/Framework/Iteration/Fixpoint/Collecting.lean
@@ -1,0 +1,95 @@
+import Cslib.Init
+import Mathlib.Data.Set.Lattice
+
+import AbsInterp.Framework.Iteration.Fixpoint.Lemmas
+import AbsInterp.Framework.Iteration.Collecting
+import AbsInterp.Framework.Semantics.Omega.Defs
+
+/-!
+# Fixpoint → collecting/omega bridge
+
+Reusable corollaries that turn an abstract post-fixpoint into a sound
+over-approximation of collecting Kleene iterates and of ω-reachability.
+
+These are the headline Session 4 results: once a solver has produced an
+abstract post-fixpoint, these theorems deliver the concrete safety
+conclusion without any further iteration-specific reasoning.
+-/
+
+namespace AbsInterp
+namespace Framework
+namespace Iteration
+
+open AbsInterp.Framework
+
+universe u v
+
+/--
+Every finite collecting Kleene iterate is concretized by an abstract
+post-fixpoint of the matching reachability transfer.
+-/
+theorem kleeneNat_subset_of_isPostFixpoint
+    {State : Type u} {Abstract : Type v}
+    (cfg : CollectingStep State)
+    (init : Set State)
+    {gamma : Concretization Abstract State}
+    {reachSharp : PostSharp Abstract}
+    {le : Abstract -> Abstract -> Prop}
+    (hSound : Sound (cfg.reachF init) gamma reachSharp)
+    (gamma_mono : ∀ {a b : Abstract}, le a b -> gamma a ⊆ gamma b)
+    {a : Abstract}
+    (hFix : IsPostFixpoint le reachSharp a) :
+    ∀ n, cfg.kleeneNat init n ⊆ gamma a := by
+  intro n
+  have hMono : MonotonePost (cfg.reachF init) := CollectingStep.reachF_monotone cfg init
+  have hEmpty : (∅ : Set State) ⊆ gamma a := Set.empty_subset _
+  exact sound_iterateNat_from_init_of_isPostFixpoint
+    hSound hMono gamma_mono hEmpty hFix n
+
+/--
+The union of all finite collecting Kleene iterates is concretized by an
+abstract post-fixpoint of the matching reachability transfer.
+-/
+theorem iUnion_kleeneNat_subset_of_isPostFixpoint
+    {State : Type u} {Abstract : Type v}
+    (cfg : CollectingStep State)
+    (init : Set State)
+    {gamma : Concretization Abstract State}
+    {reachSharp : PostSharp Abstract}
+    {le : Abstract -> Abstract -> Prop}
+    (hSound : Sound (cfg.reachF init) gamma reachSharp)
+    (gamma_mono : ∀ {a b : Abstract}, le a b -> gamma a ⊆ gamma b)
+    {a : Abstract}
+    (hFix : IsPostFixpoint le reachSharp a) :
+    (⋃ n, cfg.kleeneNat init n) ⊆ gamma a := by
+  apply Set.iUnion_subset
+  intro n
+  exact kleeneNat_subset_of_isPostFixpoint cfg init hSound gamma_mono hFix n
+
+/--
+Every ω-reachable state from `init` is concretized by an abstract
+post-fixpoint of the matching reachability transfer.
+
+This is the headline bridge: safety properties proved at the abstract
+post-fixpoint transfer through to infinite executions of the concrete
+collecting semantics.
+-/
+theorem omegaReachable_subset_of_isPostFixpoint
+    {State : Type u} {Abstract : Type v}
+    (cfg : CollectingStep State)
+    (init : Set State)
+    {gamma : Concretization Abstract State}
+    {reachSharp : PostSharp Abstract}
+    {le : Abstract -> Abstract -> Prop}
+    (hSound : Sound (cfg.reachF init) gamma reachSharp)
+    (gamma_mono : ∀ {a b : Abstract}, le a b -> gamma a ⊆ gamma b)
+    {a : Abstract}
+    (hFix : IsPostFixpoint le reachSharp a) :
+    omegaReachable cfg init ⊆ gamma a :=
+  Set.Subset.trans
+    (omegaReachable_subset_iUnion_kleeneNat cfg init)
+    (iUnion_kleeneNat_subset_of_isPostFixpoint cfg init hSound gamma_mono hFix)
+
+end Iteration
+end Framework
+end AbsInterp

--- a/AbsInterp/Framework/Iteration/Fixpoint/Defs.lean
+++ b/AbsInterp/Framework/Iteration/Fixpoint/Defs.lean
@@ -1,0 +1,28 @@
+import Cslib.Init
+
+/-!
+# Generic post-fixpoint notion
+
+Widening-independent fixpoint vocabulary: `IsPostFixpoint` states that a
+function is contracted (or stationary) at a point relative to an order.
+Specialized iterative solvers (widening, narrowing, worklist) live in
+separate modules and depend on this definition.
+-/
+
+namespace AbsInterp
+namespace Framework
+namespace Iteration
+
+universe u
+
+/-- Post-fixpoint property: `f(a) ⊑ a`. -/
+def IsPostFixpoint
+    {Abstract : Type u}
+    (le : Abstract -> Abstract -> Prop)
+    (f : Abstract -> Abstract)
+    (a : Abstract) : Prop :=
+  le (f a) a
+
+end Iteration
+end Framework
+end AbsInterp

--- a/AbsInterp/Framework/Iteration/Fixpoint/Lemmas.lean
+++ b/AbsInterp/Framework/Iteration/Fixpoint/Lemmas.lean
@@ -1,0 +1,79 @@
+import Cslib.Init
+
+import AbsInterp.Framework.Iteration.Fixpoint.Defs
+import AbsInterp.Framework.Iteration.NatIter
+import AbsInterp.Framework.Soundness.Defs
+
+/-!
+# Generic post-fixpoint soundness lemmas
+
+Widening-independent soundness consequences of a post-fixpoint. These
+lemmas are reusable by any fixpoint-producing solver (widening, narrowing,
+Kleene, worklist) and by collecting/omega-level bridges.
+-/
+
+namespace AbsInterp
+namespace Framework
+namespace Iteration
+
+open AbsInterp.Framework
+
+universe u v
+
+/--
+Gamma soundness from a post-fixpoint.
+
+If `postSharp` has a post-fixpoint `a` and `Sound` holds, then every
+natural-number concrete iterate starting from `gamma a` stays in `gamma a`.
+-/
+theorem sound_of_isPostFixpoint
+    {State : Type u} {Abstract : Type v}
+    {post : Post State}
+    {gamma : Concretization Abstract State}
+    {postSharp : PostSharp Abstract}
+    {le : Abstract -> Abstract -> Prop}
+    (hSound : Sound post gamma postSharp)
+    (hMono : MonotonePost post)
+    (gamma_mono : ∀ {a b : Abstract}, le a b -> gamma a ⊆ gamma b)
+    {a : Abstract}
+    (hFix : IsPostFixpoint le postSharp a) :
+    ∀ n, iterateNat post (gamma a) n ⊆ gamma a := by
+  intro n
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    simp only [iterateNat_succ]
+    calc post (iterateNat post (gamma a) n)
+        ⊆ post (gamma a) := hMono ih
+      _ ⊆ gamma (postSharp a) := hSound a
+      _ ⊆ gamma a := gamma_mono hFix
+
+/--
+Generic bridge from arbitrary initial concrete sets to post-fixpoint soundness.
+
+If `init ⊆ gamma a` and `a` is a post-fixpoint of a sound abstract transfer,
+then every natural-number iterate from `init` is soundly abstracted by `a`.
+-/
+theorem sound_iterateNat_from_init_of_isPostFixpoint
+    {State : Type u} {Abstract : Type v}
+    {post : Post State}
+    {gamma : Concretization Abstract State}
+    {postSharp : PostSharp Abstract}
+    {le : Abstract -> Abstract -> Prop}
+    (hSound : Sound post gamma postSharp)
+    (hMono : MonotonePost post)
+    (gamma_mono : ∀ {a b : Abstract}, le a b -> gamma a ⊆ gamma b)
+    {init : Set State}
+    {a : Abstract}
+    (hInit : init ⊆ gamma a)
+    (hFix : IsPostFixpoint le postSharp a) :
+    ∀ n, iterateNat post init n ⊆ gamma a := by
+  intro n
+  have hChain : iterateNat post init n ⊆ iterateNat post (gamma a) n :=
+    iterateNat_monotone_init hMono n hInit
+  exact Set.Subset.trans hChain
+    (sound_of_isPostFixpoint hSound hMono gamma_mono hFix n)
+
+end Iteration
+end Framework
+end AbsInterp

--- a/AbsInterp/Framework/Iteration/Widening/Defs.lean
+++ b/AbsInterp/Framework/Iteration/Widening/Defs.lean
@@ -1,5 +1,7 @@
 import Init.SizeOf
 
+import AbsInterp.Framework.Iteration.Fixpoint.Defs
+
 namespace AbsInterp
 namespace Framework
 namespace Iteration
@@ -11,14 +13,6 @@ abbrev Widen (Abstract : Type u) := Abstract -> Abstract -> Abstract
 
 /-- Narrowing interface for abstract iterative solvers. -/
 abbrev Narrow (Abstract : Type u) := Abstract -> Abstract -> Abstract
-
-/-- Post-fixpoint property: `f(a) ⊑ a`. -/
-def IsPostFixpoint
-    {Abstract : Type u}
-    (le : Abstract -> Abstract -> Prop)
-    (f : Abstract -> Abstract)
-    (a : Abstract) : Prop :=
-  le (f a) a
 
 /-- Widening upper-bound contract: `widen a b` is above both `a` and `b`. -/
 structure WidenUpperBound

--- a/AbsInterp/Framework/Iteration/Widening/Lemmas.lean
+++ b/AbsInterp/Framework/Iteration/Widening/Lemmas.lean
@@ -1,8 +1,7 @@
 import Cslib.Init
 
 import AbsInterp.Framework.Iteration.Widening.Defs
-import AbsInterp.Framework.Iteration.NatIter
-import AbsInterp.Framework.Soundness.Defs
+import AbsInterp.Framework.Iteration.Fixpoint.Defs
 
 namespace AbsInterp
 namespace Framework
@@ -10,7 +9,7 @@ namespace Iteration
 
 open AbsInterp.Framework
 
-universe u v
+universe u
 
 /-- `witer` returns a post-fixpoint of `f`. -/
 theorem isPostFixpoint_witer
@@ -46,34 +45,6 @@ theorem isPostFixpoint_pfp
     (acc : WAcc le f widen bot bot) :
     IsPostFixpoint le f (pfp le_dec hWiden bot hBot acc) :=
   isPostFixpoint_witer le_dec hWiden (hBot bot) acc
-
-/--
-Gamma soundness from post-fixpoint property.
-
-If `postSharp` has a post-fixpoint `a` and `Sound` holds,
-then `∀ n, iterateNat post (gamma a) n ⊆ gamma a`.
--/
-theorem sound_of_isPostFixpoint
-    {State : Type u} {Abstract : Type v}
-    {post : Post State}
-    {gamma : Concretization Abstract State}
-    {postSharp : PostSharp Abstract}
-    {le : Abstract -> Abstract -> Prop}
-    (hSound : Sound post gamma postSharp)
-    (hMono : MonotonePost post)
-    (gamma_mono : ∀ {a b : Abstract}, le a b -> gamma a ⊆ gamma b)
-    {a : Abstract}
-    (hFix : IsPostFixpoint le postSharp a) :
-    ∀ n, iterateNat post (gamma a) n ⊆ gamma a := by
-  intro n
-  induction n with
-  | zero => simp
-  | succ n ih =>
-    simp only [iterateNat_succ]
-    calc post (iterateNat post (gamma a) n)
-        ⊆ post (gamma a) := hMono ih
-      _ ⊆ gamma (postSharp a) := hSound a
-      _ ⊆ gamma a := gamma_mono hFix
 
 end Iteration
 end Framework

--- a/Tests/Framework/Iteration/Widening.lean
+++ b/Tests/Framework/Iteration/Widening.lean
@@ -11,7 +11,10 @@ open AbsInterp.Framework.Iteration
 /-! # Flat3 smoke test for widening/narrowing interfaces
 
 A toy 3-element flat lattice `{bot, mid, top}` exercising
-`WAcc`, `witer`, `pfp`, `IsPostFixpoint`, and `sound_of_isPostFixpoint`.
+`WAcc`, `witer`, `pfp`, `IsPostFixpoint`, `sound_of_isPostFixpoint`,
+and the collecting/omega bridge corollaries
+`kleeneNat_subset_of_isPostFixpoint` and
+`omegaReachable_subset_of_isPostFixpoint`.
 
 The `pfp_eq_top` theorem uses `native_decide` to compute the widening
 result. This is test-only code; the upstream soundness path is
@@ -131,6 +134,38 @@ example : ∀ n, iterateNat post (gamma .top) n ⊆ gamma .top := by
     post_sound post_monotone
     (fun h => gamma_mono h)
   simp [IsPostFixpoint, le]
+
+/-! ## Fixpoint → collecting/omega bridge exercised on Flat3
+
+Package `post` as a `CollectingStep`, then use the reachF-level soundness
+of the constant-top abstract transfer to push through to `kleeneNat` and
+`omegaReachable` conclusions. -/
+
+/-- Collecting step wrapper for the Flat3 concrete post. -/
+def collecting : CollectingStep Nat where
+  post := post
+  monotone := post_monotone
+
+/-- Abstract reachF transfer: constantly `.top`. The post-fixpoint condition
+    is trivial because `gamma .top = Set.univ` absorbs the initial set. -/
+theorem reachF_sound (init : Set Nat) :
+    Sound (collecting.reachF init) gamma (fun _ => Flat3.top) := by
+  intro a s _; exact Set.mem_univ s
+
+/-- `.top` is a post-fixpoint of the constant-top abstract transfer. -/
+theorem reachSharp_postFixpoint :
+    IsPostFixpoint le (fun _ : Flat3 => Flat3.top) .top := by
+  simp [IsPostFixpoint, le]
+
+/-- Bridge: every finite Kleene iterate of collecting from `{0}` is in `gamma .top`. -/
+example : ∀ n, collecting.kleeneNat {0} n ⊆ gamma .top :=
+  kleeneNat_subset_of_isPostFixpoint collecting {0}
+    (reachF_sound {0}) (fun h => gamma_mono h) reachSharp_postFixpoint
+
+/-- Bridge: every ω-reachable state from `{0}` is in `gamma .top`. -/
+example : omegaReachable collecting {0} ⊆ gamma .top :=
+  omegaReachable_subset_of_isPostFixpoint collecting {0}
+    (reachF_sound {0}) (fun h => gamma_mono h) reachSharp_postFixpoint
 
 end Flat3
 


### PR DESCRIPTION
## What changed

This PR extracts widening-independent fixpoint vocabulary into a dedicated `Iteration/Fixpoint` layer and adds reusable bridge theorems from abstract post-fixpoints to concrete collecting and omega semantics.

Concretely:
- moved `IsPostFixpoint` out of `Iteration/Widening`
- moved `sound_of_isPostFixpoint` into the new generic fixpoint layer
- added `sound_iterateNat_from_init_of_isPostFixpoint`
- added collecting/omega corollaries:
  - `kleeneNat_subset_of_isPostFixpoint`
  - `iUnion_kleeneNat_subset_of_isPostFixpoint`
  - `omegaReachable_subset_of_isPostFixpoint`
- kept `Iteration/Widening` focused on the widening engine itself (`WAcc`, `witer`, `pfp`, and their post-fixpoint theorems)
- updated the widening smoke test to consume the new bridge theorems

## Why

Session 4 previously had a reusable widening engine, but the key bridge from a computed abstract post-fixpoint to collecting/Kleene/omega soundness was not packaged as framework API. The result was that widening behaved more like a proof core plus showcase code than a reusable solver bridge.

This change makes the layering explicit:
- generic fixpoint notions live in `Iteration/Fixpoint`
- widening-specific machinery stays in `Iteration/Widening`
- collecting/omega consequences are exposed as reusable corollaries

## Impact

The framework iteration layer is now closer to a CSLib-facing solver abstraction:
- any solver that produces an abstract post-fixpoint can reuse the same soundness bridge
- collecting and omega soundness no longer depend on widening-specific module placement
- Session 4 now exposes a cleaner path from abstract fixpoint reasoning to concrete safety conclusions

## Validation

- `lake build`
- `lake test`
