### PR TITLE
refactor(lts): collecting/weak adapter follow-ups, Parity adapter, citation fixes

### DIFF
--- a/AbsInterp.lean
+++ b/AbsInterp.lean
@@ -38,6 +38,7 @@ import AbsInterp.Instances
 import AbsInterp.Instances.LTS
 import AbsInterp.Instances.LTS.Analyses.Common
 import AbsInterp.Instances.LTS.Analyses.Interval
+import AbsInterp.Instances.LTS.Analyses.Parity
 import AbsInterp.Instances.LTS.Analyses.Sign
 import AbsInterp.Instances.LTS.Core
 import AbsInterp.Instances.LTS.Instantiation.Interface

--- a/AbsInterp/Domains/Sign.lean
+++ b/AbsInterp/Domains/Sign.lean
@@ -116,7 +116,7 @@ instance : OrderTop Sign where
 
 instance : OrderBot Sign where
   bot := .bot
-  bot_le _ := fun _ hn => by simp [gammaSign] at hn
+  bot_le _ := Set.empty_subset _
 
 theorem gammaSign_monotone_of_leSign ⦃a b : Sign⦄ (hAB : a ≤ b) :
     gammaSign a ⊆ gammaSign b :=
@@ -406,47 +406,6 @@ theorem backwardAddZeroSign_reductive :
       simp [gammaSign, backwardAddZeroSign, filterZeroSign, meetSign,
         signOfFlags, hasNeg, hasZero, hasPos] at hn ⊢ <;>
       omega
-
-/-- Baseline unary transfer shape: abstract negation. -/
-def negTransfer : Sign -> Sign
-  | .bot => .bot
-  | .neg => .pos
-  | .zero => .zero
-  | .pos => .neg
-  | .nonpos => .nonneg
-  | .nonneg => .nonpos
-  | .top => .top
-
-theorem negTransfer_sound {a : Sign} {n : Int} (hn : n ∈ gammaSign a) :
-    -n ∈ gammaSign (negTransfer a) := by
-  cases a with
-  | bot =>
-      change False at hn
-      exact False.elim hn
-  | neg =>
-      change n < 0 at hn
-      change 0 < -n
-      omega
-  | zero =>
-      change n = 0 at hn
-      change -n = 0
-      omega
-  | pos =>
-      change 0 < n at hn
-      change -n < 0
-      omega
-  | nonpos =>
-      change n < 0 ∨ n = 0 at hn
-      change -n = 0 ∨ 0 < -n
-      omega
-  | nonneg =>
-      change n = 0 ∨ 0 < n at hn
-      change -n < 0 ∨ -n = 0
-      omega
-  | top =>
-      change True at hn
-      change True
-      trivial
 
 /-- Concretization-domain instance for the sign domain. -/
 def signConcretizationDomain :

--- a/AbsInterp/Framework/Domains/Backward.lean
+++ b/AbsInterp/Framework/Domains/Backward.lean
@@ -27,8 +27,9 @@ their concretizations:
 * P. Cousot, R. Cousot, *Abstract Interpretation: A Unified Lattice Model for
   Static Analysis of Programs by Construction or Approximation of Fixpoints*,
   POPL 1977. doi:10.1145/512950.512973
-* X. Leroy, *Semantics and Verification of Computer Programs*,
-  MPRI lecture notes (N40AI), 2023–2024, slides 6–8 (backward operators).
+* X. Leroy, *Mechanizing abstract interpretation*,
+  Workshop on the Next 40 years of Abstract Interpretation (N40AI), 2024,
+  slides 6–8 (backward operators). https://xavierleroy.org/talks/N40AI.pdf
 -/
 
 /-- Binary backward operators simultaneously refine two abstract values. -/

--- a/AbsInterp/Framework/Domains/Concretization.lean
+++ b/AbsInterp/Framework/Domains/Concretization.lean
@@ -22,8 +22,9 @@ soundness is derived generically when `[SemilatticeSup]` is available. An opt-in
 * P. Cousot, R. Cousot, *Abstract Interpretation: A Unified Lattice Model for
   Static Analysis of Programs by Construction or Approximation of Fixpoints*,
   POPL 1977. doi:10.1145/512950.512973
-* X. Leroy, *Semantics and Verification of Computer Programs*,
-  MPRI lecture notes (N40AI), 2023–2024.
+* X. Leroy, *Mechanizing abstract interpretation*,
+  Workshop on the Next 40 years of Abstract Interpretation (N40AI), 2024.
+  https://xavierleroy.org/talks/N40AI.pdf
 -/
 
 namespace AbsInterp

--- a/AbsInterp/Framework/Iteration/Fixpoint/Collecting.lean
+++ b/AbsInterp/Framework/Iteration/Fixpoint/Collecting.lean
@@ -11,8 +11,8 @@ import AbsInterp.Framework.Semantics.Omega.Defs
 Reusable corollaries that turn an abstract post-fixpoint into a sound
 over-approximation of collecting Kleene iterates and of ω-reachability.
 
