### PR TITLE
docs: add Verso site and stronger collecting showcase

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -1,0 +1,65 @@
+name: Docs Site
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Single in-flight deploy, cancel stale runs on the same ref.
+concurrency:
+  group: docs-site-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: site
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Lean toolchain
+        uses: leanprover/lean-action@v1
+        with:
+          lake-package-directory: site
+
+      - name: Resolve Verso dependency
+        run: lake update verso
+
+      - name: Build documentation site
+        run: lake exe site
+
+      - name: Build slide deck
+        run: lake exe slides
+
+      - name: Collect publishable HTML
+        run: |
+          mkdir -p _publish
+          # Site (multi-page HTML) becomes the root of the deployed site.
+          cp -R _out/html-multi/. _publish/
+          # Slides ship as a single-file deck under /slides/.
+          mkdir -p _publish/slides
+          cp -R _out/slides/html-single/. _publish/slides/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/_publish
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 /N40AI.pdf
 
 .vscode/
+
+# Nested Verso documentation project build artifacts.
+/site/.lake
+/site/lake-manifest.json
+/site/_out
+/site/_publish

--- a/Examples/IMP/Programs/CollectingShowcase.lean
+++ b/Examples/IMP/Programs/CollectingShowcase.lean
@@ -4,25 +4,35 @@ import Examples.IMP.Analysis.Interval
 /-!
 # IMP Collecting/Fixpoint Showcase
 
-Canonical IMP case study for the generic collecting/fixpoint path. Unlike
-`LoopShowcase` and `WidenShowcase`, this file consumes the Session 4/5
-bridge infrastructure end-to-end:
+Canonical IMP consumer of the Session 4/5 collecting/fixpoint bridge.
 
-- builds on `impSignCollectingTransfer` and `impSignReachTransfer`
-- discharges a post-fixpoint at the abstract level
-- concludes an ω-reachability safety property via
-  `omegaReachableLTS_subset_of_isPostFixpoint_impSign`
+This file exercises the generic IMP collecting path end-to-end via the
+Interval domain, proving a real **value** invariant — every ω-reachable
+state of the flagship program has `x0 = 5` at the loop head — rather
+than a purely structural `ActiveIn` statement.
 
-The showcase uses a simple always-looping program (`while 1 do skip`) so
-that the concrete set of ω-executions is non-trivial. The post-fixpoint is
-the pointwise-top abstract state, which is valid without computing a
-tighter invariant. The conclusion is a genuine control-flow property:
+## Program
 
