### PR TITLE
refactor: add IMP collecting fixpoint path

### DIFF
--- a/AbsInterp/Domains/Interval.lean
+++ b/AbsInterp/Domains/Interval.lean
@@ -112,6 +112,10 @@ instance : OrderTop Interval where
   top := .top
   le_top _ := Set.subset_univ _
 
+instance : OrderBot Interval where
+  bot := .bot
+  bot_le _ := fun _ hn => by simp [gammaInterval] at hn
+
 theorem gammaInterval_monotone_of_leInterval ⦃a b : Interval⦄ (hAB : a ≤ b) :
     gammaInterval a ⊆ gammaInterval b :=
   hAB

--- a/AbsInterp/Domains/Parity.lean
+++ b/AbsInterp/Domains/Parity.lean
@@ -61,6 +61,10 @@ instance : OrderTop Parity where
   top := .top
   le_top a := by cases a <;> simp [leParity, LE.le]
 
+instance : OrderBot Parity where
+  bot := .bot
+  bot_le a := by cases a <;> simp [LE.le, leParity]
+
 theorem gammaParity_monotone : ∀ ⦃a b : Parity⦄, leParity a b → gammaParity a ⊆ gammaParity b := by
   intro a b hab; cases a <;> cases b <;> simp_all [leParity, gammaParity, Set.subset_univ]
 

--- a/AbsInterp/Domains/Sign.lean
+++ b/AbsInterp/Domains/Sign.lean
@@ -114,6 +114,10 @@ instance : OrderTop Sign where
   top := .top
   le_top _ := Set.subset_univ _
 
+instance : OrderBot Sign where
+  bot := .bot
+  bot_le _ := fun _ hn => by simp [gammaSign] at hn
+
 theorem gammaSign_monotone_of_leSign ⦃a b : Sign⦄ (hAB : a ≤ b) :
     gammaSign a ⊆ gammaSign b :=
   hAB

--- a/Examples/IMP/Analysis/Generic.lean
+++ b/Examples/IMP/Analysis/Generic.lean
@@ -2,3 +2,4 @@ import Examples.IMP.Analysis.Generic.Domain
 import Examples.IMP.Analysis.Generic.Defs
 import Examples.IMP.Analysis.Generic.Lemmas
 import Examples.IMP.Analysis.Generic.Soundness
+import Examples.IMP.Analysis.Generic.Collecting