-These are the headline Session 4 results: once a solver has produced an
-abstract post-fixpoint, these theorems deliver the concrete safety
+These are the headline post-fixpoint bridge results: once a solver has produced
+an abstract post-fixpoint, these theorems deliver the concrete safety
 conclusion without any further iteration-specific reasoning.
 -/
 

--- a/AbsInterp/Framework/Semantics/TraceLift.lean
+++ b/AbsInterp/Framework/Semantics/TraceLift.lean
@@ -16,8 +16,9 @@ For `compose : T -> T -> T`, identity `id : T`, and `step : Label -> T`:
 
 ## References
 
-* X. Leroy, *Semantics and Verification of Computer Programs*,
-  MPRI lecture notes (N40AI), 2023–2024.
+* X. Leroy, *Mechanizing abstract interpretation*,
+  Workshop on the Next 40 years of Abstract Interpretation (N40AI), 2024.
+  https://xavierleroy.org/talks/N40AI.pdf
   (trace semantics as sequential composition of step semantics)
 -/
 

--- a/AbsInterp/Framework/Soundness/StepToTraceSoundness.lean
+++ b/AbsInterp/Framework/Soundness/StepToTraceSoundness.lean
@@ -16,8 +16,9 @@ soundness through sequential composition.
 
 ## References
 
-* X. Leroy, *Semantics and Verification of Computer Programs*,
-  MPRI lecture notes (N40AI), 2023–2024.
+* X. Leroy, *Mechanizing abstract interpretation*,
+  Workshop on the Next 40 years of Abstract Interpretation (N40AI), 2024.
+  https://xavierleroy.org/talks/N40AI.pdf
   (γ-only soundness propagation over trace semantics)
 * P. Cousot, R. Cousot, *Abstract Interpretation: A Unified Lattice Model for
   Static Analysis of Programs by Construction or Approximation of Fixpoints*,

--- a/AbsInterp/Instances/LTS.lean
+++ b/AbsInterp/Instances/LTS.lean
@@ -11,8 +11,8 @@ This barrel exposes the reusable, domain-agnostic CSLib-LTS adapter layer:
 * `Analyses.Common` — generic readout helpers (`ReadGamma`, `StepSoundOfRead`,
   `CollectingSoundOfRead`) that connect any observation-based domain to an LTS.
 
-Domain-specific readout adapters (`Analyses.Sign`, `Analyses.Interval`) are
-deliberately *not* re-exported here: they pull in concrete scalar domains and
-are downstream convenience. Import them directly where needed; the root
-`AbsInterp` barrel still aggregates them.
+Domain-specific readout adapters (`Analyses.Sign`, `Analyses.Interval`,
+`Analyses.Parity`) are deliberately *not* re-exported here: they pull in
+concrete scalar domains and are downstream convenience. Import them directly
+where needed; the root `AbsInterp` barrel still aggregates them.
 -/

--- a/AbsInterp/Instances/LTS.lean
+++ b/AbsInterp/Instances/LTS.lean
@@ -1,4 +1,18 @@
 import AbsInterp.Instances.LTS.Core
 import AbsInterp.Instances.LTS.Analyses.Common
-import AbsInterp.Instances.LTS.Analyses.Sign
-import AbsInterp.Instances.LTS.Analyses.Interval
+
+/-!
+# CSLib LTS adapter surface
+
+This barrel exposes the reusable, domain-agnostic CSLib-LTS adapter layer:
+
+* `Core` — labeled trace and unlabeled collecting semantics/instantiation
+  (the upstream-candidate surface).
+* `Analyses.Common` — generic readout helpers (`ReadGamma`, `StepSoundOfRead`,
+  `CollectingSoundOfRead`) that connect any observation-based domain to an LTS.
+
+Domain-specific readout adapters (`Analyses.Sign`, `Analyses.Interval`) are
+deliberately *not* re-exported here: they pull in concrete scalar domains and
+are downstream convenience. Import them directly where needed; the root
+`AbsInterp` barrel still aggregates them.
+-/