-> every ω-reachable state has a control location that is active in the
-> source program (i.e., executions do not escape the program's structure).
+```imp
+x0 := 5 ;;
+while x0 do
+  x0 := x0 + 0
+```
 
-This exercises the whole Session 4/5 bridge through the IMP adapter layer
-without requiring a hand-computed non-trivial post-fixpoint.
+## Proof outline
+
+1. Hand-write a `ConfigSharp Interval` post-fixpoint `fix` that assigns
+   the exact interval `[5, 5]` to `x0` at every loop-related active
+   control location and `⊤` elsewhere.
+2. Show `init ⊆ gammaProgramInterval program fix` (the initial set's
+   control is `program`, where `fix = ⊤`).
+3. Prove `fix` is a post-fixpoint of `impIntervalReachTransfer program fix`
+   by direct pointwise case analysis on every (control, variable) pair.
+4. Feed the pieces into
+   `omegaReachableLTS_subset_of_isPostFixpoint_impInterval` to obtain
+   the headline value invariant.
+
+The proof is axiom-clean: it does not use `native_decide`.
 -/
 
 namespace Examples.IMP.Programs
@@ -35,60 +45,154 @@ open AbsInterp.Framework.Iteration
 open AbsInterp.Instances.LTS
 open Examples.IMP
 
-/-- Always-looping IMP program: `while 1 do skip`. -/
-def program : Stmt := .while (.lit 1) .skip
+/-! ## Program components -/
 
-/-- Initial concrete state set: configs starting at the program's entry. -/
+/-- Loop body: `x0 := x0 + 0`. -/
+def body : Stmt := .assign Var.x0 (.add (.var Var.x0) (.lit 0))
+
+/-- Loop: `while x0 do x0 := x0 + 0`. -/
+def wloop : Stmt := .while (.var Var.x0) body
+
+/-- Flagship program: `x0 := 5 ;; while x0 do x0 := x0 + 0`. -/
+def program : Stmt := .seq (.assign Var.x0 (.lit 5)) wloop
+
+/-- Initial concrete set: configs starting at the program's entry. -/
 def init : Set Config := { c | controlOfConfig c = program }
 
-/-- Pointwise-top abstract post-fixpoint. -/
-def fix : ConfigSharp Sign := fun _ _ => ⊤
+/-! ## Candidate post-fixpoint -/
 
-/-- The top fix over-approximates the initial set. -/
-theorem init_subset_gamma :
-    init ⊆ gammaProgramSign program fix := by
+/--
+Abstract state mapping every loop-related active control to the exact
+interval `[5, 5]` for `x0` and `⊤` for every other variable/control.
+-/
+def fix : ConfigSharp Interval := fun s x =>
+  if s = .seq .skip wloop ∨ s = wloop ∨ s = .seq body wloop then
+    if x = Var.x0 then AbsInterp.Domains.mk 5 5 else ⊤
+  else
+    ⊤
+
+@[simp] private theorem fix_B_x0 :
+    fix (.seq .skip wloop) Var.x0 = AbsInterp.Domains.mk 5 5 := by
+  simp [fix]
+
+@[simp] private theorem fix_C_x0 :
+    fix wloop Var.x0 = AbsInterp.Domains.mk 5 5 := by
+  simp [fix, wloop, body]
+
+@[simp] private theorem fix_D_x0 :
+    fix (.seq body wloop) Var.x0 = AbsInterp.Domains.mk 5 5 := by
+  simp [fix, wloop, body]
+
+/-! ## Initial coverage -/
+
+theorem init_subset_gamma : init ⊆ gammaProgramInterval program fix := by
   rintro ⟨s, σ⟩ hc
   have hS : s = program := hc
   subst hS
   refine ⟨ActiveIn.self _, ?_⟩
-  intro _
-  exact Set.mem_univ _
+  intro y
+  have hNotLoop :
+      ¬ (program = .seq .skip wloop ∨ program = wloop ∨ program = .seq body wloop) := by
+    intro hOr
+    rcases hOr with h | h | h <;> simp [program, wloop, body] at h
+  have hFix : fix program y = ⊤ := by simp [fix, hNotLoop]
+  show σ y ∈ gammaInterval (fix program y)
+  rw [hFix]
+  exact gammaInterval_top (σ y)
 
-/-- `fix` is a post-fixpoint of the Sign reach transfer with initAbs = fix. -/
+/-! ## Computing `transferAnyProgram` at the relevant pointwise nodes
+
+The generic `transferAnyProgram` for our flagship program evaluates
+pointwise at the three `x0`-tracked loop controls to the exact
+interval `[5, 5]`. We unfold by structural reduction + `Pi.sup_apply`
+and then use the `intervalAnalysisDomain` capability instances'
+computation rules (all `rfl`-based) to discharge leaves.
+-/
+
+/-- `transferAnyProgram ... fix` at `(.seq .skip wloop, Var.x0)` equals `mk 5 5`. -/
+private theorem transferAny_at_B_x0 :
+    transferAnyProgram intervalAnalysisDomain program fix (.seq .skip wloop) Var.x0 =
+      AbsInterp.Domains.mk 5 5 := by
+  simp only [program, wloop, body, transferAnyProgram, transferProgram,
+             liftSeqConfig, singletonConfig,
+             seqView, evalExpr, Pi.sup_apply]
+  rfl
+
+/-- `transferAnyProgram ... fix` at `(wloop, Var.x0)` equals `mk 5 5`. -/
+private theorem transferAny_at_C_x0 :
+    transferAnyProgram intervalAnalysisDomain program fix wloop Var.x0 =
+      AbsInterp.Domains.mk 5 5 := by
+  simp only [program, wloop, body, transferAnyProgram, transferProgram,
+             liftSeqConfig, singletonConfig,
+             seqView, evalExpr, Pi.sup_apply]
+  rfl
+
+/-- `transferAnyProgram ... fix` at `(.seq body wloop, Var.x0)` equals `mk 5 5`. -/
+private theorem transferAny_at_D_x0 :
+    transferAnyProgram intervalAnalysisDomain program fix (.seq body wloop) Var.x0 =
+      AbsInterp.Domains.mk 5 5 := by
+  simp only [program, wloop, body, transferAnyProgram, transferProgram,
+             liftSeqConfig, singletonConfig,
+             seqView, evalExpr, Pi.sup_apply]
+  rfl
+
+/-! ## Post-fixpoint theorem -/
+
 theorem fix_isPostFixpoint :
-    IsPostFixpoint (· ≤ ·) (impSignReachTransfer program fix) fix := by
+    IsPostFixpoint (· ≤ ·) (impIntervalReachTransfer program fix) fix := by
   intro s x
-  exact le_top
+  show (impIntervalReachTransfer program fix fix) s x ≤ fix s x
+  show (fix ⊔ transferAnyProgram intervalAnalysisDomain program fix) s x ≤ fix s x
+  show fix s x ⊔ transferAnyProgram intervalAnalysisDomain program fix s x ≤ fix s x
+  refine sup_le le_rfl ?_
+  by_cases hx : x = Var.x0
+  swap
+  · have : fix s x = ⊤ := by simp [fix, hx]
+    rw [this]; exact le_top
+  subst hx
+  by_cases hLoop : s = .seq .skip wloop ∨ s = wloop ∨ s = .seq body wloop
+  swap
+  · have : fix s Var.x0 = ⊤ := by simp [fix, hLoop]
+    rw [this]; exact le_top
+  rcases hLoop with hB | hC | hD
+  · subst hB
+    rw [transferAny_at_B_x0, fix_B_x0]
+  · subst hC
+    rw [transferAny_at_C_x0, fix_C_x0]
+  · subst hD
+    rw [transferAny_at_D_x0, fix_D_x0]
+
+/-! ## Headline value invariant -/
 
 /--
-Headline: every ω-reachable state from the initial set has an
-`ActiveIn`-valid control location.
-
-Proof route:
-  `init ⊆ gammaProgramSign program fix`
-  + `fix` is a post-fixpoint
-  →  (via `omegaReachableLTS_subset_of_isPostFixpoint_impSign`)
-  →  `omegaReachableLTS impLTS init ⊆ gammaProgramSign program fix`
-  →  extract the `ActiveIn` component.
+Value invariant: every ω-reachable state with control at the while head
+`wloop` has `x0 = 5`.
 -/
-theorem omega_active_control :
+theorem x0_eq_5_at_wloop (σ : Store)
+    (hOmega : (wloop, σ) ∈ omegaReachableLTS impLTS init) :
+    σ Var.x0 = 5 := by
+  have hGamma : (wloop, σ) ∈ gammaProgramInterval program fix :=
+    omegaReachableLTS_subset_of_isPostFixpoint_impInterval
+      program init fix fix init_subset_gamma fix_isPostFixpoint hOmega
+  have hStore := hGamma.2
+  have hx0 : σ Var.x0 ∈ gammaInterval (fix wloop Var.x0) := hStore Var.x0
+  rw [fix_C_x0] at hx0
+  have hBounds := (mem_gammaInterval_mk_iff 5 5 (σ Var.x0)).mp hx0
+  omega
+
+/-! ## Legacy `ActiveIn`-only corollary
+
+The earlier, weaker showcase stayed at the control-flow level. It still
+compiles as a secondary smoke test.
+-/
+
+theorem legacy_omega_active_control :
     ∀ c ∈ omegaReachableLTS impLTS init,
       ActiveIn program (controlOfConfig c) := by
   intro c hc
-  have hGamma : c ∈ gammaProgramSign program fix :=
-    omegaReachableLTS_subset_of_isPostFixpoint_impSign
+  have hGamma : c ∈ gammaProgramInterval program fix :=
+    omegaReachableLTS_subset_of_isPostFixpoint_impInterval
       program init fix fix init_subset_gamma fix_isPostFixpoint hc
-  exact hGamma.1
-
-/-- Kleene corollary: every finite Kleene iterate stays within the program's
-control structure. -/
-theorem kleeneNat_active_control :
-    ∀ n, ∀ c ∈ (postAny_collectingStep impLTS).kleeneNat init n,
-      ActiveIn program (controlOfConfig c) := by
-  intro n c hc
-  have hGamma : c ∈ gammaProgramSign program fix :=
-    kleeneNat_subset_of_isPostFixpoint_impSign
-      program init fix fix init_subset_gamma fix_isPostFixpoint n hc
   exact hGamma.1
 
 end CollectingShowcase

--- a/README.md
+++ b/README.md
@@ -7,23 +7,34 @@ The project has two linked goals:
 
 1. Build a reusable abstract interpretation framework in Lean 4, centered on
    CSLib's labeled transition system view of semantics.
-2. Validate that framework on a small but nontrivial language by implementing a
-   generic abstract interpreter for loop-free IMP over the canonical IMP LTS.
+2. Validate that framework on a small but nontrivial language by implementing
+   generic IMP adapters and case studies over the canonical IMP LTS, covering
+   both labeled trace soundness and unlabeled collecting/fixpoint reasoning.
 
 The long-term direction is to mature the reusable pieces toward upstream CSLib
 contribution, rather than treating this repository as a one-off example dump.
 
+For a layered design overview — goals, design principles, dependency structure,
+IMP's role as a validation adapter, and the upstream boundary — see
+[`docs/architecture.md`](docs/architecture.md).
+
+A web version of the architecture note, a reading guide, and a
+minimal talk deck live in the nested Verso project at [`site/`](site/).
+See [`site/README.md`](site/README.md) for local build instructions
+and the GitHub Pages publication path.
+
 ## What is in place
 
-- A reusable `gamma`-only domain interface, following the soundness-first
-  approach from Leroy's N40AI notes.
-- A framework layer for concrete/abstract transformers, trace lifting, and
-  soundness from one-step transformers to traces.
-- A CSLib-LTS instantiation layer that packages those abstractions for labeled
-  transition systems.
-- Concrete Sign and Interval domains.
-- A loop-free IMP example suite whose main case study is a generic Sign
-  analysis over the canonical labeled IMP LTS.
+- A reusable `ConcretizationDomain` kernel plus a capability layer
+  (`BottomConcretization`, `MeetLike`, `FilterOperator`,
+  `RelationalBackwardOperator`, transfer capabilities).
+- A framework layer for concrete/abstract transformers, trace lifting,
+  collecting semantics, fixpoint bridges, and widening.
+- A CSLib-LTS instantiation layer for both labeled trace abstractions and
+  unlabeled collecting abstractions.
+- Concrete Sign, Interval, and Parity domains.
+- An IMP example suite that exercises both the labeled trace path and the
+  collecting/fixpoint path, including a stronger Interval collecting showcase.
 
 ## Repository map
 
@@ -38,7 +49,10 @@ contribution, rather than treating this repository as a one-off example dump.
 - `Examples/IMP`
   IMP example suite.
   The main path is:
-  `Syntax`/`Semantics`/`LTS` -> `Analysis/Sign` -> `Programs/Showcase`.
+  `Syntax`/`Semantics`/`LTS`
+  -> `Analysis/Generic`
+  -> domain wrappers
+  -> `Programs/{Showcase,CollectingShowcase}`.
   Tutorial mini-examples live under `Programs/Tutorial`.
 - `Tests`
   Smoke tests and theorem-level regression checks across framework, domains,
@@ -49,8 +63,10 @@ contribution, rather than treating this repository as a one-off example dump.
 - Start with `AbsInterp/Framework` if you want the reusable theory.
 - Read `AbsInterp/Instances/LTS` next to see how the framework is connected
   to CSLib-style LTS semantics.
-- Read `Examples/IMP/Analysis/Sign` and `Examples/IMP/Programs/Showcase` for
-  the flagship end-to-end case study.
+- Read `Examples/IMP/Analysis/Generic`, then `Examples/IMP/Analysis/Sign` or
+  `Examples/IMP/Analysis/Interval`, and then
+  `Examples/IMP/Programs/{Showcase,CollectingShowcase}` for the flagship
+  end-to-end case studies.
 - Read `Examples/IMP/Programs/Tutorial` only if you want the smaller teaching
   examples first.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,290 @@
+# Architecture Note: Layered Abstract Interpretation over CSLib-style LTS
+
+`absinterp` is a Lean 4 repository for reusable abstract-interpretation
+infrastructure organized as a small stack of layers over CSLib-style labeled
+transition systems. IMP serves as the main validation case study, not as the
+primary artifact. The long-term direction is to mature the lower layers into
+contributions to `leanprover/cslib`.
+
+## 1. Goals
+
+Two linked goals drive the project.
+
+**Build a reusable AI framework in Lean 4.** The target is reusable theory and
+infrastructure — semantic transformers, soundness interfaces, iteration
+scaffolding, and LTS-facing adapters — that another language or another abstract
+domain can plug into without re-proving boilerplate. The design is
+soundness-first: every abstract operation comes with a concretization-level
+soundness obligation, and trace/collecting/omega soundness is derived from
+one-step obligations via generic theorems.
+
+**Validate that framework on a non-trivial but manageable language.** IMP plays
+that role. The IMP case study exercises the labeled trace path
+(`soundStep → soundTrace`), the unlabeled collecting/fixpoint path
+(`postAny → reachF → kleeneNat → omegaReachable`), and the widening iteration
+interface. If the framework breaks or is awkward, the IMP path is where the
+friction surfaces first.
+
+Two explicit non-goals: no Galois connection is required (the project stays
+γ-only), and no ambition to ship an industrial IMP analyzer. The value lives in
+the reusable layers below `Examples/IMP`.
+
+## 2. Design principles
+
+**Soundness first.** Every abstract operation is accompanied by a
+concretization-level soundness statement. `Tests/Axioms.lean` pins the axiom
+footprint of thirteen upstream-candidate declarations to `propext`, `Quot.sound`,
+`Classical.choice` via `#guard_msgs`, and the build enforces this. Computation-
+heavy showcases that use `native_decide` are explicitly quarantined outside
+that path.
+
+**Keep the semantic kernel small.** The core interface, `ConcretizationDomain`,
+carries only `gamma`, `gamma_monotone`, and `gamma_top`. Anything else is
+either derived from these (join soundness) or packaged as an opt-in capability.
+A minimal kernel is what lets the same framework host simple domains like
+`Sign`, lattice-structured domains like `Interval`, and potential relational
+domains in the future without forcing structure none of them naturally carry.
+
+**Separate domain meaning from analysis operations.** `ConcretizationDomain`
+says *what the abstract values mean*. Filters, backward operators, and binary
+transfers live above that, as explicit capabilities. The benefit is
+composability: a language adapter picks exactly the capabilities it needs, and
+every capability carries its own soundness law. A two-domain analysis, or a
+relational analysis that doesn't want `filterNonzero`, doesn't have to fake one.
+
+**Keep framework core and language adapters structurally separate.**
+`AbsInterp/Framework` cannot import from `Instances/` or `Examples/`.
+`Instances/LTS` cannot import `Examples/`. IMP-specific arithmetic —
+`IMPAnalysisDomain`, `transferProgram`, `gammaProgram` — lives entirely in the
+`Examples/IMP` adapter and cannot leak upward.
+
+**Do not force more algebraic structure than necessary in the core.**
+Deliberate examples: join soundness is a generic theorem from `SemilatticeSup`
+plus `gamma_monotone`, not a structure field. Meet is expressed as `MeetLike`
+(binary soundness + reductiveness) instead of a full lattice `Inf`. This keeps
+domains with asymmetric join/meet — or domains that only need a single
+combinator — admissible as first-class citizens.
+
+**Keep collecting/fixpoint reasoning parallel to the labeled trace path.** The
+labeled path (`LTSAbstraction`, `soundTraceLifted`) and the unlabeled
+collecting/fixpoint path (`LTSCollectingAbstraction`,
+`omegaReachableLTS_subset_of_isPostFixpoint`) are deliberately independent
+structures. A labeled transfer (`Label → Abstract → Abstract`) has more
+information than an unlabeled collecting transfer (`Abstract → Abstract`), and
+deriving one from the other requires assumptions (finite label enumeration,
+abstract aggregation) that only some clients can pay. Splitting the interfaces
+reflects that.
+
+## 3. Layered architecture
+
+The repository is organized as a strict, one-directional stack. Every layer
+depends only on layers below it.
+
+**Layer 1 — Semantic core.** `AbsInterp/Framework/Concretization.lean` and
+`AbsInterp/Framework/Domains/Concretization.lean`. Defines `Concretization` (a
+plain function type) and `ConcretizationDomain` (the three-field contract). The
+generic theorem `gamma_union_subset_sup` lives here: join soundness follows
+from `gamma_monotone` and `SemilatticeSup`. This is the only layer all other
+layers depend on.
+
+**Layer 2 — Domain capabilities.** `AbsInterp/Framework/Domains/Capabilities.lean`
+and siblings. `BottomConcretization`, `PointAbstraction`, `UnaryTransfer`,
+`BinaryTransfer`, `MeetLike`, `FilterOperator`, `RelationalBackwardOperator`.
+Each capability bundles a function with its soundness obligation (and
+reductiveness where applicable). A domain picks the capabilities it actually
+satisfies; it does not have to commit to all of them. The `AbsInterp/Domains`
+instances (`Sign`, `Parity`, `Interval`) show the intended shape.
+
+**Layer 3 — Generic soundness and iteration.**
+`AbsInterp/Framework/Soundness/`, `AbsInterp/Framework/Iteration/NatIter.lean`,
+`Iteration/Collecting.lean`, `Iteration/Fixpoint/`, `Iteration/Widening/`.
+Contains:
+
+- trace lifting (`soundTrace_of_soundStep`, `liftTracePost`/`liftTracePostSharp`);
+- collecting semantics (`CollectingStep`, `reachF`, `kleeneNat`) and
+  `omegaReachable`;
+- the generic fixpoint bridge (`IsPostFixpoint`,
+  `sound_iterateNat_from_init_of_isPostFixpoint`, the
+  `*_subset_of_isPostFixpoint` specialisations to `kleeneNat` and
+  `omegaReachable`);
+- the widening engine (`Widen`, `WidenUpperBound`, `WAcc`, `witer`, `pfp`,
+  `isPostFixpoint_pfp`).
+
+Everything in Layer 3 is LTS-agnostic and language-agnostic. The split of
+`IsPostFixpoint` out of `Widening/` was deliberate: post-fixpoint soundness is
+not a widening concept, and the collecting/omega corollaries reuse it without
+pulling in `WAcc`.
+
+**Layer 4 — CSLib LTS adapters.** `AbsInterp/Instances/LTS`. Wraps CSLib's
+`LTS`/`MTr`/`ωTr`/`HasTau` into the framework's vocabulary.
+
+- `LTSAbstraction` packages a CSLib LTS with a labeled `transfer : Label →
+  Abstract → Abstract`, a step-soundness proof, and the derived
+  `soundTraceLifted` theorem.
+- `LTSCollectingAbstraction` is the *parallel* collecting interface: it carries
+  an unlabeled `transferAny`, a `ConcretizationDomain`, and a soundness proof
+  for `postAny`. It provides the reach-transfer and the headline
+  `omegaReachableLTS_subset_of_isPostFixpoint` bridge.
+- `Analyses/Common.lean` hosts the readout-based helpers
+  (`StepSoundOfRead`/`CollectingSoundOfRead`) so domain-specific hooks can
+  build either abstraction from a state-observation function.
+
+**Layer 5 — IMP adapters and case studies.** `Examples/IMP`.
+
+- `IMPAnalysisDomain` is the IMP-specific capability bundle (arithmetic
+  transfers, branch filters, backward operators).
+- The labeled path: `transferProgram`, `soundStep_imp`, `impAbstraction`, with
+  thin wrappers in `Analysis/{Sign,Interval,Parity}/Defs.lean`.
+- The collecting path: `transferAnyProgram`, `soundAny_imp`,
+  `impCollectingTransfer`, `impReachTransfer`, and the
+  `{kleeneNat,omegaReachableLTS}_subset_of_isPostFixpoint_imp{Sign,Interval,Parity}`
+  corollaries.
+- Programs: `Showcase` (labeled Sign trace analysis), `LoopShowcase`,
+  `WidenShowcase`, and `CollectingShowcase` (the Interval `x0 = 5` value
+  invariant consumer of the Session 4/5 bridge).
+
+The dependency direction is strict. Layer 5 sits above Layer 4, which sits
+above Layer 3, and so on. Nothing in Layer 4 or below mentions IMP.
+
+## 4. Why the current interfaces look the way they do
+
+**`ConcretizationDomain` replaced an earlier `GammaOnlyDomain`.** The old
+interface tried to fold join behaviour into the domain structure. In practice,
+join soundness is a theorem from `gamma_monotone` plus an existing `Sup`
+instance, so stored fields just duplicated Mathlib's lattice hierarchy.
+`ConcretizationDomain` is now the narrowest thing that *must* be true, and
+`SemilatticeSup`/`OrderTop` come from Mathlib instances on each concrete
+domain. Join soundness is derived, not stored.
+
+**`MeetLike` is a capability, not a fully-fledged lattice `Inf`.** Some domains
+have a natural meet that isn't the lattice infimum (`intersectParity`);
+others may want a combinator that is reductive but not idempotent. Treating
+meet as a capability captures exactly the property the IMP transfer actually
+needs (`refineAddStore` for `x = x` case) without imposing a lattice
+obligation the domain might not carry cleanly.
+
+**Filter and backward operators are capabilities, not core fields.** A
+domain can instantiate `ConcretizationDomain` without a branch filter; a
+language whose condition language never refines an abstract value doesn't need
+to fake one. By contrast, the labeled `transferProgram` recursion *does* need a
+filter for `.ite` and `.while`, so it demands `FilterOperator` at the
+adapter level, not at the core.
+
+**Collecting/fixpoint abstraction is a separate structure from
+`LTSAbstraction`.** `LTSAbstraction` takes a labeled transfer and targets
+trace soundness. `LTSCollectingAbstraction` takes an unlabeled transfer and
+targets reachability/fixpoints. Overloading would have required injecting
+either finite-label enumeration or abstract aggregation into the core; both
+assumptions are real costs that not every language can pay.
+
+**`gammaProgram` is deliberately *not* a `ConcretizationDomain`.** The IMP
+concretization is program-relative: it carries an `ActiveIn program`
+constraint on the control location. That constraint is what lets
+`soundStep_imp` avoid having to handle arbitrary non-active control states.
+But `ConcretizationDomain.gamma_top` requires `∀ c, c ∈ gamma ⊤`, which would
+force program-irrelevant configurations back into scope. Instead, IMP provides
+its bridge theorems (`kleeneNat_subset_of_isPostFixpoint_imp`,
+`omegaReachableLTS_subset_of_isPostFixpoint_imp`) as direct specialisations of
+the framework-level fixpoint theorems that accept a plain `Concretization` plus
+`gamma_monotone`. The spec's preferred "literal `LTSCollectingAbstraction`
+value for IMP" is not realisable without either subtyping `Config` to active
+configurations or weakening the framework interface; neither is worth it for
+the benefit.
+
+**Axiom-cleanliness is a first-class constraint.** The upstream-candidate path
+stays on `propext`, `Quot.sound`, `Classical.choice`. `native_decide` (which
+introduces `Lean.ofReduceBool` and `Lean.trustCompiler`) is confined to
+validation computations in showcases and tests. The newest IMP
+`CollectingShowcase` proves `x0 = 5` at the loop head via a hand-written
+post-fixpoint precisely so the flagship collecting invariant stays in the
+axiom-clean region.
+
+## 5. Case-study role of IMP
+
+IMP is a validation adapter, not the product. Its job is to exercise every
+reusable layer end-to-end and to be specific enough that the framework's
+genericity can be measured.
+
+- **Labeled trace path.** `soundStep_impSign` combines with
+  `LTSAbstraction.soundTraceLifted` to yield `SoundTrace` for the Sign
+  analysis, consumed in `Programs/Showcase.lean`.
+- **Unlabeled collecting/fixpoint path.** `soundAny_imp` plus the generic
+  fixpoint bridge gives `omegaReachableLTS_subset_of_isPostFixpoint_imp`.
+  `Programs/CollectingShowcase.lean` proves a genuine value invariant
+  (`x0 = 5` at the while head of `x0 := 5;; while x0 do x0 := x0 + 0`) through
+  this path.
+- **Widening path.** `Programs/WidenShowcase.lean` exercises the widening
+  interface (`WidenUpperBound`, `WAcc`, `pfp`, `isPostFixpoint_pfp`) on an
+  Interval analysis.
+- **Tutorial examples.** `Programs/Tutorial/` contains small standalone LTSs
+  for readers who want to understand the interfaces without the full IMP LTS.
+
+IMP's arithmetic specificity is tolerated because it lives strictly above the
+reusable layers. No IMP identifier appears in `AbsInterp/Framework` or
+`AbsInterp/Instances/LTS`.
+
+## 6. Upstream boundary
+
+These pieces are realistic CSLib upstream candidates once packaged:
+
+- `Concretization`, `ConcretizationDomain`, `gamma_union_subset_sup`;
+- the capability layer (`BottomConcretization`, `MeetLike`, `PointAbstraction`,
+  `FilterOperator`, `RelationalBackwardOperator`, `UnaryTransfer`,
+  `BinaryTransfer`);
+- generic soundness infrastructure (`Sound`, `SoundStep`, `SoundTrace`,
+  `soundTrace_of_soundStep`, `liftTrace`/`liftTracePost`);
+- iteration scaffolding (`iterateNat`, `CollectingStep`, `reachF`, `kleeneNat`,
+  `omegaReachable_subset_iUnion_kleeneNat`);
+- the fixpoint/widening layer (`IsPostFixpoint`,
+  `sound_iterateNat_from_init_of_isPostFixpoint`,
+  `*_subset_of_isPostFixpoint`, `Widen`, `WidenUpperBound`, `WAcc`, `witer`,
+  `pfp`, `isPostFixpoint_pfp`);
+- the CSLib LTS adapter layer (`LTSAbstraction`, `LTSCollectingAbstraction`,
+  `soundTraceLifted`, `omegaReachableLTS_subset_omegaReachable`,
+  `CollectingSoundOfRead` / `StepSoundOfRead`).
+
+These pieces should stay local to this repository:
+
+- the IMP syntax, semantics, and `impLTS`;
+- `IMPAnalysisDomain` and its per-domain instances;
+- `transferProgram`/`transferAnyProgram` and their program-relative soundness
+  theorems;
+- program-specific showcases (`Showcase`, `LoopShowcase`, `WidenShowcase`,
+  `CollectingShowcase`);
+- tutorial LTSs.
+
+The split is principled: anything that mentions IMP, IMP arithmetic, or a
+specific program belongs above the framework boundary.
+
+## 7. Current limitations and future work
+
+- **Proof robustness.** Some collecting showcase proofs rely on structural
+  unfolding of `transferAnyProgram`; if it migrates to well-founded recursion,
+  those `rfl` finishers need explicit equation rewrites.
+- **Domain coverage.** Only Sign, Parity, and Interval are packaged. Relational
+  domains (congruences, pairwise difference) are natural next targets and
+  would stress the kernel's minimality.
+- **Widening and solver stories.** Widening is wired on simple finite flat
+  lattices; realistic config-level widening (`IntervalConfigSharp`) and
+  narrowing are not yet packaged as reusable solver combinators.
+- **Weak/τ path.** `Weak`/`HasTau` support exists but has not been exercised in
+  an end-to-end case study at the collecting/omega layer.
+- **Upstream packaging.** Namespaces, docstrings, and Mathlib-style linting
+  still need a sweep before a serious first CSLib PR.
+
+## 8. Repository map
+
+- `AbsInterp/Framework` — Layers 1–3 (semantic kernel, capabilities, generic
+  soundness, iteration, fixpoint, widening).
+- `AbsInterp/Instances/LTS` — Layer 4 (CSLib LTS adapters, including both
+  labeled trace and unlabeled collecting interfaces).
+- `AbsInterp/Domains` — concrete scalar domains (`Sign`, `Parity`, `Interval`)
+  with their capability instances.
+- `Examples/IMP` — Layer 5 (IMP adapter, per-domain instances, programs).
+- `Tests` — regression tests, axiom guards, and framework-level smoke tests.
+
+Start from `AbsInterp/Framework/Domains/Concretization.lean` if you want the
+semantic kernel; from `AbsInterp/Instances/LTS/Instantiation/CollectingInterface.lean`
+if you want the CSLib integration; from
+`Examples/IMP/Programs/CollectingShowcase.lean` if you want to see the full
+pipeline land on a concrete value invariant.

--- a/site/AbsinterpDocs.lean
+++ b/site/AbsinterpDocs.lean
@@ -1,0 +1,1 @@
+import AbsinterpDocs.Basic

--- a/site/AbsinterpDocs/Architecture.lean
+++ b/site/AbsinterpDocs/Architecture.lean
@@ -1,0 +1,155 @@
+import VersoManual
+
+open Verso.Genre Manual
+
+#doc (Manual) "Architecture" =>
+%%%
+tag := "architecture"
+%%%
+
+This chapter adapts `docs/architecture.md` for web browsing. Read the
+original alongside the source tree for the fullest picture.
+
+# Goals
+
+Two linked goals drive the project.
+
+- *Build a reusable AI framework in Lean 4.* The target is reusable
+  theory and infrastructure — semantic transformers, soundness interfaces,
+  iteration scaffolding, and LTS-facing adapters — that another language
+  or another abstract domain can plug into without re-proving boilerplate.
+  The design is soundness-first.
+- *Validate that framework on a non-trivial but manageable language.*
+  IMP plays that role. The IMP case study exercises the labeled trace
+  path, the unlabeled collecting/fixpoint path, and the widening
+  iteration interface.
+
+The project is γ-only: no Galois connection is required. There is no
+ambition to ship an industrial IMP analyzer — the value lives in the
+reusable layers below `Examples/IMP`.
+
+# Design principles
+
+- *Soundness first.* Every abstract operation carries a
+  concretization-level soundness proof. `Tests/Axioms.lean` fixes the
+  axiom footprint of the upstream-candidate path at compile time.
+- *Keep the semantic kernel small.* `ConcretizationDomain` carries
+  only `gamma`, `gamma_monotone`, and `gamma_top`. Anything derivable is
+  a theorem, not a stored field.
+- *Separate meaning from operations.* `ConcretizationDomain` says
+  *what the abstract values mean*. Filters, backward operators, and
+  binary transfers are opt-in capabilities above the kernel.
+- *Keep framework and adapters structurally separate.*
+  `AbsInterp/Framework` cannot import from `Instances/` or `Examples/`.
+  `Instances/LTS` cannot import `Examples/`.
+- *Parallel trace and collecting paths.* The labeled trace path and
+  the unlabeled collecting/fixpoint path are deliberately independent
+  structures, because deriving one from the other would require
+  assumptions (finite label enumeration, abstract aggregation) that only
+  some clients can pay.
+
+# Layered architecture
+
+The repository is a strict, one-directional stack.
+
+: Layer 1 — Semantic core
+
+  `Concretization` (a plain function) and `ConcretizationDomain` (the
+  three-field contract). Defines the minimum data required for
+  soundness. Contains the generic theorem `gamma_union_subset_sup`.
+
+: Layer 2 — Domain capabilities
+
+  `BottomConcretization`, `PointAbstraction`, `UnaryTransfer`,
+  `BinaryTransfer`, `MeetLike`, `FilterOperator`,
+  `RelationalBackwardOperator`. Each capability bundles a function with
+  its soundness obligation. A domain picks the capabilities it
+  genuinely satisfies.
+
+: Layer 3 — Generic soundness and iteration
+
+  Trace lifting (`soundTrace_of_soundStep`), collecting semantics
+  (`CollectingStep`, `reachF`, `kleeneNat`, `omegaReachable`), the
+  generic fixpoint bridge (`IsPostFixpoint`,
+  `sound_iterateNat_from_init_of_isPostFixpoint`,
+  `*_subset_of_isPostFixpoint`), and the widening engine
+  (`Widen`, `WidenUpperBound`, `WAcc`, `witer`, `pfp`). All
+  LTS-agnostic and language-agnostic.
+
+: Layer 4 — CSLib LTS adapters
+
+  `LTSAbstraction` wraps a CSLib `LTS` with a labeled transfer and the
+  derived trace-soundness theorem. `LTSCollectingAbstraction` is the
+  parallel unlabeled collecting interface bundling a
+  `ConcretizationDomain` with `postAny`-soundness. `Analyses/Common.lean`
+  provides the readout-based helpers
+  (`StepSoundOfRead` / `CollectingSoundOfRead`).
+
+: Layer 5 — IMP adapters and case studies
+
+  `IMPAnalysisDomain`, `transferProgram`, `soundStep_imp`,
+  `impAbstraction` (labeled path), plus `transferAnyProgram`,
+  `soundAny_imp`, `impCollectingTransfer`, `impReachTransfer`,
+  `{kleeneNat,omegaReachableLTS}_subset_of_isPostFixpoint_imp{Sign,Interval,Parity}`
+  (collecting path). Showcases: `Showcase`, `LoopShowcase`,
+  `WidenShowcase`, `CollectingShowcase`.
+
+# Key interface decisions
+
+: `ConcretizationDomain` replaced a richer `GammaOnlyDomain`
+
+  The earlier design folded join behaviour into the domain structure.
+  In practice, join soundness is a theorem from `gamma_monotone` plus
+  Mathlib's `SemilatticeSup`. Storing it was duplication.
+
+: Meet is a capability, not a lattice `Inf`
+
+  Some domains have a natural meet that isn't the lattice infimum
+  (`intersectParity`); others only need a reductive combinator.
+  `MeetLike` captures exactly that.
+
+: Filters and backward operators are capabilities
+
+  A domain can instantiate `ConcretizationDomain` without a branch
+  filter; a language whose condition vocabulary never refines an
+  abstract value doesn't need to fake one.
+
+: Collecting/fixpoint abstraction is a separate structure
+
+  `LTSAbstraction` takes a labeled transfer; `LTSCollectingAbstraction`
+  takes an unlabeled one. Merging them would force extra assumptions
+  onto every client.
+
+: `gammaProgram` is program-relative, not a full `ConcretizationDomain`
+
+  IMP's concretization carries an `ActiveIn program` constraint that is
+  what makes `soundStep_imp` tractable. That constraint is incompatible
+  with `ConcretizationDomain.gamma_top` for arbitrary configurations.
+  IMP therefore ships direct specialisations of the framework fixpoint
+  theorems (`kleeneNat_subset_of_isPostFixpoint_imp`,
+  `omegaReachableLTS_subset_of_isPostFixpoint_imp`) instead of a
+  literal `LTSCollectingAbstraction` value.
+
+# Upstream boundary
+
+Realistic CSLib upstream candidates:
+
+- `Concretization`, `ConcretizationDomain`, `gamma_union_subset_sup`;
+- the capability layer;
+- generic soundness (`Sound`, `SoundStep`, `SoundTrace`,
+  `soundTrace_of_soundStep`, `liftTrace`/`liftTracePost`);
+- iteration scaffolding (`iterateNat`, `CollectingStep`, `reachF`,
+  `kleeneNat`, `omegaReachable_subset_iUnion_kleeneNat`);
+- fixpoint/widening layer (`IsPostFixpoint`,
+  `*_subset_of_isPostFixpoint`, `Widen`, `WAcc`, `witer`, `pfp`);
+- CSLib LTS adapters (`LTSAbstraction`, `LTSCollectingAbstraction`,
+  `soundTraceLifted`, `omegaReachableLTS_subset_omegaReachable`,
+  `{Step,Collecting}SoundOfRead`).
+
+Pieces that should stay local to this repository:
+
+- IMP syntax, semantics, and `impLTS`;
+- `IMPAnalysisDomain` and its per-domain instances;
+- `transferProgram` / `transferAnyProgram` and their program-relative
+  soundness theorems;
+- program-specific showcases and tutorial LTSs.

--- a/site/AbsinterpDocs/Basic.lean
+++ b/site/AbsinterpDocs/Basic.lean
@@ -1,0 +1,34 @@
+import VersoManual
+
+import AbsinterpDocs.Home
+import AbsinterpDocs.Architecture
+import AbsinterpDocs.ReadingGuide
+import AbsinterpDocs.IMPCollectingShowcase
+
+open Verso.Genre Manual
+
+set_option pp.rawOnError true
+
+#doc (Manual) "absinterp — layered abstract interpretation in Lean 4" =>
+%%%
+shortTitle := "absinterp"
+authors := ["absinterp contributors"]
+%%%
+
+Welcome to the `absinterp` documentation site.
+`absinterp` is a Lean 4 repository for reusable abstract-interpretation
+infrastructure over CSLib-style labeled transition systems, with IMP as the
+main validation case study.
+
+This site collects the design notes, reading paths, and showcase writeups
+that live alongside the source tree. The Lean source itself is the
+authoritative specification; this site exists to orient readers and
+reviewers.
+
+{include 1 AbsinterpDocs.Home}
+
+{include 1 AbsinterpDocs.Architecture}
+
+{include 1 AbsinterpDocs.ReadingGuide}
+
+{include 1 AbsinterpDocs.IMPCollectingShowcase}

--- a/site/AbsinterpDocs/Home.lean
+++ b/site/AbsinterpDocs/Home.lean
@@ -1,0 +1,65 @@
+import VersoManual
+
+open Verso.Genre Manual
+
+#doc (Manual) "Home" =>
+%%%
+tag := "home"
+%%%
+
+`absinterp` builds reusable abstract-interpretation theory and infrastructure
+in Lean 4. The project is organized in layers — a minimal semantic kernel
+(`ConcretizationDomain`), a capability layer for reusable domain operations,
+generic soundness/iteration/fixpoint scaffolding, CSLib-style LTS adapters,
+and an IMP validation layer on top.
+
+# Status
+
+- Soundness-first: every abstract operation is paired with a
+  concretization-level soundness proof. `Tests/Axioms.lean` pins the axiom
+  footprint of the upstream-candidate path to the standard three
+  (`propext`, `Quot.sound`, `Classical.choice`).
+- Two independent end-to-end paths are exercised: labeled trace soundness
+  (`soundStep_imp` → `soundTraceLifted`) and unlabeled collecting/fixpoint
+  soundness (`soundAny_imp` → `omegaReachableLTS_subset_of_isPostFixpoint`).
+- Sign, Parity, and Interval scalar domains are packaged with the full
+  capability set (bottom, point abstraction, transfers, filters, meet-like,
+  relational backward operators).
+- The flagship case study `Examples/IMP/Programs/CollectingShowcase.lean`
+  proves a real value invariant (`x0 = 5` at the while head of
+  `x0 := 5;; while x0 do x0 := x0 + 0`) via the generic IMP collecting
+  bridge. The proof is axiom-clean — no `native_decide`.
+
+# Why Lean 4 + abstract interpretation?
+
+Abstract interpretation is a mature semantic framework for building sound
+static analyses. Mechanising it in Lean 4 benefits from:
+
+- *Pay-as-you-go algebraic structure.* Only `ConcretizationDomain` +
+  `gamma_monotone` + `SemilatticeSup` are needed for join soundness;
+  nothing forces a full Galois connection.
+- *Typeclass-driven capabilities.* Filters, backward operators, and
+  transfers are opt-in structures, each carrying their own soundness
+  obligation.
+- *CSLib-style LTS semantics.* Aligning the concrete side with CSLib's
+  `LTS` / `MTr` / `ωTr` / `HasTau` gives a common vocabulary for future
+  upstream packaging and for analyses over other CSLib-defined languages.
+- *Axiom hygiene.* `#guard_msgs in #print axioms` makes the
+  upstream-candidate path's axiom footprint a compile-time invariant.
+
+# Where to go next
+
+- {ref "architecture"}[Architecture] — the layered design, interface
+  choices, and the upstream boundary.
+- {ref "reading-guide"}[Reading Guide] — a compact path through the source
+  tree and the session-by-session evolution.
+- {ref "imp-collecting-showcase"}[IMP Collecting Showcase] — the flagship
+  Interval value-invariant theorem and its proof structure.
+
+# Repository
+
+The source, issue tracker, and PRs live at
+[github.com/Maokami/absinterp](https://github.com/Maokami/absinterp).
+The root `README.md` and `docs/architecture.md` carry deeper detail; this
+site restates the same story in a form more suitable for web browsing and
+talks.

--- a/site/AbsinterpDocs/IMPCollectingShowcase.lean
+++ b/site/AbsinterpDocs/IMPCollectingShowcase.lean
@@ -1,0 +1,113 @@
+import VersoManual
+
+open Verso.Genre Manual
+
+#doc (Manual) "IMP Collecting Showcase" =>
+%%%
+tag := "imp-collecting-showcase"
+%%%
+
+This chapter walks through the stronger IMP collecting case study.
+The authoritative Lean source is
+[`Examples/IMP/Programs/CollectingShowcase.lean`](https://github.com/Maokami/absinterp/blob/main/Examples/IMP/Programs/CollectingShowcase.lean).
+
+# The program
+
+```
+x0 := 5 ;;
+while x0 do
+  x0 := x0 + 0
+```
+
+Concretely: set `x0` to `5`, then loop forever re-assigning `x0 := x0 + 0`
+as long as `x0 ≠ 0`. Because the body leaves `x0` unchanged and the loop
+entry pins `x0` to `5`, every infinite execution from any initial store
+keeps `x0 = 5` from the first iteration onward.
+
+This program is chosen because it is
+
+- *divergent*, so it fits the `omegaReachableLTS` story directly;
+- *arithmetically non-trivial*, exercising branch filtering,
+  expression evaluation, the addition transfer, and store update;
+- *tight enough* that a hand-written exact interval post-fixpoint
+  `x0 = [5, 5]` exists and is closed under every transfer.
+
+It is deliberately stronger than a `ActiveIn`-only structural smoke test
+and weaker than anything requiring widening — a clean spot to exercise
+the generic collecting/fixpoint bridge end to end.
+
+# What is proved
+
+The headline theorem is
+
+```
+theorem x0_eq_5_at_wloop (σ : Store)
+    (hOmega : (wloop, σ) ∈ omegaReachableLTS impLTS init) :
+    σ Var.x0 = 5
+```
+
+Read: every state reachable on an infinite execution from the initial
+set, whose control is at the while head `wloop`, has `x0 = 5`.
+
+The `init` set is `{ c | controlOfConfig c = program }` — any concrete
+store, at the program's entry control. The invariant is therefore
+genuinely about concrete program states, not about the abstract domain
+alone.
+
+# How the proof is structured
+
+The proof consumes the Session 4/5 infrastructure.
+
+- A hand-written abstract post-fixpoint `fix : ConfigSharp Interval`
+  assigns `x0 = [5, 5]` at the three loop-related active controls
+  (`.seq .skip wloop`, `wloop`, `.seq body wloop`) and `⊤` everywhere
+  else.
+- `init_subset_gamma : init ⊆ gammaProgramInterval program fix` — the
+  initial set lives at the program entry control where `fix = ⊤`, so
+  any initial store is admitted.
+- `fix_isPostFixpoint :
+   IsPostFixpoint (· ≤ ·) (impIntervalReachTransfer program fix) fix`
+  — the central content. Proved pointwise: outside
+  `(control, x0) ∈ {B, C, D} × {Var.x0}` the bound is trivial
+  (`fix = ⊤`); the three non-trivial evaluations of
+  `transferAnyProgram intervalAnalysisDomain program fix` reduce by
+  structural unfolding + `Pi.sup_apply` to `mk 5 5 = mk 5 5`.
+- `omegaReachableLTS_subset_of_isPostFixpoint_impInterval` is the
+  Session 5 bridge specialised to the Interval IMP collecting
+  abstraction. It composes
+  `omegaReachableLTS_subset_omegaReachable` with the generic
+  fixpoint theorem `omegaReachable_subset_of_isPostFixpoint` and
+  delivers `omegaReachableLTS impLTS init ⊆ gammaProgramInterval program fix`.
+- Extracting `σ Var.x0 ∈ gammaInterval (mk 5 5) = {5}` at the
+  `wloop` control finishes with `omega`.
+
+# Why it matters
+
+This is the first IMP artifact in the repository that is
+
+- *axiom-clean* — the proof avoids `native_decide` entirely. The
+  critical `transferAny_at_{B,C,D}_x0` lemmas unfold
+  `transferAnyProgram` structurally and finish with `rfl`, which means
+  the flagship collecting theorem stays on the upstream-candidate axiom
+  path (`propext`, `Quot.sound`, `Classical.choice`).
+- *materially about values*, not just control. `ActiveIn`-only
+  invariants say the executions stay inside the program; this one
+  says `x0` takes a specific integer value at a specific control
+  point.
+- *a genuine consumer* of both Session 4 (generic fixpoint bridge)
+  and Session 5 (LTS collecting adapter), exercising the IMP adapter
+  (Session 6) and the per-domain Interval wrappers in between.
+
+As a case study, it gives the framework an end-to-end demo with a
+concrete, checkable conclusion — the natural next escalation from the
+earlier widening and labeled-trace showcases.
+
+# Related artifacts
+
+- `Examples/IMP/Programs/Showcase.lean` — labeled Sign trace analysis,
+  a flagship for the trace path.
+- `Examples/IMP/Programs/WidenShowcase.lean` — widening/`pfp` on a
+  small Interval-based `Flat3` lattice.
+- `Examples/IMP/Programs/LoopShowcase.lean` — an earlier Sign-based
+  countdown loop demo, now structurally subsumed by the stronger
+  Interval case.

--- a/site/AbsinterpDocs/ReadingGuide.lean
+++ b/site/AbsinterpDocs/ReadingGuide.lean
@@ -1,0 +1,94 @@
+import VersoManual
+
+open Verso.Genre Manual
+
+#doc (Manual) "Reading Guide" =>
+%%%
+tag := "reading-guide"
+%%%
+
+A compact reader path through the repository.
+
+# If you want the reusable theory
+
+Start at the semantic kernel and walk outward.
+
+- `AbsInterp/Framework/Concretization.lean`
+- `AbsInterp/Framework/Domains/Concretization.lean`
+  — the `ConcretizationDomain` contract and `gamma_union_subset_sup`.
+- `AbsInterp/Framework/Domains/Capabilities.lean` and siblings
+  (`BottomConcretization`, `PointAbstraction`, `FilterOperator`,
+  `RelationalBackwardOperator`, `MeetLike`, transfer capabilities).
+- `AbsInterp/Framework/Soundness/` — one-step, step, and trace soundness
+  predicates plus trace lifting.
+- `AbsInterp/Framework/Iteration/` — `iterateNat`, `Collecting`,
+  `Fixpoint/`, `Widening/`.
+
+# If you want the CSLib integration
+
+- `AbsInterp/Instances/LTS/Semantics/` — `Concrete`, `Collecting`,
+  `Omega`, `Weak`.
+- `AbsInterp/Instances/LTS/Instantiation/Interface.lean` —
+  `LTSAbstraction` for the labeled trace path.
+- `AbsInterp/Instances/LTS/Instantiation/CollectingInterface.lean` —
+  `LTSCollectingAbstraction` for the unlabeled collecting path.
+- `AbsInterp/Instances/LTS/Instantiation/{Soundness,CollectingSoundness}.lean`
+  — the derived soundness theorems.
+- `AbsInterp/Instances/LTS/Analyses/Common.lean` — readout helpers
+  (`StepSoundOfRead`, `CollectingSoundOfRead`).
+
+# If you want the IMP case study
+
+- `Examples/IMP/Syntax.lean`, `Semantics/`, `LTS.lean` — the concrete
+  language.
+- `Examples/IMP/Abstraction/` — `ConfigSharp`, `StoreSharp`,
+  `gammaConfigOf`, `gammaProgramConfigOf`.
+- `Examples/IMP/Analysis/Generic/Domain.lean` — `IMPAnalysisDomain`.
+- `Examples/IMP/Analysis/Generic/{Defs,Lemmas,Soundness}.lean` — the
+  labeled transfer + `soundStep_imp` + `impAbstraction`.
+- `Examples/IMP/Analysis/Generic/Collecting.lean` — the unlabeled
+  `transferAnyProgram`, `soundAny_imp`, and the IMP bridge theorems.
+- `Examples/IMP/Analysis/{Sign,Interval,Parity}/Defs.lean` — thin
+  per-domain wrappers.
+- `Examples/IMP/Programs/Showcase.lean` — labeled Sign showcase.
+- `Examples/IMP/Programs/CollectingShowcase.lean` — Interval value
+  invariant `x0 = 5` via the collecting bridge.
+- `Examples/IMP/Programs/WidenShowcase.lean` — widening demo.
+
+# Session-by-session evolution
+
+The repository's current shape is the result of several focused sessions.
+The following list orients a new reader to what each session contributed.
+
+- *Session 1* — canonicalised the γ-only domain contract
+  (`GammaOnlyDomain` → `ConcretizationDomain`); join soundness became
+  a generic theorem.
+- *Session 2* — soundness transport: one-step → trace lifting,
+  packaged as `LTSAbstraction.soundTraceLifted`.
+- *Session 3* — scalar domain cleanup: stale `Max` / `join_sound` API
+  removed; interval widening moved into a dedicated module.
+- *Session 4* — the generic fixpoint bridge: `IsPostFixpoint` and
+  `sound_of_isPostFixpoint` moved out of the widening module; new
+  `sound_iterateNat_from_init_of_isPostFixpoint`,
+  `kleeneNat_subset_of_isPostFixpoint`,
+  `omegaReachable_subset_of_isPostFixpoint`.
+- *Session 5* — CSLib LTS collecting adapter:
+  `LTSCollectingAbstraction`, `sound_reachTransfer`,
+  `omegaReachableLTS_subset_of_isPostFixpoint`, the readout helper
+  `CollectingSoundOfRead`.
+- *Session 6* — IMP collecting adapter: `transferAnyProgram`,
+  `soundAny_imp`, `impCollectingTransfer`, the thin Sign/Interval/Parity
+  wrappers, and the first `CollectingShowcase` smoke test.
+- *Issue #113* — strengthened IMP collecting showcase:
+  `CollectingShowcase` now proves `x0 = 5` at the while head of the
+  flagship program via a hand-written Interval post-fixpoint,
+  axiom-clean (no `native_decide`).
+
+# Strongest showcase artifacts
+
+- *Labeled trace path:* `Examples/IMP/Programs/Showcase.lean`.
+- *Unlabeled collecting/fixpoint path:*
+  `Examples/IMP/Programs/CollectingShowcase.lean` — the current flagship,
+  proving a concrete value invariant.
+- *Widening:* `Examples/IMP/Programs/WidenShowcase.lean`.
+- *Axiom hygiene check:* `Tests/Axioms.lean`.

--- a/site/AbsinterpSlides.lean
+++ b/site/AbsinterpSlides.lean
@@ -1,0 +1,1 @@
+import AbsinterpSlides.Intro

--- a/site/AbsinterpSlides/Intro.lean
+++ b/site/AbsinterpSlides/Intro.lean
@@ -1,0 +1,119 @@
+import VersoManual
+
+open Verso.Genre Manual
+
+/-!
+A minimal talk deck for `absinterp`. Built with `VersoManual` because the
+official Verso stack does not yet ship a dedicated slide genre; each
+top-level section is a logical slide. The executable emits a single-file
+HTML that can be opened in a browser and scrolled through, or styled
+downstream for slide-show rendering. Replace with the official Verso
+slide genre once it ships a tag compatible with the repository toolchain.
+-/
+
+#doc (Manual) "Layered Abstract Interpretation in Lean 4" =>
+%%%
+shortTitle := "absinterp slides"
+authors := ["absinterp contributors"]
+%%%
+
+A short talk deck for `absinterp`.
+
+# Project goal
+
+`absinterp` is a Lean 4 library for *reusable* abstract interpretation
+over *CSLib-style LTS semantics*. IMP is the validation case study,
+not the product.
+
+- Soundness-first, γ-only — no Galois connection required.
+- Long-term target: mature the reusable pieces toward an upstream CSLib
+  contribution.
+
+# Layered architecture
+
+The framework is a strict, one-directional stack.
+
+- *Semantic core.* `Concretization`, `ConcretizationDomain`,
+  `gamma_union_subset_sup`.
+- *Domain capabilities.* `BottomConcretization`, `MeetLike`,
+  `PointAbstraction`, `FilterOperator`, `RelationalBackwardOperator`,
+  transfers.
+- *Generic soundness + iteration.* Step/trace lifting, collecting
+  semantics, the fixpoint bridge, the widening engine.
+- *CSLib LTS adapters.* `LTSAbstraction` (trace) and
+  `LTSCollectingAbstraction` (collecting).
+- *IMP adapter.* `IMPAnalysisDomain`, `transferProgram`,
+  `transferAnyProgram`, per-domain wrappers, programs.
+
+Higher layers depend only on lower layers. IMP arithmetic never leaks
+into the framework core.
+
+# Trace vs. collecting paths
+
+The framework ships two independent end-to-end paths.
+
+: Labeled trace path
+
+  `LTSAbstraction` takes a labeled `Label → Abstract → Abstract`
+  transfer plus a step-soundness proof; `soundTraceLifted` derives
+  trace-level soundness.
+
+: Unlabeled collecting/fixpoint path
+
+  `LTSCollectingAbstraction` takes an unlabeled `Abstract → Abstract`
+  transfer plus `postAny`-soundness; the fixpoint bridge
+  `omegaReachable_subset_of_isPostFixpoint` turns an abstract
+  post-fixpoint into a concrete safety conclusion.
+
+The two paths are kept parallel on purpose: bridging them requires
+extra structure (finite label enumeration, abstract aggregation) that
+only some clients can pay for.
+
+# IMP case studies
+
+IMP exercises the framework end-to-end.
+
+- *`Programs/Showcase.lean`* — labeled Sign analysis along fixed
+  traces over the canonical IMP LTS.
+- *`Programs/WidenShowcase.lean`* — widening on a small finite
+  `Flat3` domain, exercising `WAcc` / `witer` / `pfp`.
+- *`Programs/CollectingShowcase.lean`* — the flagship collecting
+  case study: proves `x0 = 5` at the while head of
+  `x0 := 5;; while x0 do x0 := x0 + 0` via a hand-written Interval
+  post-fixpoint. Axiom-clean — no `native_decide`.
+
+# Upstream boundary
+
+Candidates for CSLib upstreaming:
+
+- semantic kernel (`ConcretizationDomain`, `gamma_union_subset_sup`);
+- capability layer;
+- generic soundness + iteration + fixpoint + widening;
+- CSLib LTS adapters (`LTSAbstraction`, `LTSCollectingAbstraction`,
+  readout helpers).
+
+Lives only in this repo:
+
+- IMP syntax/semantics/`impLTS`;
+- `IMPAnalysisDomain`;
+- program-specific showcases and tutorials.
+
+The split is principled: anything mentioning IMP belongs above the
+framework boundary.
+
+# Status and next steps
+
+- Axiom-clean upstream-candidate path, with `Tests/Axioms.lean` as
+  a compile-time guard on the axiom footprint.
+- Two flagship showcase invariants in place (Sign trace, Interval
+  collecting `x0 = 5`).
+- Still open: relational domain instances, narrowing, realistic
+  widening over config abstractions, namespacing/docstring pass for
+  the first CSLib PR.
+
+# Pointers
+
+- Repository:
+  [github.com/Maokami/absinterp](https://github.com/Maokami/absinterp)
+- Architecture note: `docs/architecture.md`
+- Documentation site: this Verso project

--- a/site/Main.lean
+++ b/site/Main.lean
@@ -1,0 +1,15 @@
+import VersoManual
+import AbsinterpDocs
+
+open Verso.Genre.Manual
+
+def config : Config := {
+  sourceLink := some "https://github.com/Maokami/absinterp"
+  issueLink := some "https://github.com/Maokami/absinterp/issues"
+  emitTeX := false
+  emitHtmlSingle := .no
+  emitHtmlMulti := .immediately
+  htmlDepth := 2
+}
+
+def main := manualMain (%doc AbsinterpDocs.Basic) (config := { config with })

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,115 @@
+# absinterp documentation site
+
+Nested Verso project that builds the `absinterp` documentation website
+and a minimal talk deck. Kept strictly separate from the root Lean
+package — `lake build`, `lake build Tests`, and `lake test` at the
+repository root are unaffected.
+
+## Layout
+
+```text
+site/
+├── lean-toolchain            # must match the root's Lean toolchain
+├── lakefile.toml             # Verso dependency + two exes
+├── Main.lean                 # entry point for the site
+├── AbsinterpDocs.lean        # barrel importing AbsinterpDocs.Basic
+├── AbsinterpDocs/
+│   ├── Basic.lean            # root #doc (Manual)
+│   ├── Home.lean
+│   ├── Architecture.lean
+│   ├── ReadingGuide.lean
+│   └── IMPCollectingShowcase.lean
+├── SlidesMain.lean           # entry point for the slide deck
+├── AbsinterpSlides.lean      # barrel importing AbsinterpSlides.Intro
+└── AbsinterpSlides/
+    └── Intro.lean            # single-deck slide content
+```
+
+## Verso revision strategy
+
+This project is pinned to the Verso tag
+[`v4.30.0-rc1`](https://github.com/leanprover/verso/tree/v4.30.0-rc1),
+which exactly matches the repository-wide Lean toolchain
+(`leanprover/lean4:v4.30.0-rc1`). That tag was chosen because:
+
+- it is a shipped Verso release with a matching toolchain file, so the
+  transitive dependency graph (subverso, MD4Lean, plausible) is
+  reproducible;
+- it avoids the risk of a `main`-based pin silently picking up
+  incompatible nightly churn;
+- the exact-toolchain match means the nested project's Lean binary is
+  identical to the one the root project uses, so there is no
+  elanswitching overhead.
+
+Upgrade plan: when Lean `v4.30.0` stable ships (and a corresponding
+Verso `v4.30.0` tag exists), move the pin to that stable tag. If the
+root `absinterp` toolchain moves ahead of Verso's releases (as happened
+briefly with `v4.30.0-rc2`), prefer the newest Verso tag whose
+toolchain still matches over a `main`-based pin.
+
+## First build
+
+The first build fetches Verso and its transitive dependencies
+(`subverso`, `MD4Lean`, `plausible`, plus their own deps). This can
+take a while (several minutes) depending on network and disk.
+
+```bash
+cd site
+lake update verso
+lake build site
+```
+
+Subsequent builds are incremental.
+
+## Build the documentation site
+
+```bash
+cd site
+lake exe site
+```
+
+Output lands under `site/_out/html-multi/`. Preview locally with any
+static web server, for example:
+
+```bash
+cd site/_out/html-multi
+python3 -m http.server 8000
+```
+
+and open <http://localhost:8000>.
+
+## Build the slide deck
+
+```bash
+cd site
+lake exe slides
+```
+
+The slides executable emits a single-file HTML at
+`site/_out/slides/html-single/index.html`. Open that file in a
+browser.
+
+The current slide deck uses `VersoManual` as the backing genre, with
+each top-level section acting as a logical slide. When Verso ships a
+dedicated slides genre whose toolchain matches ours, migrate
+`AbsinterpSlides/Intro.lean` to that genre.
+
+## GitHub Pages deployment
+
+The workflow at `.github/workflows/docs-site.yml` builds the docs site
+on every push to `main` and publishes the emitted HTML to GitHub Pages.
+Repository settings must have Pages enabled with the "GitHub Actions"
+source for the workflow to succeed.
+
+Published URL:
+`https://<owner>.github.io/<repo>/` — for this repository, once enabled
+that resolves to `https://maokami.github.io/absinterp/`.
+
+## Do not
+
+- Do not add imports from the root `AbsInterp` or `Examples` libraries
+  into site sources; the nested project intentionally does not depend
+  on the root Lean package. Reference the source by link or filename
+  instead.
+- Do not move the root project's `lakefile.toml` or toolchain to
+  accommodate Verso. The two projects stay independent.

--- a/site/SlidesMain.lean
+++ b/site/SlidesMain.lean
@@ -1,0 +1,16 @@
+import VersoManual
+import AbsinterpSlides
+
+open Verso.Genre.Manual
+
+def config : Config := {
+  sourceLink := some "https://github.com/Maokami/absinterp"
+  issueLink := some "https://github.com/Maokami/absinterp/issues"
+  emitTeX := false
+  emitHtmlSingle := .immediately
+  emitHtmlMulti := .no
+  destination := "_out/slides"
+  htmlDepth := 1
+}
+
+def main := manualMain (%doc AbsinterpSlides.Intro) (config := { config with })

--- a/site/lakefile.toml
+++ b/site/lakefile.toml
@@ -1,0 +1,31 @@
+name = "absinterp-docs"
+version = "0.1.0"
+defaultTargets = ["site", "slides"]
+
+[leanOptions]
+pp.unicode.fun = true
+
+# Verso is pinned to its `v4.30.0-rc1` tag, which matches the repository-wide
+# Lean toolchain (leanprover/lean4:v4.30.0-rc1). See `site/README.md` for the
+# revision-strategy rationale and the upgrade plan once Lean v4.30.0 stable
+# ships.
+[[require]]
+name = "verso"
+git = "https://github.com/leanprover/verso.git"
+rev = "v4.30.0-rc1"
+
+[[lean_lib]]
+name = "AbsinterpDocs"
+
+[[lean_lib]]
+name = "AbsinterpSlides"
+
+[[lean_exe]]
+name = "site"
+root = "Main"
+supportInterpreter = true
+
+[[lean_exe]]
+name = "slides"
+root = "SlidesMain"
+supportInterpreter = true

--- a/site/lean-toolchain
+++ b/site/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.30.0-rc1


### PR DESCRIPTION
## Summary

- add the stronger Interval collecting showcase with the `x0 := 5;; while x0 do x0 := x0 + 0` value invariant
- add `docs/architecture.md` and align the root README with the current layered architecture
- add a nested Verso `site/` project, a minimal slide deck, and a GitHub Pages workflow

## Validation

- `lake build`
- `lake build Tests`
- `lake test`
- `cd site && lake build`
- `cd site && lake exe site`
- `cd site && lake exe slides`

## Notes

- `.claude/` remains excluded
- low-priority follow-up for showcase proof brittleness: #114
- Verso scaffold tracked in #115
- stronger collecting showcase tracked in #113