--- a/Examples/IMP/Analysis/Generic/Collecting.lean
+++ b/Examples/IMP/Analysis/Generic/Collecting.lean
@@ -1,0 +1,375 @@
+import Cslib.Init
+import Mathlib.Data.Set.Lattice
+
+import AbsInterp.Framework
+import AbsInterp.Instances.LTS
+import Examples.IMP.Analysis.Generic.Soundness
+
+/-!
+# Generic IMP unlabeled collecting transfer
+
+Defines a generic unlabeled collecting transfer `transferAnyProgram` for a
+fixed IMP program and scalar abstract domain. The transfer over-approximates
+every `Step`-firing from any `ActiveIn` source by joining the finitely many
+labeled transfer branches that can fire at each program shape.
+
+Together with `soundAny_imp` and the
+`{kleeneNat,omegaReachableLTS}_subset_of_isPostFixpoint_imp` corollaries,
+this is the IMP adapter into the Session 4 fixpoint bridge (and parallel
+to the Session 5 `LTSCollectingAbstraction` path — see the note in
+`## Fixpoint bridge for IMP collecting soundness` below for the
+packaging trade-off).
+-/
+
+namespace Examples.IMP
+
+open AbsInterp
+open AbsInterp.Framework
+open AbsInterp.Framework.Domains
+open AbsInterp.Instances.LTS
+
+universe u
+
+variable {A : Type u} [SemilatticeSup A] [OrderTop A] [OrderBot A]
+         (d : IMPAnalysisDomain A)
+
+/-- Unlabeled collecting transfer for a fixed IMP program. -/
+def transferAnyProgram (d : IMPAnalysisDomain A) :
+    Stmt → ConfigSharp A → ConfigSharp A
+  | .skip, _ => botConfigSharp
+  | .assign x e, κ =>
+      transferProgram d (.assign x e) .assign κ
+  | .seq s1 s2, κ =>
+      joinConfig d.scalarDomain
+        (liftSeqConfig s2 (transferAnyProgram d s1 (seqView s2 κ)))
+        (joinConfig d.scalarDomain
+          (singletonConfig s2 ((seqView s2 κ) .skip))
+          (transferAnyProgram d s2 κ))
+  | .ite cond s1 s2, κ =>
+      joinConfig d.scalarDomain
+        (singletonConfig s1 (filterTrueStoreOf d cond (κ (.ite cond s1 s2))))
+        (joinConfig d.scalarDomain
+          (singletonConfig s2 (filterFalseStoreOf d cond (κ (.ite cond s1 s2))))
+          (joinConfig d.scalarDomain
+            (transferAnyProgram d s1 κ)
+            (transferAnyProgram d s2 κ)))
+  | .while cond body, κ =>
+      joinConfig d.scalarDomain
+        (singletonConfig (.seq body (.while cond body))
+          (filterTrueStoreOf d cond (κ (.while cond body))))
+        (joinConfig d.scalarDomain
+          (singletonConfig .skip (filterFalseStoreOf d cond (κ (.while cond body))))
+          (joinConfig d.scalarDomain
+            (liftSeqConfig (.while cond body)
+              (transferAnyProgram d body (seqView (.while cond body) κ)))
+            (singletonConfig (.while cond body)
+              ((seqView (.while cond body) κ) .skip))))
+
+/-- Package the unlabeled collecting transfer as a framework one-step transformer. -/
+def impCollectingTransfer (d : IMPAnalysisDomain A) (program : Stmt) :
+    PostSharp (ConfigSharp A) :=
+  transferAnyProgram d program
+
+set_option linter.unusedSectionVars false in
+/-- `liftSeqConfig` is monotone in its config argument. -/
+theorem liftSeqConfig_mono {s2 : Stmt} {κ₁ κ₂ : ConfigSharp A}
+    (h : κ₁ ≤ κ₂) : liftSeqConfig s2 κ₁ ≤ liftSeqConfig s2 κ₂ := by
+  intro s x
+  cases s with
+  | skip => exact le_refl _
+  | assign _ _ => exact le_refl _
+  | ite _ _ _ => exact le_refl _
+  | «while» _ _ => exact le_refl _
+  | seq s s2' =>
+      by_cases hEq : s2' = s2
+      · subst hEq
+        simp only [liftSeqConfig, if_true]
+        exact h s x
+      · simp [liftSeqConfig, hEq]
+
+/--
+Coverage lemma: the labeled transfer `transferProgram d program μ κ` is
+pointwise `≤` the unlabeled collecting transfer `transferAnyProgram d program κ`.
+Proved by structural induction on `program` with case analysis on `μ`.
+-/
+theorem transferProgram_le_transferAnyProgram :
+    ∀ (program : Stmt) (μ : StepLabel) (κ : ConfigSharp A),
+      transferProgram d program μ κ ≤ transferAnyProgram d program κ := by
+  intro program
+  induction program with
+  | skip =>
+      intro μ κ
+      cases μ <;> simp [transferProgram, transferAnyProgram]
+  | assign x e =>
+      intro μ κ
+      cases μ with
+      | assign => simp [transferProgram, transferAnyProgram]
+      | seqStep _ | seqDone | ifTrue | ifFalse | whileTrue | whileFalse =>
+          intro s y
+          simp [transferProgram, transferAnyProgram, botConfigSharp, botStoreSharp]
+  | seq s1 s2 ih1 ih2 =>
+      intro μ κ
+      cases μ with
+      | assign =>
+          intro s y
+          simp only [transferProgram]
+          have h := ih2 .assign κ s y
+          refine le_trans h ?_
+          simp only [transferAnyProgram, joinConfig]
+          exact le_sup_of_le_right (le_sup_of_le_right (le_refl _))
+      | ifTrue =>
+          intro s y
+          simp only [transferProgram]
+          have h := ih2 .ifTrue κ s y
+          refine le_trans h ?_
+          simp only [transferAnyProgram, joinConfig]
+          exact le_sup_of_le_right (le_sup_of_le_right (le_refl _))
+      | ifFalse =>
+          intro s y
+          simp only [transferProgram]
+          have h := ih2 .ifFalse κ s y
+          refine le_trans h ?_
+          simp only [transferAnyProgram, joinConfig]
+          exact le_sup_of_le_right (le_sup_of_le_right (le_refl _))
+      | whileTrue =>
+          intro s y
+          simp only [transferProgram]
+          have h := ih2 .whileTrue κ s y
+          refine le_trans h ?_
+          simp only [transferAnyProgram, joinConfig]
+          exact le_sup_of_le_right (le_sup_of_le_right (le_refl _))
+      | whileFalse =>
+          intro s y
+          simp only [transferProgram]
+          have h := ih2 .whileFalse κ s y
+          refine le_trans h ?_
+          simp only [transferAnyProgram, joinConfig]
+          exact le_sup_of_le_right (le_sup_of_le_right (le_refl _))
+      | seqDone =>
+          -- transferProgram = joinConfig (singletonConfig s2 ((seqView s2 κ) .skip)) (transferProgram d s2 .seqDone κ)
+          -- transferAnyProgram = joinConfig (liftSeqConfig s2 (transferAnyProgram d s1 (seqView s2 κ))) (joinConfig (singletonConfig s2 ((seqView s2 κ) .skip)) (transferAnyProgram d s2 κ))
+          intro s y
+          simp only [transferProgram, transferAnyProgram, joinConfig]
+          refine sup_le ?_ ?_
+          · -- singletonConfig piece: directly a component of transferAnyProgram
+            exact le_sup_of_le_right (le_sup_of_le_left (le_refl _))
+          · -- transferProgram d s2 .seqDone κ ≤ transferAnyProgram d s2 κ by IH ≤ the right join
+            have h := ih2 .seqDone κ s y
+            refine le_trans h ?_
+            exact le_sup_of_le_right (le_sup_of_le_right (le_refl _))
+      | seqStep μ' =>
+          -- transferProgram = joinConfig (liftSeqConfig s2 (transferProgram d s1 μ' (seqView s2 κ))) (transferProgram d s2 (.seqStep μ') κ)
+          -- transferAnyProgram = joinConfig (liftSeqConfig s2 (transferAnyProgram d s1 (seqView s2 κ))) (...)
+          intro s y
+          simp only [transferProgram, transferAnyProgram, joinConfig]
+          refine sup_le ?_ ?_
+          · -- liftSeqConfig monotonicity + IH on s1
+            have hs1 := ih1 μ' (seqView s2 κ)
+            have hLift := liftSeqConfig_mono (s2 := s2) hs1 s y
+            refine le_trans hLift ?_
+            exact le_sup_of_le_left (le_refl _)
+          · have h := ih2 (.seqStep μ') κ s y
+            refine le_trans h ?_
+            exact le_sup_of_le_right (le_sup_of_le_right (le_refl _))
+  | ite cond s1 s2 ih1 ih2 =>
+      intro μ κ
+      cases μ with
+      | ifTrue =>
+          intro s y
+          simp only [transferProgram, transferAnyProgram, joinConfig]
+          refine sup_le ?_ (sup_le ?_ ?_)
+          · exact le_sup_of_le_left (le_refl _)
+          · have h := ih1 .ifTrue κ s y
+            refine le_trans h ?_
+            exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_left (le_refl _)))
+          · have h := ih2 .ifTrue κ s y
+            refine le_trans h ?_
+            exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_right (le_refl _)))
+      | ifFalse =>
+          intro s y
+          simp only [transferProgram, transferAnyProgram, joinConfig]
+          refine sup_le ?_ (sup_le ?_ ?_)
+          · exact le_sup_of_le_right (le_sup_of_le_left (le_refl _))
+          · have h := ih1 .ifFalse κ s y
+            refine le_trans h ?_
+            exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_left (le_refl _)))
+          · have h := ih2 .ifFalse κ s y
+            refine le_trans h ?_
+            exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_right (le_refl _)))
+      | assign =>
+          intro s y
+          simp only [transferProgram, transferAnyProgram, joinConfig]
+          refine sup_le ?_ ?_
+          · have h := ih1 .assign κ s y
+            refine le_trans h ?_
+            exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_left (le_refl _)))
+          · have h := ih2 .assign κ s y
+            refine le_trans h ?_
+            exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_right (le_refl _)))
+      | seqStep μ' =>
+          intro s y
+          simp only [transferProgram, transferAnyProgram, joinConfig]
+          refine sup_le ?_ ?_
+          · have h := ih1 (.seqStep μ') κ s y
+            refine le_trans h ?_
+            exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_left (le_refl _)))
+          · have h := ih2 (.seqStep μ') κ s y
+            refine le_trans h ?_
+            exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_right (le_refl _)))
+      | seqDone =>
+          intro s y
+          simp only [transferProgram, transferAnyProgram, joinConfig]
+          refine sup_le ?_ ?_
+          · have h := ih1 .seqDone κ s y
+            refine le_trans h ?_
+            exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_left (le_refl _)))
+          · have h := ih2 .seqDone κ s y
+            refine le_trans h ?_
+            exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_right (le_refl _)))
+      | whileTrue =>
+          intro s y
+          simp only [transferProgram, transferAnyProgram, joinConfig]
+          refine sup_le ?_ ?_
+          · have h := ih1 .whileTrue κ s y
+            refine le_trans h ?_
+            exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_left (le_refl _)))
+          · have h := ih2 .whileTrue κ s y
+            refine le_trans h ?_
+            exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_right (le_refl _)))
+      | whileFalse =>
+          intro s y
+          simp only [transferProgram, transferAnyProgram, joinConfig]
+          refine sup_le ?_ ?_
+          · have h := ih1 .whileFalse κ s y
+            refine le_trans h ?_
+            exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_left (le_refl _)))
+          · have h := ih2 .whileFalse κ s y
+            refine le_trans h ?_
+            exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_right (le_refl _)))
+  | «while» cond body ih =>
+      intro μ κ
+      cases μ with
+      | whileTrue =>
+          intro s y
+          simp only [transferProgram, transferAnyProgram, joinConfig]
+          exact le_sup_of_le_left (le_refl _)
+      | whileFalse =>
+          intro s y
+          simp only [transferProgram, transferAnyProgram, joinConfig]
+          exact le_sup_of_le_right (le_sup_of_le_left (le_refl _))
+      | seqDone =>
+          intro s y
+          simp only [transferProgram, transferAnyProgram, joinConfig]
+          exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_right (le_refl _)))
+      | seqStep μ' =>
+          intro s y
+          have hBody := ih μ' (seqView (.while cond body) κ)
+          have hLift := liftSeqConfig_mono (s2 := .while cond body) hBody s y
+          simp only [transferProgram, transferAnyProgram, joinConfig]
+          refine le_trans hLift ?_
+          exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_left (le_refl _)))
+      | assign | ifTrue | ifFalse =>
+          intro s y
+          simp only [transferProgram, transferAnyProgram, botConfigSharp, botStoreSharp]
+          exact bot_le
+
+/--
+Monotonicity of `gammaProgram` in the abstract-configuration argument.
+-/
+theorem gammaProgram_monotone {κ₁ κ₂ : ConfigSharp A} (hLe : κ₁ ≤ κ₂) (program : Stmt) :
+    gammaProgram d program κ₁ ⊆ gammaProgram d program κ₂ := by
+  rintro c ⟨hActive, hConf⟩
+  refine ⟨hActive, ?_⟩
+  exact (configConcretizationDomain d.scalarDomain).gamma_monotone hLe hConf
+
+/--
+Generic IMP collecting soundness: the unlabeled collecting transfer
+`transferAnyProgram` soundly over-approximates `postAny impLTS` w.r.t.
+`gammaProgram`.
+-/
+theorem soundAny_imp (program : Stmt) :
+    Sound (postAny impLTS) (gammaProgram d program) (transferAnyProgram d program) := by
+  intro κ c' hc'
+  rcases (mem_postAny (lts := impLTS) (states := gammaProgram d program κ)
+    (s' := c')).1 hc' with ⟨c, hc, μ, htr⟩
+  rcases c with ⟨source, σ⟩
+  rcases c' with ⟨target, σ'⟩
+  rcases hc with ⟨hActive, hStore⟩
+  have hLabeled : (target, σ') ∈ gammaProgram d program (transferProgram d program μ κ) :=
+    localStepSoundOfActive d hActive hStore htr
+  exact gammaProgram_monotone d
+    (transferProgram_le_transferAnyProgram d program μ κ) program hLabeled
+
+/-! ## Fixpoint bridge for IMP collecting soundness
+
+`gammaProgram d program` is a `Concretization`, not a `ConcretizationDomain`
+(it carries an `ActiveIn` constraint that rules out `gamma_top`). We therefore
+package the IMP-side collecting bridge as direct specialisations of the
+framework theorems `Iteration.omegaReachable_subset_of_isPostFixpoint` and
+`Iteration.kleeneNat_subset_of_isPostFixpoint`, rather than as a strict
+`LTSCollectingAbstraction`.
+-/
+
+/-- The reach transfer over the generic IMP collecting transfer. -/
+def impReachTransfer (d : IMPAnalysisDomain A) (program : Stmt)
+    (initAbs : ConfigSharp A) : PostSharp (ConfigSharp A) :=
+  fun a => initAbs ⊔ transferAnyProgram d program a
+
+/--
+Soundness of the IMP reach transfer with an abstract initial over-approximation.
+
+Whenever a concrete initial set is bounded by `gammaProgram d program initAbs`,
+the reach transfer `initAbs ⊔ transferAnyProgram d program ·` is sound w.r.t.
+the collecting step `reachF init` on `postAny_collectingStep impLTS`.
+-/
+theorem sound_impReachTransfer
+    (program : Stmt)
+    {init : Set Config} {initAbs : ConfigSharp A}
+    (hInit : init ⊆ gammaProgram d program initAbs) :
+    Sound ((postAny_collectingStep impLTS).reachF init)
+      (gammaProgram d program)
+      (impReachTransfer d program initAbs) := by
+  intro a c hc
+  rcases hc with hInitMem | hPostMem
+  · -- init contribution
+    have hLeft : initAbs ≤ impReachTransfer d program initAbs a := by
+      intro s x; exact le_sup_of_le_left (le_refl _)
+    exact gammaProgram_monotone d hLeft program (hInit hInitMem)
+  · -- postAny contribution
+    have hSound : c ∈ gammaProgram d program (transferAnyProgram d program a) :=
+      soundAny_imp d program a hPostMem
+    have hRight : transferAnyProgram d program a ≤ impReachTransfer d program initAbs a := by
+      intro s x; exact le_sup_of_le_right (le_refl _)
+    exact gammaProgram_monotone d hRight program hSound
+
+/-- Specialisation of the generic Kleene-iterate bridge to IMP. -/
+theorem kleeneNat_subset_of_isPostFixpoint_imp
+    (program : Stmt)
+    (init : Set Config) (initAbs a : ConfigSharp A)
+    (hInit : init ⊆ gammaProgram d program initAbs)
+    (hFix : AbsInterp.Framework.Iteration.IsPostFixpoint (· ≤ ·)
+      (impReachTransfer d program initAbs) a) :
+    ∀ n, (postAny_collectingStep impLTS).kleeneNat init n ⊆ gammaProgram d program a :=
+  AbsInterp.Framework.Iteration.kleeneNat_subset_of_isPostFixpoint
+    (postAny_collectingStep impLTS) init
+    (sound_impReachTransfer d program hInit)
+    (fun h => gammaProgram_monotone d h program)
+    hFix
+
+/-- Specialisation of the generic ω-reachable bridge to IMP. -/
+theorem omegaReachableLTS_subset_of_isPostFixpoint_imp
+    (program : Stmt)
+    (init : Set Config) (initAbs a : ConfigSharp A)
+    (hInit : init ⊆ gammaProgram d program initAbs)
+    (hFix : AbsInterp.Framework.Iteration.IsPostFixpoint (· ≤ ·)
+      (impReachTransfer d program initAbs) a) :
+    omegaReachableLTS impLTS init ⊆ gammaProgram d program a :=
+  Set.Subset.trans
+    (omegaReachableLTS_subset_omegaReachable impLTS init)
+    (AbsInterp.Framework.Iteration.omegaReachable_subset_of_isPostFixpoint
+      (postAny_collectingStep impLTS) init
+      (sound_impReachTransfer d program hInit)
+      (fun h => gammaProgram_monotone d h program)
+      hFix)
+
+end Examples.IMP

--- a/Examples/IMP/Analysis/Generic/Collecting.lean
+++ b/Examples/IMP/Analysis/Generic/Collecting.lean
@@ -40,30 +40,22 @@ def transferAnyProgram (d : IMPAnalysisDomain A) :
   | .assign x e, κ =>
       transferProgram d (.assign x e) .assign κ
   | .seq s1 s2, κ =>
-      joinConfig d.scalarDomain
-        (liftSeqConfig s2 (transferAnyProgram d s1 (seqView s2 κ)))
-        (joinConfig d.scalarDomain
-          (singletonConfig s2 ((seqView s2 κ) .skip))
-          (transferAnyProgram d s2 κ))
+      liftSeqConfig s2 (transferAnyProgram d s1 (seqView s2 κ)) ⊔
+        (singletonConfig s2 ((seqView s2 κ) .skip) ⊔
+          transferAnyProgram d s2 κ)
   | .ite cond s1 s2, κ =>
-      joinConfig d.scalarDomain
-        (singletonConfig s1 (filterTrueStoreOf d cond (κ (.ite cond s1 s2))))
-        (joinConfig d.scalarDomain
-          (singletonConfig s2 (filterFalseStoreOf d cond (κ (.ite cond s1 s2))))
-          (joinConfig d.scalarDomain
-            (transferAnyProgram d s1 κ)
-            (transferAnyProgram d s2 κ)))
+      singletonConfig s1 (filterTrueStoreOf d cond (κ (.ite cond s1 s2))) ⊔
+        (singletonConfig s2 (filterFalseStoreOf d cond (κ (.ite cond s1 s2))) ⊔
+          (transferAnyProgram d s1 κ ⊔
+            transferAnyProgram d s2 κ))
   | .while cond body, κ =>
-      joinConfig d.scalarDomain
-        (singletonConfig (.seq body (.while cond body))
-          (filterTrueStoreOf d cond (κ (.while cond body))))
-        (joinConfig d.scalarDomain
-          (singletonConfig .skip (filterFalseStoreOf d cond (κ (.while cond body))))
-          (joinConfig d.scalarDomain
-            (liftSeqConfig (.while cond body)
-              (transferAnyProgram d body (seqView (.while cond body) κ)))
-            (singletonConfig (.while cond body)
-              ((seqView (.while cond body) κ) .skip))))
+      singletonConfig (.seq body (.while cond body))
+          (filterTrueStoreOf d cond (κ (.while cond body))) ⊔
+        (singletonConfig .skip (filterFalseStoreOf d cond (κ (.while cond body))) ⊔
+          (liftSeqConfig (.while cond body)
+            (transferAnyProgram d body (seqView (.while cond body) κ)) ⊔
+            singletonConfig (.while cond body)
+              ((seqView (.while cond body) κ) .skip)))
 
 /-- Package the unlabeled collecting transfer as a framework one-step transformer. -/
 def impCollectingTransfer (d : IMPAnalysisDomain A) (program : Stmt) :
@@ -115,41 +107,41 @@ theorem transferProgram_le_transferAnyProgram :
           simp only [transferProgram]
           have h := ih2 .assign κ s y
           refine le_trans h ?_
-          simp only [transferAnyProgram, joinConfig]
+          simp only [transferAnyProgram]
           exact le_sup_of_le_right (le_sup_of_le_right (le_refl _))
       | ifTrue =>
           intro s y
           simp only [transferProgram]
           have h := ih2 .ifTrue κ s y
           refine le_trans h ?_
-          simp only [transferAnyProgram, joinConfig]
+          simp only [transferAnyProgram]
           exact le_sup_of_le_right (le_sup_of_le_right (le_refl _))
       | ifFalse =>
           intro s y
           simp only [transferProgram]
           have h := ih2 .ifFalse κ s y
           refine le_trans h ?_
-          simp only [transferAnyProgram, joinConfig]
+          simp only [transferAnyProgram]
           exact le_sup_of_le_right (le_sup_of_le_right (le_refl _))
       | whileTrue =>
           intro s y
           simp only [transferProgram]
           have h := ih2 .whileTrue κ s y
           refine le_trans h ?_
-          simp only [transferAnyProgram, joinConfig]
+          simp only [transferAnyProgram]
           exact le_sup_of_le_right (le_sup_of_le_right (le_refl _))
       | whileFalse =>
           intro s y
           simp only [transferProgram]
           have h := ih2 .whileFalse κ s y
           refine le_trans h ?_
-          simp only [transferAnyProgram, joinConfig]
+          simp only [transferAnyProgram]
           exact le_sup_of_le_right (le_sup_of_le_right (le_refl _))
       | seqDone =>
           -- transferProgram = joinConfig (singletonConfig s2 ((seqView s2 κ) .skip)) (transferProgram d s2 .seqDone κ)
           -- transferAnyProgram = joinConfig (liftSeqConfig s2 (transferAnyProgram d s1 (seqView s2 κ))) (joinConfig (singletonConfig s2 ((seqView s2 κ) .skip)) (transferAnyProgram d s2 κ))
           intro s y
-          simp only [transferProgram, transferAnyProgram, joinConfig]
+          simp only [transferProgram, transferAnyProgram]
           refine sup_le ?_ ?_
           · -- singletonConfig piece: directly a component of transferAnyProgram
             exact le_sup_of_le_right (le_sup_of_le_left (le_refl _))
@@ -161,7 +153,7 @@ theorem transferProgram_le_transferAnyProgram :
           -- transferProgram = joinConfig (liftSeqConfig s2 (transferProgram d s1 μ' (seqView s2 κ))) (transferProgram d s2 (.seqStep μ') κ)
           -- transferAnyProgram = joinConfig (liftSeqConfig s2 (transferAnyProgram d s1 (seqView s2 κ))) (...)
           intro s y
-          simp only [transferProgram, transferAnyProgram, joinConfig]
+          simp only [transferProgram, transferAnyProgram]
           refine sup_le ?_ ?_
           · -- liftSeqConfig monotonicity + IH on s1
             have hs1 := ih1 μ' (seqView s2 κ)
@@ -176,7 +168,7 @@ theorem transferProgram_le_transferAnyProgram :
       cases μ with
       | ifTrue =>
           intro s y
-          simp only [transferProgram, transferAnyProgram, joinConfig]
+          simp only [transferProgram, transferAnyProgram]
           refine sup_le ?_ (sup_le ?_ ?_)
           · exact le_sup_of_le_left (le_refl _)
           · have h := ih1 .ifTrue κ s y
@@ -187,7 +179,7 @@ theorem transferProgram_le_transferAnyProgram :
             exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_right (le_refl _)))
       | ifFalse =>
           intro s y