--- a/AbsInterp/Instances/LTS/Analyses/Parity.lean
+++ b/AbsInterp/Instances/LTS/Analyses/Parity.lean
@@ -1,0 +1,68 @@
+import Cslib.Init
+
+import AbsInterp.Domains.Parity
+import AbsInterp.Instances.LTS.Analyses.Common
+
+namespace AbsInterp
+namespace Instances
+namespace LTS
+namespace Analyses
+
+open AbsInterp.Framework
+open AbsInterp.Domains
+
+universe u v
+
+/-- State concretization for the parity domain via an integer observation function. -/
+abbrev ParityGamma (State : Type u) := ReadGamma Parity Int State
+
+/-- Lift `gammaParity` to concrete states using a readout `State -> Int`. -/
+def gammaParityState
+    {State : Type u} :
+    ParityGamma State :=
+  gammaStateOfRead gammaParity
+
+/-- Label-indexed parity transfer family. -/
+abbrev ParityTransfer (Label : Type v) := Label -> Parity -> Parity
+
+/--
+Local one-step parity soundness condition over LTS transitions.
+
+This can be discharged by language-specific transition/transfer lemmas, then
+lifted to framework `SoundStep`.
+-/
+def ParityStepSound
+    {State : Type u}
+    {Label : Type v}
+    (lts : Cslib.LTS State Label)
+    (read : State -> Int)
+    (transfer : ParityTransfer Label) : Prop :=
+  StepSoundOfRead gammaParity lts read transfer
+
+/-- Bridge from local parity-transition soundness to framework `SoundStep`. -/
+theorem soundStep_postStep_parity_of_stepSound
+    {State : Type u}
+    {Label : Type v}
+    (lts : Cslib.LTS State Label)
+    (read : State -> Int)
+    (transfer : ParityTransfer Label)
+    (hStep : ParityStepSound lts read transfer) :
+    SoundStep (postStep lts) (gammaParityState read) transfer := by
+  simpa [ParityStepSound, gammaParityState] using
+    (soundStep_postStep_of_stepSound (gamma := gammaParity) lts read transfer hStep)
+
+/-- Build an LTS abstraction from local parity-step soundness obligations. -/
+def parityAbstractionOfStepSound
+    {State : Type u}
+    {Label : Type v}
+    (lts : Cslib.LTS State Label)
+    (read : State -> Int)
+    (transfer : ParityTransfer Label)
+    (hStep : ParityStepSound lts read transfer) :
+    LTSAbstraction State Label Parity :=
+  abstractionOfStepSound (gamma := gammaParity) lts read transfer hStep
+
+end Analyses
+end LTS
+end Instances
+end AbsInterp

--- a/AbsInterp/Instances/LTS/Core.lean
+++ b/AbsInterp/Instances/LTS/Core.lean
@@ -8,3 +8,4 @@ import AbsInterp.Instances.LTS.Instantiation.Interface
 import AbsInterp.Instances.LTS.Instantiation.Soundness
 import AbsInterp.Instances.LTS.Instantiation.CollectingInterface
 import AbsInterp.Instances.LTS.Instantiation.CollectingSoundness
+import AbsInterp.Instances.LTS.Instantiation.WeakSoundness

--- a/AbsInterp/Instances/LTS/Instantiation/CollectingInterface.lean
+++ b/AbsInterp/Instances/LTS/Instantiation/CollectingInterface.lean
@@ -29,6 +29,53 @@ open AbsInterp.Framework.Domains
 universe u v w
 
 /--
+Unbundled reach transfer, shared by the bundled `LTSCollectingAbstraction`
+and by bare-`gamma` clients (e.g. program-relative concretizations that are
+not full `ConcretizationDomain`s): add the abstract initial approximation
+`initAbs` at every step.
+-/
+def reachTransferAny
+    {Abstract : Type w}
+    [SemilatticeSup Abstract]
+    (transferAny : PostSharp Abstract)
+    (initAbs : Abstract) :
+    PostSharp Abstract :=
+  fun a => initAbs ⊔ transferAny a
+
+/--
+Soundness of `reachTransferAny` against the LTS collecting reachability
+operator, stated for a bare concretization `gamma` plus a monotonicity proof.
+This is the primary statement; the `ConcretizationDomain`-bundled
+`LTSCollectingAbstraction.sound_reachTransfer` is a convenience wrapper and
+clients without `gamma_top`/`OrderTop` (such as IMP) call this directly.
+-/
+theorem sound_reachTransferAny
+    {State : Type u}
+    {Label : Type v}
+    {Abstract : Type w}
+    [SemilatticeSup Abstract]
+    (lts : Cslib.LTS State Label)
+    (gamma : Concretization Abstract State)
+    (gamma_mono : ∀ {a b : Abstract}, a ≤ b → gamma a ⊆ gamma b)
+    (transferAny : PostSharp Abstract)
+    (soundAny : Sound (postAny lts) gamma transferAny)
+    {init : Set State}
+    {initAbs : Abstract}
+    (hInit : init ⊆ gamma initAbs) :
+    Sound ((postAny_collectingStep lts).reachF init) gamma
+      (reachTransferAny transferAny initAbs) := by
+  intro a s hs
+  rcases hs with hInitMem | hPostMem
+  · have hLeft : initAbs ≤ reachTransferAny transferAny initAbs a := by
+      show initAbs ≤ initAbs ⊔ transferAny a
+      exact le_sup_left
+    exact gamma_mono hLeft (hInit hInitMem)
+  · have hRight : transferAny a ≤ reachTransferAny transferAny initAbs a := by
+      show transferAny a ≤ initAbs ⊔ transferAny a
+      exact le_sup_right
+    exact gamma_mono hRight (soundAny a hPostMem)
+
+/--
 Reusable interface for unlabeled collecting abstract interpretation over a
 CSLib LTS.
 
