### PR TITLE
ci: fix docs site deployment workflow

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -25,13 +25,21 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Lean toolchain
-        uses: leanprover/lean-action@v1
-        with:
-          lake-package-directory: site
+      - name: Install elan
+        run: |
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Verify Lean toolchain
+        run: |
+          lean --version
+          lake --version
 
       - name: Resolve Verso dependency
         run: lake update verso
+
+      - name: Build docs project
+        run: lake build
 
       - name: Build documentation site
         run: lake exe site

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ IMP's role as a validation adapter, and the upstream boundary — see
 A web version of the architecture note, a reading guide, and a
 minimal talk deck live in the nested Verso project at [`site/`](site/).
 See [`site/README.md`](site/README.md) for local build instructions
-and the GitHub Pages publication path.
+and the GitHub Pages publication path. To publish the site, enable
+GitHub Pages with **Source = GitHub Actions** in the repository settings.
 
 ## What is in place
 

--- a/site/Main.lean
+++ b/site/Main.lean
@@ -3,6 +3,10 @@ import AbsinterpDocs
 
 open Verso.Genre.Manual
 
+/--
+Emit the multi-page documentation site into the default `_out/html-multi`
+layout. The GitHub Pages workflow publishes this tree at the site root.
+-/
 def config : Config := {
   sourceLink := some "https://github.com/Maokami/absinterp"
   issueLink := some "https://github.com/Maokami/absinterp/issues"

--- a/site/SlidesMain.lean
+++ b/site/SlidesMain.lean
@@ -3,6 +3,10 @@ import AbsinterpSlides
 
 open Verso.Genre.Manual
 
+/--
+Emit the single-file talk deck under `_out/slides`, which the GitHub Pages
+workflow republishes under `/slides/`.
+-/
 def config : Config := {
   sourceLink := some "https://github.com/Maokami/absinterp"
   issueLink := some "https://github.com/Maokami/absinterp/issues"


### PR DESCRIPTION
## Summary

- replace `leanprover/lean-action` in the docs-site workflow
- install elan directly, then resolve Verso deps with `lake update verso`
- build the nested `site/` project before generating the HTML artifacts

## Why

The original Pages workflow failed on `main` because the nested Verso project
does not commit `site/lake-manifest.json`, while `lean-action` expects a
manifest up front for nested Lake projects.

## Notes

- this does not change the root Lean project build/test workflow
- after merging, Pages should be configured with **Source = GitHub Actions**
- follow-up slide-quality issue: #117