-          simp only [transferProgram, transferAnyProgram, joinConfig]
+          simp only [transferProgram, transferAnyProgram]
           refine sup_le ?_ (sup_le ?_ ?_)
           · exact le_sup_of_le_right (le_sup_of_le_left (le_refl _))
           · have h := ih1 .ifFalse κ s y
@@ -198,7 +190,7 @@ theorem transferProgram_le_transferAnyProgram :
             exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_right (le_refl _)))
       | assign =>
           intro s y
-          simp only [transferProgram, transferAnyProgram, joinConfig]
+          simp only [transferProgram, transferAnyProgram]
           refine sup_le ?_ ?_
           · have h := ih1 .assign κ s y
             refine le_trans h ?_
@@ -208,7 +200,7 @@ theorem transferProgram_le_transferAnyProgram :
             exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_right (le_refl _)))
       | seqStep μ' =>
           intro s y
-          simp only [transferProgram, transferAnyProgram, joinConfig]
+          simp only [transferProgram, transferAnyProgram]
           refine sup_le ?_ ?_
           · have h := ih1 (.seqStep μ') κ s y
             refine le_trans h ?_
@@ -218,7 +210,7 @@ theorem transferProgram_le_transferAnyProgram :
             exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_right (le_refl _)))
       | seqDone =>
           intro s y