@@ -84,7 +131,7 @@ def reachTransfer
     (cfg : LTSCollectingAbstraction State Label Abstract)
     (initAbs : Abstract) :
     PostSharp Abstract :=
-  fun a => initAbs ⊔ cfg.transferAny a
+  reachTransferAny cfg.transferAny initAbs
 
 /--
 The abstract reachability transfer is sound w.r.t. the concrete LTS
@@ -98,19 +145,9 @@ theorem sound_reachTransfer
     (hInit : init ⊆ cfg.domain.gamma initAbs) :
     Sound ((postAny_collectingStep cfg.lts).reachF init)
       cfg.domain.gamma
-      (cfg.reachTransfer initAbs) := by
-  intro a s hs
-  rcases hs with hInitMem | hPostMem
-  ·
-    have hLeft : initAbs ≤ cfg.reachTransfer initAbs a := by
-      change initAbs ≤ initAbs ⊔ cfg.transferAny a
-      exact le_sup_left
-    exact cfg.domain.gamma_monotone hLeft (hInit hInitMem)
-  ·
-    have hRight : cfg.transferAny a ≤ cfg.reachTransfer initAbs a := by
-      change cfg.transferAny a ≤ initAbs ⊔ cfg.transferAny a
-      exact le_sup_right
-    exact cfg.domain.gamma_monotone hRight (cfg.soundAny a hPostMem)
+      (cfg.reachTransfer initAbs) :=
+  sound_reachTransferAny cfg.lts cfg.domain.gamma
+    (fun h => cfg.domain.gamma_monotone h) cfg.transferAny cfg.soundAny hInit
 
 end LTSCollectingAbstraction
 

--- a/AbsInterp/Instances/LTS/Instantiation/CollectingInterface.lean
+++ b/AbsInterp/Instances/LTS/Instantiation/CollectingInterface.lean
@@ -15,7 +15,7 @@ captures the labeled one-step soundness obligation used for trace
 soundness.
 
 This interface is the adapter from the LTS collecting semantics to the
-generic Session 4 post-fixpoint bridge
+generic post-fixpoint bridge
 (`AbsInterp.Framework.Iteration.Fixpoint.Collecting`).
 -/
 

--- a/AbsInterp/Instances/LTS/Instantiation/CollectingSoundness.lean
+++ b/AbsInterp/Instances/LTS/Instantiation/CollectingSoundness.lean
@@ -12,7 +12,7 @@ Reusable corollaries that combine:
 
 - the LTS unlabeled collecting semantics (`postAny_collectingStep`),
 - a sound abstract collecting transfer bundled as `LTSCollectingAbstraction`,
-- the generic Session 4 post-fixpoint bridge.
+- the generic post-fixpoint bridge.
 
 Each theorem takes an abstract post-fixpoint of `cfg.reachTransfer initAbs`
 and concludes a concrete safety statement: every finite Kleene iterate,

--- a/AbsInterp/Instances/LTS/Instantiation/Interface.lean
+++ b/AbsInterp/Instances/LTS/Instantiation/Interface.lean
@@ -12,10 +12,11 @@ trace-soundness proofs via `soundTrace_of_soundStep`.
 
 ## References
 
-* X. Leroy, *Semantics and Verification of Computer Programs*,
-  MPRI lecture notes (N40AI), 2023–2024.
-* R. Montesi et al., *CSLib: A Lean 4 Library for Computer Science Foundations*,
-  leanprover/cslib, 2024–2025. https://github.com/leanprover/cslib
+* X. Leroy, *Mechanizing abstract interpretation*,
+  Workshop on the Next 40 years of Abstract Interpretation (N40AI), 2024.
+  https://xavierleroy.org/talks/N40AI.pdf
+* C. Barrett et al., *CSLib: The Lean Computer Science Library*,
+  arXiv:2602.04846, 2026. https://github.com/leanprover/cslib
 -/
 
 namespace AbsInterp

