### PR TITLE
[codex] add LTS collecting fixpoint bridge

### DIFF
--- a/AbsInterp/Instances/LTS/Analyses/Common.lean
+++ b/AbsInterp/Instances/LTS/Analyses/Common.lean
@@ -2,8 +2,11 @@ import Cslib.Init
 import Cslib.Foundations.Semantics.LTS.Basic
 
 import AbsInterp.Framework.Soundness
+import AbsInterp.Framework.Domains.Concretization
 import AbsInterp.Instances.LTS.Semantics.Concrete
+import AbsInterp.Instances.LTS.Semantics.Collecting
 import AbsInterp.Instances.LTS.Instantiation.Interface
+import AbsInterp.Instances.LTS.Instantiation.CollectingInterface
 
 namespace AbsInterp
 namespace Instances
@@ -98,6 +101,89 @@ def abstractionOfStepSound
     (gammaStateOfRead gamma read)
     transfer
     (soundStep_postStep_of_stepSound gamma lts read transfer hStep)
+
+/-!
+## Readout-based collecting soundness
+
+Parallel readout path for the unlabeled collecting abstraction, used to
+discharge `LTSCollectingAbstraction.soundAny` for domains that observe
+states through a readout function. This mirrors `StepSoundOfRead` /
+`abstractionOfStepSound` on the labeled trace side.
+-/
+
+/--
+Local unlabeled collecting soundness condition for readout-based
+abstract LTS analyses.
+
+Any transition `s →? s'` from a state in `γ(a)` lands in `γ(transferAny a)`,
+independently of the label used.
+-/
+def CollectingSoundOfRead
+    {State : Type u}
+    {Label : Type v}
+    {Abstract : Type w}
+    {Observation : Type x}
+    (gamma : Abstract -> Set Observation)
+    (lts : Cslib.LTS State Label)
+    (read : State -> Observation)
+    (transferAny : PostSharp Abstract) : Prop :=
+  ∀ (a : Abstract) (s s' : State),
+    s ∈ gammaStateOfRead gamma read a ->
+    (∃ label : Label, lts.Tr s label s') ->
+    s' ∈ gammaStateOfRead gamma read (transferAny a)
+
+/-- Bridge from local readout-based collecting soundness to framework `Sound`
+over `postAny`. -/
+theorem sound_postAny_of_collectingSound
+    {State : Type u}
+    {Label : Type v}
+    {Abstract : Type w}
+    {Observation : Type x}
+    (gamma : Abstract -> Set Observation)
+    (lts : Cslib.LTS State Label)
+    (read : State -> Observation)
+    (transferAny : PostSharp Abstract)
+    (hAny : CollectingSoundOfRead gamma lts read transferAny) :
+    Sound (postAny lts) (gammaStateOfRead gamma read) transferAny := by
+  intro a s' hs'
+  rcases (mem_postAny (lts := lts)
+      (states := gammaStateOfRead gamma read a) (s' := s')).1 hs'
+    with ⟨s, hsMem, label, htr⟩
+  exact hAny a s s' hsMem ⟨label, htr⟩
+
+/-- Lift a γ-only concretization domain on observations to one on states
+through a readout function. -/
+def ConcretizationDomain.ofRead
+    {State : Type u}
+    {Abstract : Type w}
+    {Observation : Type x}
+    [Preorder Abstract] [OrderTop Abstract]
+    (domain : AbsInterp.Framework.Domains.ConcretizationDomain Abstract Observation)
+    (read : State -> Observation) :
+    AbsInterp.Framework.Domains.ConcretizationDomain Abstract State where
+  gamma := gammaStateOfRead domain.gamma read
+  gamma_monotone := fun _ _ h _ hs => domain.gamma_monotone h hs
+  gamma_top := fun s => domain.gamma_top (read s)
+
+/-- Build an LTS collecting abstraction from local readout-based collecting
+soundness obligations. -/
+def collectingAbstractionOfCollectingSound
+    {State : Type u}
+    {Label : Type v}
+    {Abstract : Type w}
+    {Observation : Type x}
+    [SemilatticeSup Abstract] [OrderTop Abstract]
+    (domain : AbsInterp.Framework.Domains.ConcretizationDomain Abstract Observation)
+    (lts : Cslib.LTS State Label)
+    (read : State -> Observation)
+    (transferAny : PostSharp Abstract)
+    (hAny : CollectingSoundOfRead domain.gamma lts read transferAny) :
+    LTSCollectingAbstraction State Label Abstract where
+  lts := lts
+  domain := ConcretizationDomain.ofRead domain read
+  transferAny := transferAny
+  soundAny :=
+    sound_postAny_of_collectingSound domain.gamma lts read transferAny hAny
 
 end Analyses
 end LTS

--- a/AbsInterp/Instances/LTS/Core.lean
+++ b/AbsInterp/Instances/LTS/Core.lean
@@ -6,3 +6,5 @@ import AbsInterp.Instances.LTS.Semantics.Weak
 import AbsInterp.Instances.LTS.Semantics.Omega
 import AbsInterp.Instances.LTS.Instantiation.Interface
 import AbsInterp.Instances.LTS.Instantiation.Soundness
+import AbsInterp.Instances.LTS.Instantiation.CollectingInterface
+import AbsInterp.Instances.LTS.Instantiation.CollectingSoundness

--- a/AbsInterp/Instances/LTS/Instantiation/CollectingInterface.lean
+++ b/AbsInterp/Instances/LTS/Instantiation/CollectingInterface.lean
@@ -100,14 +100,17 @@ theorem sound_reachTransfer
       cfg.domain.gamma
       (cfg.reachTransfer initAbs) := by
   intro a s hs
-  have hUnion :
-      cfg.domain.gamma initAbs ∪ cfg.domain.gamma (cfg.transferAny a) ⊆
-        cfg.domain.gamma (initAbs ⊔ cfg.transferAny a) :=
-    ConcretizationDomain.gamma_union_subset_sup cfg.domain
-      initAbs (cfg.transferAny a)
   rcases hs with hInitMem | hPostMem
-  · exact hUnion (Or.inl (hInit hInitMem))
-  · exact hUnion (Or.inr (cfg.soundAny a hPostMem))
+  ·
+    have hLeft : initAbs ≤ cfg.reachTransfer initAbs a := by
+      change initAbs ≤ initAbs ⊔ cfg.transferAny a
+      exact le_sup_left
+    exact cfg.domain.gamma_monotone hLeft (hInit hInitMem)
+  ·
+    have hRight : cfg.transferAny a ≤ cfg.reachTransfer initAbs a := by
+      change cfg.transferAny a ≤ initAbs ⊔ cfg.transferAny a
+      exact le_sup_right
+    exact cfg.domain.gamma_monotone hRight (cfg.soundAny a hPostMem)
 
 end LTSCollectingAbstraction
 

--- a/AbsInterp/Instances/LTS/Instantiation/CollectingInterface.lean
+++ b/AbsInterp/Instances/LTS/Instantiation/CollectingInterface.lean
@@ -1,0 +1,116 @@
+import Cslib.Init
+import Cslib.Foundations.Semantics.LTS.Basic
+
+import AbsInterp.Framework.Domains.Concretization
+import AbsInterp.Framework.Soundness.Defs
+import AbsInterp.Instances.LTS.Semantics.Collecting
+
+/-!
+# LTS Collecting Abstraction Interface
+
+`LTSCollectingAbstraction` packages a CSLib LTS with an **unlabeled**
+collecting transfer function that is sound w.r.t. `postAny`. It is
+intentionally parallel to (and independent from) `LTSAbstraction`, which
+captures the labeled one-step soundness obligation used for trace
+soundness.
+
+This interface is the adapter from the LTS collecting semantics to the
+generic Session 4 post-fixpoint bridge
+(`AbsInterp.Framework.Iteration.Fixpoint.Collecting`).
+-/
+
+namespace AbsInterp
+namespace Instances
+namespace LTS
+
+open AbsInterp.Framework
+open AbsInterp.Framework.Domains
+
+universe u v w
+
+/--
+Reusable interface for unlabeled collecting abstract interpretation over a
+CSLib LTS.
+
+Fields:
+- `lts`: the underlying CSLib LTS.
+- `domain`: a γ-only concretization domain on `Abstract`.
+- `transferAny`: abstract transfer for the unlabeled `postAny` semantics.
+- `soundAny`: one-step soundness of `transferAny` w.r.t. `postAny lts`.
+
+Why a separate structure from `LTSAbstraction`:
+- `LTSAbstraction` takes a **labeled** transfer (`Label → Abstract → Abstract`)
+  and targets trace soundness.
+- `LTSCollectingAbstraction` takes an **unlabeled** transfer (`Abstract →
+  Abstract`) and targets collecting/fixpoint reasoning. Deriving the latter
+  from the former requires extra assumptions (e.g. finite label
+  enumeration, abstract join aggregation) that this layer deliberately
+  avoids.
+-/
+structure LTSCollectingAbstraction
+    (State : Type u)
+    (Label : Type v)
+    (Abstract : Type w)
+    [SemilatticeSup Abstract]
+    [OrderTop Abstract] where
+  /-- The underlying CSLib LTS. -/
+  lts : Cslib.LTS State Label
+  /-- A γ-only concretization domain over `Abstract`. -/
+  domain : ConcretizationDomain Abstract State
+  /-- Abstract transfer for the unlabeled `postAny` semantics. -/
+  transferAny : PostSharp Abstract
+  /-- One-step soundness of `transferAny` w.r.t. the LTS collecting step. -/
+  soundAny : Sound (postAny lts) domain.gamma transferAny
+
+namespace LTSCollectingAbstraction
+
+variable
+    {State : Type u}
+    {Label : Type v}
+    {Abstract : Type w}
+    [SemilatticeSup Abstract]
+    [OrderTop Abstract]
+
+/--
+Reachability transformer lifting an abstract entry approximation `initAbs`:
+
+`reachTransfer cfg initAbs a = initAbs ⊔ cfg.transferAny a`.
+
+This matches `(postAny_collectingStep cfg.lts).reachF init` once `init`
+is over-approximated by `initAbs`, and is the abstract object we iterate
+with a widening solver to reach a post-fixpoint.
+-/
+def reachTransfer
+    (cfg : LTSCollectingAbstraction State Label Abstract)
+    (initAbs : Abstract) :
+    PostSharp Abstract :=
+  fun a => initAbs ⊔ cfg.transferAny a
+
+/--
+The abstract reachability transfer is sound w.r.t. the concrete LTS
+collecting reachability operator whenever the initial concrete set is
+bounded by `initAbs`.
+-/
+theorem sound_reachTransfer
+    (cfg : LTSCollectingAbstraction State Label Abstract)
+    {init : Set State}
+    {initAbs : Abstract}
+    (hInit : init ⊆ cfg.domain.gamma initAbs) :
+    Sound ((postAny_collectingStep cfg.lts).reachF init)
+      cfg.domain.gamma
+      (cfg.reachTransfer initAbs) := by
+  intro a s hs
+  have hUnion :
+      cfg.domain.gamma initAbs ∪ cfg.domain.gamma (cfg.transferAny a) ⊆
+        cfg.domain.gamma (initAbs ⊔ cfg.transferAny a) :=
+    ConcretizationDomain.gamma_union_subset_sup cfg.domain
+      initAbs (cfg.transferAny a)
+  rcases hs with hInitMem | hPostMem
+  · exact hUnion (Or.inl (hInit hInitMem))
+  · exact hUnion (Or.inr (cfg.soundAny a hPostMem))
+
+end LTSCollectingAbstraction
+
+end LTS
+end Instances
+end AbsInterp

--- a/AbsInterp/Instances/LTS/Instantiation/CollectingSoundness.lean
+++ b/AbsInterp/Instances/LTS/Instantiation/CollectingSoundness.lean
@@ -1,0 +1,104 @@
+import Cslib.Init
+import Mathlib.Data.Set.Lattice
+
+import AbsInterp.Framework.Iteration.Fixpoint
+import AbsInterp.Instances.LTS.Semantics.Omega
+import AbsInterp.Instances.LTS.Instantiation.CollectingInterface
+
+/-!
+# LTS collecting/fixpoint bridge theorems
+
+Reusable corollaries that combine:
+
+- the LTS unlabeled collecting semantics (`postAny_collectingStep`),
+- a sound abstract collecting transfer bundled as `LTSCollectingAbstraction`,
+- the generic Session 4 post-fixpoint bridge.
+
+Each theorem takes an abstract post-fixpoint of `cfg.reachTransfer initAbs`
+and concludes a concrete safety statement: every finite Kleene iterate,
+the full union of Kleene iterates, or every LTS ω-reachable state is
+contained in the concretization of that post-fixpoint.
+-/
+
+namespace AbsInterp
+namespace Instances
+namespace LTS
+
+open AbsInterp.Framework
+open AbsInterp.Framework.Domains
+open AbsInterp.Framework.Iteration
+
+namespace LTSCollectingAbstraction
+
+universe u v w
+
+variable
+    {State : Type u}
+    {Label : Type v}
+    {Abstract : Type w}
+    [SemilatticeSup Abstract]
+    [OrderTop Abstract]
+
+/--
+If `init ⊆ γ(initAbs)` and `a` is a post-fixpoint of `cfg.reachTransfer initAbs`,
+then every finite Kleene iterate of the LTS collecting semantics from `init`
+is concretized by `a`.
+-/
+theorem kleeneNat_subset_of_isPostFixpoint
+    (cfg : LTSCollectingAbstraction State Label Abstract)
+    (init : Set State)
+    (initAbs a : Abstract)
+    (hInit : init ⊆ cfg.domain.gamma initAbs)
+    (hFix : IsPostFixpoint (· ≤ ·) (cfg.reachTransfer initAbs) a) :
+    ∀ n, (postAny_collectingStep cfg.lts).kleeneNat init n ⊆ cfg.domain.gamma a :=
+  Iteration.kleeneNat_subset_of_isPostFixpoint
+    (postAny_collectingStep cfg.lts) init
+    (cfg.sound_reachTransfer hInit)
+    (fun h => cfg.domain.gamma_monotone h)
+    hFix
+
+/--
+Under the same hypotheses, the union of all finite Kleene iterates is
+concretized by `a`.
+-/
+theorem iUnion_kleeneNat_subset_of_isPostFixpoint
+    (cfg : LTSCollectingAbstraction State Label Abstract)
+    (init : Set State)
+    (initAbs a : Abstract)
+    (hInit : init ⊆ cfg.domain.gamma initAbs)
+    (hFix : IsPostFixpoint (· ≤ ·) (cfg.reachTransfer initAbs) a) :
+    (⋃ n, (postAny_collectingStep cfg.lts).kleeneNat init n) ⊆ cfg.domain.gamma a :=
+  Iteration.iUnion_kleeneNat_subset_of_isPostFixpoint
+    (postAny_collectingStep cfg.lts) init
+    (cfg.sound_reachTransfer hInit)
+    (fun h => cfg.domain.gamma_monotone h)
+    hFix
+
+/--
+Headline bridge: every state on a CSLib `ωTr` of `cfg.lts` starting in
+`init` is concretized by an abstract post-fixpoint of
+`cfg.reachTransfer initAbs`.
+
+This composes `omegaReachableLTS_subset_omegaReachable` with the generic
+`omegaReachable_subset_of_isPostFixpoint`.
+-/
+theorem omegaReachableLTS_subset_of_isPostFixpoint
+    (cfg : LTSCollectingAbstraction State Label Abstract)
+    (init : Set State)
+    (initAbs a : Abstract)
+    (hInit : init ⊆ cfg.domain.gamma initAbs)
+    (hFix : IsPostFixpoint (· ≤ ·) (cfg.reachTransfer initAbs) a) :
+    omegaReachableLTS cfg.lts init ⊆ cfg.domain.gamma a :=
+  Set.Subset.trans
+    (omegaReachableLTS_subset_omegaReachable cfg.lts init)
+    (Iteration.omegaReachable_subset_of_isPostFixpoint
+      (postAny_collectingStep cfg.lts) init
+      (cfg.sound_reachTransfer hInit)
+      (fun h => cfg.domain.gamma_monotone h)
+      hFix)
+
+end LTSCollectingAbstraction
+
+end LTS
+end Instances
+end AbsInterp

--- a/Tests.lean
+++ b/Tests.lean
@@ -13,6 +13,7 @@ import Tests.Instances.LTS.Collecting
 import Tests.Instances.LTS.CollectingTrace
 import Tests.Instances.LTS.IntervalHook
 import Tests.Instances.LTS.SignHook
+import Tests.Instances.LTS.CollectingHook
 import Tests.Framework.Iteration.NatIter
 import Tests.Framework.Iteration.Widening
 import Tests.Framework.Semantics.AbstractOrder

--- a/Tests/Instances/LTS/CollectingHook.lean
+++ b/Tests/Instances/LTS/CollectingHook.lean
@@ -1,0 +1,153 @@
+import Cslib.Init
+import Mathlib.Data.Set.Lattice
+
+import AbsInterp
+
+namespace Tests
+namespace InstancesLTSCollectingHook
+
+open AbsInterp
+open AbsInterp.Framework
+open AbsInterp.Framework.Domains
+open AbsInterp.Framework.Iteration
+open AbsInterp.Instances.LTS
+open AbsInterp.Instances.LTS.Analyses
+
+/-!
+# CollectingHook smoke test
+
+Exercises the Session 5 LTS collecting/fixpoint bridge on a toy looping
+LTS with a constant-top abstract domain. Proves that every ω-reachable
+state of the LTS is concretized by the abstract post-fixpoint,
+using:
+
+- `LTSCollectingAbstraction` (new collecting interface)
+- `CollectingSoundOfRead` + `collectingAbstractionOfCollectingSound`
+  (new readout helper)
+- `LTSCollectingAbstraction.omegaReachableLTS_subset_of_isPostFixpoint`
+  (new LTS omega bridge)
+-/
+
+/-- Toy LTS: `0 →()→ 1`, `1 →()→ 0`. -/
+def loopLTS : Cslib.LTS Nat Unit where
+  Tr s _ s' := (s = 0 ∧ s' = 1) ∨ (s = 1 ∧ s' = 0)
+
+/-- Minimal two-element abstract domain: `bot ≤ top`. -/
+inductive Top2 where
+  | bot
+  | top
+  deriving DecidableEq, Repr
+
+namespace Top2
+
+def le : Top2 -> Top2 -> Prop
+  | .bot, _ => True
+  | .top, .top => True
+  | .top, .bot => False
+
+theorem le_refl : ∀ a : Top2, le a a := by
+  intro a; cases a <;> simp [le]
+
+theorem le_trans : ∀ {a b c : Top2}, le a b -> le b c -> le a c := by
+  intro a b c hab hbc; cases a <;> cases b <;> cases c <;> simp_all [le]
+
+theorem le_antisymm : ∀ {a b : Top2}, le a b -> le b a -> a = b := by
+  intro a b hab hba; cases a <;> cases b <;> simp_all [le]
+
+instance : PartialOrder Top2 where
+  le := le
+  le_refl := le_refl
+  le_trans := @le_trans
+  le_antisymm _ _ := le_antisymm
+
+instance : OrderTop Top2 where
+  top := .top
+  le_top a := by cases a <;> simp [LE.le, le]
+
+/-- Join: `bot ⊔ a = a`, otherwise `top`. -/
+def sup : Top2 -> Top2 -> Top2
+  | .bot, a => a
+  | a, .bot => a
+  | _, _ => .top
+
+theorem le_sup_left : ∀ a b : Top2, a ≤ sup a b := by
+  intro a b; cases a <;> cases b <;> simp [LE.le, le, sup]
+
+theorem le_sup_right : ∀ a b : Top2, b ≤ sup a b := by
+  intro a b; cases a <;> cases b <;> simp [LE.le, le, sup]
+
+theorem sup_le : ∀ {a b c : Top2}, a ≤ c -> b ≤ c -> sup a b ≤ c := by
+  intro a b c hac hbc; cases a <;> cases b <;> cases c <;> simp_all [LE.le, le, sup]
+
+instance : SemilatticeSup Top2 where
+  sup := sup
+  le_sup_left := le_sup_left
+  le_sup_right := le_sup_right
+  sup_le _ _ _ ha hb := sup_le ha hb
+
+/-- Constant-top concretization over any observation type. -/
+def gamma {Observation : Type} : Top2 -> Set Observation
+  | .bot => ∅
+  | .top => Set.univ
+
+theorem gamma_monotone {Observation : Type} :
+    ∀ ⦃a b : Top2⦄, a ≤ b -> (gamma a : Set Observation) ⊆ gamma b := by
+  intro a b hab; cases a <;> cases b <;> simp_all [LE.le, le, gamma]
+
+def concretization (Observation : Type) :
+    ConcretizationDomain Top2 Observation where
+  gamma := gamma
+  gamma_monotone := gamma_monotone
+  gamma_top _ := Set.mem_univ _
+
+end Top2
+
+/-! ## Building the collecting abstraction via the readout helper -/
+
+/-- Read states as themselves (into Nat as the observation). -/
+def readId : Nat -> Nat := fun s => s
+
+/-- Transfer: always jump to `.top`. -/
+def transferAnyToy : PostSharp Top2 := fun _ => .top
+
+/-- `transferAnyToy` is collecting-sound via readout. -/
+theorem collectingSoundToy :
+    CollectingSoundOfRead (Top2.gamma (Observation := Nat)) loopLTS readId transferAnyToy := by
+  intro a s s' _ _
+  simp [transferAnyToy, gammaStateOfRead, Top2.gamma]
+
+/-- Build the collecting abstraction via the readout helper. -/
+def toyCollecting : LTSCollectingAbstraction Nat Unit Top2 :=
+  collectingAbstractionOfCollectingSound
+    (Top2.concretization Nat) loopLTS readId transferAnyToy collectingSoundToy
+
+/-! ## Using the bridge to conclude omega-reachability safety -/
+
+/-- `.top` is a post-fixpoint of the reachability transfer. -/
+theorem toy_isPostFixpoint :
+    IsPostFixpoint (· ≤ ·) (toyCollecting.reachTransfer .top) .top := by
+  simp [IsPostFixpoint, LTSCollectingAbstraction.reachTransfer, transferAnyToy,
+        toyCollecting, collectingAbstractionOfCollectingSound]
+
+/-- Any initial concrete set is bounded by `.top`. -/
+theorem init_subset_gammaTop (init : Set Nat) :
+    init ⊆ (toyCollecting.domain.gamma .top : Set Nat) := by
+  intro s _; exact Set.mem_univ _
+
+/-- Headline: every ω-reachable state is concretized by the post-fixpoint. -/
+example :
+    omegaReachableLTS loopLTS {0} ⊆ toyCollecting.domain.gamma .top :=
+  LTSCollectingAbstraction.omegaReachableLTS_subset_of_isPostFixpoint
+    toyCollecting {0} .top .top
+    (init_subset_gammaTop {0}) toy_isPostFixpoint
+
+/-- Corollary: every finite Kleene iterate is concretized by the post-fixpoint. -/
+example :
+    ∀ n, (postAny_collectingStep loopLTS).kleeneNat {0} n ⊆
+      toyCollecting.domain.gamma .top :=
+  LTSCollectingAbstraction.kleeneNat_subset_of_isPostFixpoint
+    toyCollecting {0} .top .top
+    (init_subset_gammaTop {0}) toy_isPostFixpoint
+
+end InstancesLTSCollectingHook
+end Tests


### PR DESCRIPTION
## What changed

This PR adds a separate LTS collecting/fixpoint abstraction path alongside the existing labeled trace abstraction.

Concretely:
- added `LTSCollectingAbstraction` for unlabeled collecting semantics over `postAny`
- added `reachTransfer` and `sound_reachTransfer`
- added Session 4 bridge reuse at the LTS layer:
  - `kleeneNat_subset_of_isPostFixpoint`
  - `iUnion_kleeneNat_subset_of_isPostFixpoint`
  - `omegaReachableLTS_subset_of_isPostFixpoint`
- added a readout-based collecting helper path parallel to `StepSoundOfRead`
  - `CollectingSoundOfRead`
  - `sound_postAny_of_collectingSound`
  - `ConcretizationDomain.ofRead`
  - `collectingAbstractionOfCollectingSound`
- re-exported the new collecting interface/soundness modules from `Instances/LTS/Core`
- added `Tests/Instances/LTS/CollectingHook.lean` to exercise the new bridge on a toy looping LTS

## Why

Before this change, the repository had:
- a good LTS path for labeled step/trace soundness (`LTSAbstraction`)
- a good generic fixpoint/collecting/omega bridge from Session 4

But there was no reusable LTS-facing abstraction that connected the two for unlabeled collecting semantics. This meant the trace path was well packaged, while the collecting/fixpoint path remained more ad hoc.

This PR fills that gap without overloading `LTSAbstraction` or requiring extra assumptions like finite label enumeration.

## Impact

The LTS adapter layer now has two clear and parallel interfaces:
- labeled trace abstraction for step/trace soundness
- unlabeled collecting abstraction for reachability/fixpoint/omega reasoning

This makes the `Instances/LTS` layer a much cleaner CSLib-facing adapter on top of the framework's generic Session 4 fixpoint infrastructure.

## Validation

- `lake build`
- `lake test`