-          simp only [transferProgram, transferAnyProgram, joinConfig]
+          simp only [transferProgram, transferAnyProgram]
           refine sup_le ?_ ?_
           · have h := ih1 .seqDone κ s y
             refine le_trans h ?_
@@ -228,7 +220,7 @@ theorem transferProgram_le_transferAnyProgram :
             exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_right (le_refl _)))
       | whileTrue =>
           intro s y
-          simp only [transferProgram, transferAnyProgram, joinConfig]
+          simp only [transferProgram, transferAnyProgram]
           refine sup_le ?_ ?_
           · have h := ih1 .whileTrue κ s y
             refine le_trans h ?_
@@ -238,7 +230,7 @@ theorem transferProgram_le_transferAnyProgram :
             exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_right (le_refl _)))
       | whileFalse =>
           intro s y
-          simp only [transferProgram, transferAnyProgram, joinConfig]
+          simp only [transferProgram, transferAnyProgram]
           refine sup_le ?_ ?_
           · have h := ih1 .whileFalse κ s y
             refine le_trans h ?_
@@ -251,21 +243,21 @@ theorem transferProgram_le_transferAnyProgram :
       cases μ with
       | whileTrue =>
           intro s y
-          simp only [transferProgram, transferAnyProgram, joinConfig]
+          simp only [transferProgram, transferAnyProgram]
           exact le_sup_of_le_left (le_refl _)
       | whileFalse =>
           intro s y