--- a/AbsInterp/Instances/LTS/Instantiation/WeakSoundness.lean
+++ b/AbsInterp/Instances/LTS/Instantiation/WeakSoundness.lean
@@ -1,0 +1,76 @@
+import Cslib.Init
+import Cslib.Foundations.Semantics.LTS.HasTau
+
+import AbsInterp.Framework.Semantics.Weak
+import AbsInterp.Framework.Soundness
+import AbsInterp.Instances.LTS.Semantics.Weak
+import AbsInterp.Instances.LTS.Semantics.Lemmas
+import AbsInterp.Instances.LTS.Instantiation.Interface
+
+/-!
+# Weak (τ-closure) soundness for LTS abstractions
+
+Bridges the LTS τ-closure operator `tauClosureOp` into the framework's
+closure-based weak soundness theorems (`sound_weak_of_sound_closure`).
+
+Given strong one-step soundness over an LTS and a concretization that is closed
+under τ-closure, weak step soundness — and, via `soundTrace_of_soundStep`, weak
+trace soundness — follow with no extra reasoning.
+
+This connects the τ-closure operator `tauClosureOp` to the framework's
+closure-based weak soundness layer, which the LTS τ-closure primitives in
+`Semantics/Weak.lean` were not previously wired into. Relating this
+closure-based weak post (`cl ∘ post ∘ cl`) to the saturate-based `weakPostStep`
+(`postStep lts.saturate`) is left as further work.
+-/
+
+namespace AbsInterp
+namespace Instances
+namespace LTS
+
+open Cslib
+open AbsInterp.Framework
+
+universe u v w
+
+variable
+    {State : Type u}
+    {Label : Type v}
+    {Abstract : Type w}
+    [HasTau Label]
+
+/--
+Weak (τ-closure) step soundness from strong step soundness over an LTS,
+provided the concretization is closed under τ-closure.
+-/
+theorem soundStep_weakClosure_of_soundStep
+    (lts : Cslib.LTS State Label)
+    {gamma : Concretization Abstract State}
+    {transfer : StepPostSharp Abstract Label}
+    (hSound : SoundStep (postStep lts) gamma transfer)
+    (hClosed : GammaClosed (tauClosureOp lts) gamma) :
+    SoundStep
+      (fun label => weakPost (tauClosureOp lts) (postStep lts label))
+      gamma transfer :=
+  soundStep_weak_of_soundStep_closure hSound
+    (fun label => postStep_monotone lts label) hClosed
+
+/--
+End-to-end: an `LTSAbstraction` whose concretization is closed under τ-closure
+is sound for the weak (τ-closure) lifted trace transformer.
+-/
+theorem LTSAbstraction.soundTraceWeak
+    (cfg : LTSAbstraction State Label Abstract)
+    (hClosed : GammaClosed (tauClosureOp cfg.lts) cfg.gamma) :
+    SoundTrace
+      (liftTracePost
+        (fun label => weakPost (tauClosureOp cfg.lts) (postStep cfg.lts label)))
+      cfg.gamma
+      (liftTracePostSharp cfg.transfer) :=
+  soundTrace_of_soundStep
+    (soundStep_weakClosure_of_soundStep cfg.lts cfg.soundStep hClosed)
+    (fun label => weakPost_monotone (postStep_monotone cfg.lts label))
+
+end LTS
+end Instances
+end AbsInterp

--- a/Examples/IMP/Analysis/Generic/Collecting.lean
+++ b/Examples/IMP/Analysis/Generic/Collecting.lean
@@ -295,17 +295,17 @@ theorem soundAny_imp (program : Stmt) :
 /-! ## Fixpoint bridge for IMP collecting soundness
 
 `gammaProgram d program` is a `Concretization`, not a `ConcretizationDomain`
-(it carries an `ActiveIn` constraint that rules out `gamma_top`). We therefore
-package the IMP-side collecting bridge as direct specialisations of the
-framework theorems `Iteration.omegaReachable_subset_of_isPostFixpoint` and
-`Iteration.kleeneNat_subset_of_isPostFixpoint`, rather than as a strict
-`LTSCollectingAbstraction`.
+(it carries an `ActiveIn` constraint that rules out `gamma_top`), so IMP cannot
+instantiate the bundled `LTSCollectingAbstraction`. It instead reuses the
+bare-`gamma` primitives `reachTransferAny` / `sound_reachTransferAny` and the
+framework theorems `Iteration.kleeneNat_subset_of_isPostFixpoint` /
+`Iteration.omegaReachable_subset_of_isPostFixpoint` directly.
 -/
 
 /-- The reach transfer over the generic IMP collecting transfer. -/
 def impReachTransfer (d : IMPAnalysisDomain A) (program : Stmt)
     (initAbs : ConfigSharp A) : PostSharp (ConfigSharp A) :=
-  fun a => initAbs ⊔ transferAnyProgram d program a
+  reachTransferAny (transferAnyProgram d program) initAbs
 
 /--
 Soundness of the IMP reach transfer with an abstract initial over-approximation.
@@ -320,17 +320,10 @@ theorem sound_impReachTransfer
     (hInit : init ⊆ gammaProgram d program initAbs) :
     Sound ((postAny_collectingStep impLTS).reachF init)
       (gammaProgram d program)