-          simp only [transferProgram, transferAnyProgram, joinConfig]
+          simp only [transferProgram, transferAnyProgram]
           exact le_sup_of_le_right (le_sup_of_le_left (le_refl _))
       | seqDone =>
           intro s y
-          simp only [transferProgram, transferAnyProgram, joinConfig]
+          simp only [transferProgram, transferAnyProgram]
           exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_right (le_refl _)))
       | seqStep μ' =>
           intro s y
           have hBody := ih μ' (seqView (.while cond body) κ)
           have hLift := liftSeqConfig_mono (s2 := .while cond body) hBody s y
-          simp only [transferProgram, transferAnyProgram, joinConfig]
+          simp only [transferProgram, transferAnyProgram]
           refine le_trans hLift ?_
           exact le_sup_of_le_right (le_sup_of_le_right (le_sup_of_le_left (le_refl _)))
       | assign | ifTrue | ifFalse =>
@@ -332,14 +324,12 @@ theorem sound_impReachTransfer
   intro a c hc
   rcases hc with hInitMem | hPostMem
   · -- init contribution
-    have hLeft : initAbs ≤ impReachTransfer d program initAbs a := by
-      intro s x; exact le_sup_of_le_left (le_refl _)
+    have hLeft : initAbs ≤ impReachTransfer d program initAbs a := le_sup_left
     exact gammaProgram_monotone d hLeft program (hInit hInitMem)
   · -- postAny contribution
     have hSound : c ∈ gammaProgram d program (transferAnyProgram d program a) :=
       soundAny_imp d program a hPostMem
-    have hRight : transferAnyProgram d program a ≤ impReachTransfer d program initAbs a := by
-      intro s x; exact le_sup_of_le_right (le_refl _)
+    have hRight : transferAnyProgram d program a ≤ impReachTransfer d program initAbs a := le_sup_right
     exact gammaProgram_monotone d hRight program hSound
 
 /-- Specialisation of the generic Kleene-iterate bridge to IMP. -/

--- a/Examples/IMP/Analysis/Interval/Defs.lean
+++ b/Examples/IMP/Analysis/Interval/Defs.lean
@@ -69,4 +69,41 @@ def impIntervalAbstraction (program : Stmt) :
     LTSAbstraction Config StepLabel (ConfigSharp Interval) :=
   impAbstraction intervalAnalysisDomain program
 
+/-! ## Collecting/fixpoint path -/
+
+/-- Unlabeled collecting transfer specialized to the Interval IMP analysis. -/
+def impIntervalCollectingTransfer (program : Stmt) :
+    PostSharp (ConfigSharp Interval) :=
+  impCollectingTransfer intervalAnalysisDomain program
+
+/-- Generic Interval IMP collecting soundness (unlabeled `postAny`). -/
+theorem soundAny_impInterval (program : Stmt) :
+    Sound (postAny impLTS) (gammaProgramInterval program) (impIntervalCollectingTransfer program) :=
+  soundAny_imp intervalAnalysisDomain program
+
+/-- Reach transfer over Interval IMP collecting, for a given abstract initial value. -/
+def impIntervalReachTransfer (program : Stmt) (initAbs : ConfigSharp Interval) :
+    PostSharp (ConfigSharp Interval) :=
+  impReachTransfer intervalAnalysisDomain program initAbs
+
+/-- Interval specialisation of the generic IMP ω-reachable bridge. -/
+theorem omegaReachableLTS_subset_of_isPostFixpoint_impInterval
+    (program : Stmt) (init : Set Config)
+    (initAbs a : ConfigSharp Interval)
+    (hInit : init ⊆ gammaProgramInterval program initAbs)
+    (hFix : AbsInterp.Framework.Iteration.IsPostFixpoint (· ≤ ·)
+      (impIntervalReachTransfer program initAbs) a) :
+    omegaReachableLTS impLTS init ⊆ gammaProgramInterval program a :=
+  omegaReachableLTS_subset_of_isPostFixpoint_imp intervalAnalysisDomain program init initAbs a hInit hFix
+
+/-- Interval specialisation of the generic IMP Kleene-iterate bridge. -/
+theorem kleeneNat_subset_of_isPostFixpoint_impInterval
+    (program : Stmt) (init : Set Config)
+    (initAbs a : ConfigSharp Interval)
+    (hInit : init ⊆ gammaProgramInterval program initAbs)
+    (hFix : AbsInterp.Framework.Iteration.IsPostFixpoint (· ≤ ·)
+      (impIntervalReachTransfer program initAbs) a) :
+    ∀ n, (postAny_collectingStep impLTS).kleeneNat init n ⊆ gammaProgramInterval program a :=
+  kleeneNat_subset_of_isPostFixpoint_imp intervalAnalysisDomain program init initAbs a hInit hFix
+
 end Examples.IMP