-      (impReachTransfer d program initAbs) := by
-  intro a c hc
-  rcases hc with hInitMem | hPostMem
-  · -- init contribution
-    have hLeft : initAbs ≤ impReachTransfer d program initAbs a := le_sup_left
-    exact gammaProgram_monotone d hLeft program (hInit hInitMem)
-  · -- postAny contribution
-    have hSound : c ∈ gammaProgram d program (transferAnyProgram d program a) :=
-      soundAny_imp d program a hPostMem
-    have hRight : transferAnyProgram d program a ≤ impReachTransfer d program initAbs a := le_sup_right
-    exact gammaProgram_monotone d hRight program hSound
+      (impReachTransfer d program initAbs) :=
+  sound_reachTransferAny impLTS (gammaProgram d program)
+    (fun h => gammaProgram_monotone d h program) (transferAnyProgram d program)
+    (soundAny_imp d program) hInit
 
 /-- Specialisation of the generic Kleene-iterate bridge to IMP. -/
 theorem kleeneNat_subset_of_isPostFixpoint_imp

--- a/Examples/IMP/Analysis/Generic/Collecting.lean
+++ b/Examples/IMP/Analysis/Generic/Collecting.lean
@@ -15,8 +15,8 @@ labeled transfer branches that can fire at each program shape.
 
 Together with `soundAny_imp` and the
 `{kleeneNat,omegaReachableLTS}_subset_of_isPostFixpoint_imp` corollaries,