--- a/Examples/IMP/Analysis/Parity/Defs.lean
+++ b/Examples/IMP/Analysis/Parity/Defs.lean
@@ -60,4 +60,41 @@ def impParityAbstraction (program : Stmt) :
     LTSAbstraction Config StepLabel (ConfigSharp Parity) :=
   impAbstraction parityAnalysisDomain program
 
+/-! ## Collecting/fixpoint path -/
+
+/-- Unlabeled collecting transfer specialized to the Parity IMP analysis. -/
+def impParityCollectingTransfer (program : Stmt) :
+    PostSharp (ConfigSharp Parity) :=
+  impCollectingTransfer parityAnalysisDomain program
+
+/-- Generic Parity IMP collecting soundness (unlabeled `postAny`). -/
+theorem soundAny_impParity (program : Stmt) :
+    Sound (postAny impLTS) (gammaProgramParity program) (impParityCollectingTransfer program) :=
+  soundAny_imp parityAnalysisDomain program
+
+/-- Reach transfer over Parity IMP collecting, for a given abstract initial value. -/
+def impParityReachTransfer (program : Stmt) (initAbs : ConfigSharp Parity) :
+    PostSharp (ConfigSharp Parity) :=
+  impReachTransfer parityAnalysisDomain program initAbs
+
+/-- Parity specialisation of the generic IMP ω-reachable bridge. -/
+theorem omegaReachableLTS_subset_of_isPostFixpoint_impParity
+    (program : Stmt) (init : Set Config)
+    (initAbs a : ConfigSharp Parity)
+    (hInit : init ⊆ gammaProgramParity program initAbs)
+    (hFix : AbsInterp.Framework.Iteration.IsPostFixpoint (· ≤ ·)
+      (impParityReachTransfer program initAbs) a) :
+    omegaReachableLTS impLTS init ⊆ gammaProgramParity program a :=
+  omegaReachableLTS_subset_of_isPostFixpoint_imp parityAnalysisDomain program init initAbs a hInit hFix
+
+/-- Parity specialisation of the generic IMP Kleene-iterate bridge. -/
+theorem kleeneNat_subset_of_isPostFixpoint_impParity
+    (program : Stmt) (init : Set Config)
+    (initAbs a : ConfigSharp Parity)
+    (hInit : init ⊆ gammaProgramParity program initAbs)
+    (hFix : AbsInterp.Framework.Iteration.IsPostFixpoint (· ≤ ·)
+      (impParityReachTransfer program initAbs) a) :
+    ∀ n, (postAny_collectingStep impLTS).kleeneNat init n ⊆ gammaProgramParity program a :=
+  kleeneNat_subset_of_isPostFixpoint_imp parityAnalysisDomain program init initAbs a hInit hFix
+
 end Examples.IMP

--- a/Examples/IMP/Analysis/Sign/Defs.lean
+++ b/Examples/IMP/Analysis/Sign/Defs.lean
@@ -79,4 +79,41 @@ def impSignAbstraction (program : Stmt) :
     LTSAbstraction Config StepLabel (ConfigSharp Sign) :=
   impAbstraction signAnalysisDomain program
 
+/-! ## Collecting/fixpoint path -/
+
+/-- Unlabeled collecting transfer specialized to the Sign IMP analysis. -/
+def impSignCollectingTransfer (program : Stmt) :
+    PostSharp (ConfigSharp Sign) :=
+  impCollectingTransfer signAnalysisDomain program
+
+/-- Generic Sign IMP collecting soundness (unlabeled `postAny`). -/
+theorem soundAny_impSign (program : Stmt) :
+    Sound (postAny impLTS) (gammaProgramSign program) (impSignCollectingTransfer program) :=
+  soundAny_imp signAnalysisDomain program
+
+/-- Reach transfer over Sign IMP collecting, for a given abstract initial value. -/
+def impSignReachTransfer (program : Stmt) (initAbs : ConfigSharp Sign) :
+    PostSharp (ConfigSharp Sign) :=
+  impReachTransfer signAnalysisDomain program initAbs
+
+/-- Sign specialisation of the generic IMP ω-reachable bridge. -/
+theorem omegaReachableLTS_subset_of_isPostFixpoint_impSign
+    (program : Stmt) (init : Set Config)
+    (initAbs a : ConfigSharp Sign)
+    (hInit : init ⊆ gammaProgramSign program initAbs)
+    (hFix : AbsInterp.Framework.Iteration.IsPostFixpoint (· ≤ ·)
+      (impSignReachTransfer program initAbs) a) :
+    omegaReachableLTS impLTS init ⊆ gammaProgramSign program a :=
+  omegaReachableLTS_subset_of_isPostFixpoint_imp signAnalysisDomain program init initAbs a hInit hFix
+
+/-- Sign specialisation of the generic IMP Kleene-iterate bridge. -/
+theorem kleeneNat_subset_of_isPostFixpoint_impSign
+    (program : Stmt) (init : Set Config)
+    (initAbs a : ConfigSharp Sign)
+    (hInit : init ⊆ gammaProgramSign program initAbs)
+    (hFix : AbsInterp.Framework.Iteration.IsPostFixpoint (· ≤ ·)
+      (impSignReachTransfer program initAbs) a) :
+    ∀ n, (postAny_collectingStep impLTS).kleeneNat init n ⊆ gammaProgramSign program a :=
+  kleeneNat_subset_of_isPostFixpoint_imp signAnalysisDomain program init initAbs a hInit hFix
+
 end Examples.IMP

--- a/Examples/IMP/Programs.lean
+++ b/Examples/IMP/Programs.lean
@@ -2,6 +2,7 @@ import Examples.IMP.Programs.Tutorial
 import Examples.IMP.Programs.Showcase
 import Examples.IMP.Programs.WidenShowcase
 import Examples.IMP.Programs.LoopShowcase
+import Examples.IMP.Programs.CollectingShowcase
 
 /-!
 Program-level demonstrations for the IMP example suite.
@@ -10,4 +11,6 @@ Program-level demonstrations for the IMP example suite.
 - `Showcase`: the main generic IMP case study over the canonical IMP LTS
 - `WidenShowcase`: widening-based Interval analysis over a while loop
 - `LoopShowcase`: Sign analysis of a countdown loop with concrete exit property
+- `CollectingShowcase`: IMP consumer of the Session 4/5 collecting/fixpoint
+  bridge via `impSignCollectingAbstraction`
 -/

--- a/Examples/IMP/Programs/CollectingShowcase.lean
+++ b/Examples/IMP/Programs/CollectingShowcase.lean
@@ -1,0 +1,95 @@
+import Examples.IMP.Analysis.Sign
+import Examples.IMP.Analysis.Interval
+
+/-!
+# IMP Collecting/Fixpoint Showcase
+
+Canonical IMP case study for the generic collecting/fixpoint path. Unlike
+`LoopShowcase` and `WidenShowcase`, this file consumes the Session 4/5
+bridge infrastructure end-to-end:
+
+- builds on `impSignCollectingTransfer` and `impSignReachTransfer`
+- discharges a post-fixpoint at the abstract level
+- concludes an ω-reachability safety property via
+  `omegaReachableLTS_subset_of_isPostFixpoint_impSign`
+
+The showcase uses a simple always-looping program (`while 1 do skip`) so
+that the concrete set of ω-executions is non-trivial. The post-fixpoint is
+the pointwise-top abstract state, which is valid without computing a
+tighter invariant. The conclusion is a genuine control-flow property:
+
+> every ω-reachable state has a control location that is active in the
+> source program (i.e., executions do not escape the program's structure).
+
+This exercises the whole Session 4/5 bridge through the IMP adapter layer
+without requiring a hand-computed non-trivial post-fixpoint.
+-/
+
+namespace Examples.IMP.Programs
+namespace CollectingShowcase
+
+open AbsInterp
+open AbsInterp.Domains
+open AbsInterp.Framework
+open AbsInterp.Framework.Iteration
+open AbsInterp.Instances.LTS
+open Examples.IMP
+
+/-- Always-looping IMP program: `while 1 do skip`. -/
+def program : Stmt := .while (.lit 1) .skip
+
+/-- Initial concrete state set: configs starting at the program's entry. -/
+def init : Set Config := { c | controlOfConfig c = program }
+
+/-- Pointwise-top abstract post-fixpoint. -/
+def fix : ConfigSharp Sign := fun _ _ => ⊤
+
+/-- The top fix over-approximates the initial set. -/
+theorem init_subset_gamma :
+    init ⊆ gammaProgramSign program fix := by
+  rintro ⟨s, σ⟩ hc
+  have hS : s = program := hc
+  subst hS
+  refine ⟨ActiveIn.self _, ?_⟩
+  intro _
+  exact Set.mem_univ _
+
+/-- `fix` is a post-fixpoint of the Sign reach transfer with initAbs = fix. -/
+theorem fix_isPostFixpoint :
+    IsPostFixpoint (· ≤ ·) (impSignReachTransfer program fix) fix := by
+  intro s x
+  exact le_top
+
+/--
+Headline: every ω-reachable state from the initial set has an
+`ActiveIn`-valid control location.
+
+Proof route:
+  `init ⊆ gammaProgramSign program fix`
+  + `fix` is a post-fixpoint
+  →  (via `omegaReachableLTS_subset_of_isPostFixpoint_impSign`)
+  →  `omegaReachableLTS impLTS init ⊆ gammaProgramSign program fix`
+  →  extract the `ActiveIn` component.
+-/
+theorem omega_active_control :
+    ∀ c ∈ omegaReachableLTS impLTS init,
+      ActiveIn program (controlOfConfig c) := by
+  intro c hc
+  have hGamma : c ∈ gammaProgramSign program fix :=
+    omegaReachableLTS_subset_of_isPostFixpoint_impSign
+      program init fix fix init_subset_gamma fix_isPostFixpoint hc
+  exact hGamma.1
+
+/-- Kleene corollary: every finite Kleene iterate stays within the program's
+control structure. -/
+theorem kleeneNat_active_control :
+    ∀ n, ∀ c ∈ (postAny_collectingStep impLTS).kleeneNat init n,
+      ActiveIn program (controlOfConfig c) := by
+  intro n c hc
+  have hGamma : c ∈ gammaProgramSign program fix :=
+    kleeneNat_subset_of_isPostFixpoint_impSign
+      program init fix fix init_subset_gamma fix_isPostFixpoint n hc
+  exact hGamma.1
+
+end CollectingShowcase
+end Examples.IMP.Programs


### PR DESCRIPTION
## Summary
- add a generic IMP unlabeled collecting transfer and fixpoint bridge theorems
- expose thin Sign/Interval/Parity collecting-path wrappers
- add a canonical IMP collecting showcase using the generic omega/Kleene bridge

## Validation
- lake build
- lake build Tests
- lake test