-this is the IMP adapter into the Session 4 fixpoint bridge (and parallel
-to the Session 5 `LTSCollectingAbstraction` path — see the note in
+this is the IMP adapter into the generic fixpoint bridge (and parallel
+to the `LTSCollectingAbstraction` path — see the note in
 `## Fixpoint bridge for IMP collecting soundness` below for the
 packaging trade-off).
 -/

--- a/Examples/IMP/Programs.lean
+++ b/Examples/IMP/Programs.lean
@@ -11,6 +11,6 @@ Program-level demonstrations for the IMP example suite.
 - `Showcase`: the main generic IMP case study over the canonical IMP LTS
 - `WidenShowcase`: widening-based Interval analysis over a while loop
 - `LoopShowcase`: Sign analysis of a countdown loop with concrete exit property
-- `CollectingShowcase`: IMP consumer of the Session 4/5 collecting/fixpoint
+- `CollectingShowcase`: IMP consumer of the collecting/fixpoint
   bridge via `impSignCollectingAbstraction`
 -/

--- a/Examples/IMP/Programs/CollectingShowcase.lean
+++ b/Examples/IMP/Programs/CollectingShowcase.lean
@@ -4,7 +4,7 @@ import Examples.IMP.Analysis.Interval
 /-!
 # IMP Collecting/Fixpoint Showcase
 
-Canonical IMP consumer of the Session 4/5 collecting/fixpoint bridge.
+Canonical IMP consumer of the collecting/fixpoint bridge.
 
 This file exercises the generic IMP collecting path end-to-end via the
 Interval domain, proving a real **value** invariant — every ω-reachable

--- a/Examples/IMP/Programs/Tutorial/Assign.lean
+++ b/Examples/IMP/Programs/Tutorial/Assign.lean
@@ -4,6 +4,7 @@ import Cslib.Foundations.Semantics.LTS.Basic
 import AbsInterp.Domains
 import AbsInterp.Framework
 import AbsInterp.Instances.LTS
+import AbsInterp.Instances.LTS.Analyses.Sign
 
 import Examples.IMP.Semantics
 

--- a/Examples/IMP/Programs/Tutorial/Branch.lean
+++ b/Examples/IMP/Programs/Tutorial/Branch.lean
@@ -4,6 +4,7 @@ import Cslib.Foundations.Semantics.LTS.Basic
 import AbsInterp.Domains
 import AbsInterp.Framework
 import AbsInterp.Instances.LTS
+import AbsInterp.Instances.LTS.Analyses.Sign
 
 import Examples.IMP.Semantics
 

--- a/Tests.lean
+++ b/Tests.lean
@@ -13,6 +13,7 @@ import Tests.Instances.LTS.Collecting
 import Tests.Instances.LTS.CollectingTrace
 import Tests.Instances.LTS.IntervalHook
 import Tests.Instances.LTS.SignHook
+import Tests.Instances.LTS.ParityHook
 import Tests.Instances.LTS.CollectingHook
 import Tests.Instances.LTS.Weak
 import Tests.Instances.LTS.Omega

--- a/Tests.lean
+++ b/Tests.lean
@@ -14,6 +14,8 @@ import Tests.Instances.LTS.CollectingTrace
 import Tests.Instances.LTS.IntervalHook
 import Tests.Instances.LTS.SignHook
 import Tests.Instances.LTS.CollectingHook
+import Tests.Instances.LTS.Weak
+import Tests.Instances.LTS.Omega
 import Tests.Framework.Iteration.NatIter
 import Tests.Framework.Iteration.Widening
 import Tests.Framework.Semantics.AbstractOrder

--- a/Tests/Axioms.lean
+++ b/Tests/Axioms.lean
@@ -42,12 +42,20 @@ the mismatch will cause a compile-time error and fail CI.
 /-- info: 'AbsInterp.Instances.LTS.tauClosureOp' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in #print axioms AbsInterp.Instances.LTS.tauClosureOp
 
+/-- info: 'AbsInterp.Instances.LTS.sound_reachTransferAny' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in #print axioms AbsInterp.Instances.LTS.sound_reachTransferAny
+
 /--
 info: 'AbsInterp.Instances.LTS.omegaReachableLTS_subset_iUnion_kleeneNat' depends on axioms: [propext,
  Classical.choice,
  Quot.sound]
 -/
 #guard_msgs in #print axioms AbsInterp.Instances.LTS.omegaReachableLTS_subset_iUnion_kleeneNat
+
+/-! ## Examples/IMP — Generic collecting -/
+
+/-- info: 'Examples.IMP.sound_impReachTransfer' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in #print axioms Examples.IMP.sound_impReachTransfer
 
 /-! ## Examples/IMP — Sign -/
 

--- a/Tests/Axioms.lean
+++ b/Tests/Axioms.lean
@@ -42,6 +42,12 @@ the mismatch will cause a compile-time error and fail CI.
 /-- info: 'AbsInterp.Instances.LTS.tauClosureOp' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in #print axioms AbsInterp.Instances.LTS.tauClosureOp
 
+/-- info: 'AbsInterp.Instances.LTS.soundStep_weakClosure_of_soundStep' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in #print axioms AbsInterp.Instances.LTS.soundStep_weakClosure_of_soundStep
+
+/-- info: 'AbsInterp.Instances.LTS.LTSAbstraction.soundTraceWeak' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in #print axioms AbsInterp.Instances.LTS.LTSAbstraction.soundTraceWeak
+
 /-- info: 'AbsInterp.Instances.LTS.sound_reachTransferAny' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in #print axioms AbsInterp.Instances.LTS.sound_reachTransferAny
 

--- a/Tests/Domains/Sign.lean
+++ b/Tests/Domains/Sign.lean
@@ -43,13 +43,6 @@ example : joinSign Sign.neg Sign.zero = Sign.nonpos := by
 example : joinSign Sign.neg Sign.pos = Sign.top := by
   rfl
 
-example : negTransfer Sign.nonpos = Sign.nonneg := by
-  rfl
-
-example (n : Int) (hn : n ∈ gammaSign Sign.nonneg) :
-    -n ∈ gammaSign (negTransfer Sign.nonneg) := by
-  exact negTransfer_sound hn
-
 -- meetSign tests
 example : meetSign Sign.neg Sign.nonneg = Sign.bot := by rfl
 example : meetSign Sign.top Sign.pos = Sign.pos := by rfl

--- a/Tests/Instances/LTS/CollectingHook.lean
+++ b/Tests/Instances/LTS/CollectingHook.lean
@@ -126,8 +126,8 @@ def toyCollecting : LTSCollectingAbstraction Nat Unit Top2 :=
 /-- `.top` is a post-fixpoint of the reachability transfer. -/
 theorem toy_isPostFixpoint :
     IsPostFixpoint (· ≤ ·) (toyCollecting.reachTransfer .top) .top := by
-  simp [IsPostFixpoint, LTSCollectingAbstraction.reachTransfer, transferAnyToy,
-        toyCollecting, collectingAbstractionOfCollectingSound]
+  simp [IsPostFixpoint, LTSCollectingAbstraction.reachTransfer, reachTransferAny,
+        transferAnyToy, toyCollecting, collectingAbstractionOfCollectingSound]
 
 /-- Any initial concrete set is bounded by `.top`. -/
 theorem init_subset_gammaTop (init : Set Nat) :

--- a/Tests/Instances/LTS/ParityHook.lean
+++ b/Tests/Instances/LTS/ParityHook.lean
@@ -1,0 +1,51 @@
+import Cslib.Init
+
+import AbsInterp
+
+namespace Tests
+namespace InstancesLTSParityHook
+
+open AbsInterp
+open AbsInterp.Domains
+open AbsInterp.Framework
+open AbsInterp.Instances.LTS
+open AbsInterp.Instances.LTS.Analyses
+
+def toyLTS : Cslib.LTS Int Bool where
+  Tr s label s' := (label = false ∧ s' = s) ∨ (label = true ∧ s' = 0)
+
+def readId : Int -> Int := fun s => s
+
+def transferToy : Bool -> Parity -> Parity
+  | false, a => a
+  | true, _ => .even
+
+theorem stepSoundToy :
+    ParityStepSound toyLTS readId transferToy := by
+  intro label a s s' hs htr
+  rcases htr with hKeep | hZero
+  · rcases hKeep with ⟨hLabel, hEq⟩
+    subst hLabel
+    subst hEq
+    simpa [gammaParityState, readId, transferToy] using hs
+  · rcases hZero with ⟨hLabel, hEq⟩
+    subst hLabel
+    subst hEq
+    simp [readId, transferToy, gammaParity]
+
+example :
+    SoundStep (postStep toyLTS) (gammaParityState readId) transferToy := by
+  exact soundStep_postStep_parity_of_stepSound toyLTS readId transferToy stepSoundToy
+
+def toyParityAbstraction : LTSAbstraction Int Bool Parity :=
+  parityAbstractionOfStepSound toyLTS readId transferToy stepSoundToy
+
+example :
+    SoundTrace
+      (liftTracePost (postStep toyLTS))
+      (gammaParityState readId)
+      (liftTracePostSharp transferToy) := by
+  exact toyParityAbstraction.soundTraceLifted
+
+end InstancesLTSParityHook
+end Tests

--- a/Tests/Instances/LTS/Weak.lean
+++ b/Tests/Instances/LTS/Weak.lean
@@ -81,5 +81,27 @@ example : ({0} : Set Nat) ⊆ (tauClosureOp toyLTS).cl {0} :=
 -- weakPostAny_collectingStep instantiation compiles
 example : CollectingStep Nat := weakPostAny_collectingStep toyLTS
 
+-- End-to-end: strong step soundness on a (trivially τ-closed) ⊤ concretization
+-- lifts to weak (τ-closure) step soundness via `soundStep_weakClosure_of_soundStep`.
+example :
+    SoundStep
+      (fun label => weakPost (tauClosureOp toyLTS) (postStep toyLTS label))
+      (fun _ : Unit => (Set.univ : Set Nat)) (fun _ _ => ()) := by
+  apply soundStep_weakClosure_of_soundStep toyLTS
+  · intro _ _ _ _; exact Set.mem_univ _
+  · intro _ _ _; exact Set.mem_univ _
+
+-- The same hypotheses, packaged as an `LTSAbstraction`, give weak trace soundness
+-- via `LTSAbstraction.soundTraceWeak`.
+example :
+    SoundTrace
+      (liftTracePost
+        (fun label => weakPost (tauClosureOp toyLTS) (postStep toyLTS label)))
+      (fun _ : Unit => (Set.univ : Set Nat))
+      (liftTracePostSharp (fun _ _ => ())) :=
+  (LTSAbstraction.ofExplicit toyLTS (fun _ : Unit => (Set.univ : Set Nat))
+      (fun _ _ => ()) (fun _ _ _ _ => Set.mem_univ _)).soundTraceWeak
+    (fun _ _ _ => Set.mem_univ _)
+
 end InstancesLTSWeak
 end Tests


### PR DESCRIPTION
## Summary

LTS adapter-layer follow-ups surfaced by a multi-agent structural review of
`AbsInterp/Instances/LTS`, plus the pre-existing `negTransfer` removal and a
citation correctness pass. All changes are framework/instance-level; no theorem
statements were weakened and no new `sorry`/custom axioms were introduced.

- **`refactor(domains)`**: remove unused `negTransfer` / `negTransfer_sound`
  (no remaining references).
- **`refactor(lts)`**: introduce bare-`gamma` `reachTransferAny` /
  `sound_reachTransferAny` as the primary collecting reach-transfer; both
  `LTSCollectingAbstraction` and the IMP collecting path now delegate to it
  (removes duplicated scaffolding IMP needed because `gammaProgram` is not a
  `ConcretizationDomain`).
- **`refactor(lts)`**: scope the `Instances/LTS` barrel to the domain-agnostic
  adapter surface (`Core` + `Analyses.Common`); domain-specific Sign/Interval
  adapters are no longer re-exported transitively.
- **`feat(lts)`**: bridge the LTS `tauClosureOp` into the framework's
  closure-based weak soundness (`soundStep_weakClosure_of_soundStep`,
  `LTSAbstraction.soundTraceWeak`); also wire the previously unreferenced
  `Weak`/`Omega` test files into the `Tests` aggregate so CI compiles them.
- **`chore(lts)`**: drop internal "Session N" dev-log jargon from docstrings and
  add the missing `Analyses.Parity` readout adapter (+ `ParityHook` test).
- **`docs`**: fix miscited references — Leroy is the talk *Mechanizing abstract
  interpretation* (N40AI workshop, 2024), and CSLib is *C. Barrett et al.,
  CSLib: The Lean Computer Science Library*, arXiv:2602.04846, 2026.

## Linked issue

N/A (review-driven follow-ups).

## Scope

`AbsInterp/Framework`, `AbsInterp/Instances/LTS`, `AbsInterp/Domains/Sign.lean`,
`Examples/IMP`, and `Tests`. No changes to public theorem statements.

## Validation

`lake build && lake build Tests && lake test` all pass (942 jobs), including the
`--wfail --iofail` hygiene build and `lint-style`. Zero `sorry`, zero custom
axioms; new public soundness declarations are pinned in `Tests/Axioms.lean`.

## AI usage disclosure

Developed with substantial AI assistance (Claude Code / Codex). All proofs are
machine-checked; each agent-assisted commit carries a `Co-authored-by` trailer.
Each change was cross-reviewed by separate Codex + Gemini passes before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
